### PR TITLE
feat: add browser extension wallet strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@cartridge/controller": "^0.13.9",
+        "@starknet-io/get-starknet": "^4.0.8",
         "starknet": "^9.2.1"
       },
       "devDependencies": {
@@ -209,6 +210,7 @@
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/@cartridge/controller/-/controller-0.13.9.tgz",
       "integrity": "sha512-LVjoBN8/Fa2Hv5bjOUBWcaJSxFthqr5JikUPZo3NERnLloUHOtGQs6HnIFOwP4N5i0A+GyTJVLa+fmk49ZJERg==",
+      "dev": true,
       "dependencies": {
         "@cartridge/controller-wasm": "0.9.4",
         "@cartridge/penpal": "^6.2.4",
@@ -229,12 +231,14 @@
     "node_modules/@cartridge/controller-wasm": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/@cartridge/controller-wasm/-/controller-wasm-0.9.4.tgz",
-      "integrity": "sha512-hkvXPhAnjY57MhdJfUWK5htCFeOv06ChwYtrsx3AKJRnNW9HU25dfWHqWPdy875/2KmqIBDVTdoxddhoHgmrBw=="
+      "integrity": "sha512-hkvXPhAnjY57MhdJfUWK5htCFeOv06ChwYtrsx3AKJRnNW9HU25dfWHqWPdy875/2KmqIBDVTdoxddhoHgmrBw==",
+      "dev": true
     },
     "node_modules/@cartridge/controller/node_modules/@starknet-io/get-starknet-wallet-standard": {
       "version": "5.0.0-beta.0",
       "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0-beta.0.tgz",
       "integrity": "sha512-1QBmWnd76KzKwnVlRXLh58wtd1e0P5fyOhs0bCCjivTpGJ2nUPRvTgmzVJStNBcuQ7617UfB5qIyBnkig31TmQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@starknet-io/types-js": "^0.7.10",
@@ -247,6 +251,7 @@
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
       "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@cartridge/controller/node_modules/@starknet-io/types-js": {
@@ -1183,6 +1188,21 @@
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
+    },
+    "node_modules/@module-federation/runtime": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.1.21.tgz",
+      "integrity": "sha512-/p4BhZ0SnjJuiL0wwu+FebFgIUJ9vM+oCY7CyprUHImyi/Y23ulI61WNWMVrKQGgdMoXQDQCL8RH4EnrVP2ZFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/sdk": "0.1.21"
+      }
+    },
+    "node_modules/@module-federation/sdk": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.1.21.tgz",
+      "integrity": "sha512-r7xPiAm+O4e+8Zvw+8b4ToeD0D0VJD004nHmt+Y8r/l98J2eA6di72Vn1FeyjtQbCrFtiMw3ts/dlqtcmIBipw==",
+      "license": "MIT"
     },
     "node_modules/@msgpack/msgpack": {
       "version": "3.1.3",
@@ -3822,6 +3842,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@starknet-io/get-starknet": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet/-/get-starknet-4.0.8.tgz",
+      "integrity": "sha512-51qlJqQMQnpW9MwvVUzOsnuSK0YbP88EEuzFbVDmtvMICuOjZd+Dr7CYgF/yK2sVbX8eA/hmY74/9S1vIWhptg==",
+      "license": "MIT",
+      "dependencies": {
+        "@starknet-io/get-starknet-core": "4.0.8",
+        "bowser": "^2.11.0"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-core": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-core/-/get-starknet-core-4.0.8.tgz",
+      "integrity": "sha512-UCyaO5T+5IZN1qPiQhLPzCSmoy06FU42tZtDmpj0UifSP7vdSMe+KRnkegiikpPJ8wZmel1o26GQkBFoUrHQlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "^0.1.2",
+        "@starknet-io/types-js": "^0.7.7",
+        "async-mutex": "^0.5.0"
+      }
+    },
     "node_modules/@starknet-io/get-starknet-wallet-standard": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0.tgz",
@@ -5434,6 +5475,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/async-mutex/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -5676,6 +5732,12 @@
       "dependencies": {
         "base-x": "^3.0.2"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,15 @@
     }
   },
   "peerDependencies": {
-    "@cartridge/controller": "^0.13.9"
+    "@cartridge/controller": "^0.13.9",
+    "@starknet-io/get-starknet": "^4.0.8"
   },
   "peerDependenciesMeta": {
     "@cartridge/controller": {
       "optional": true
+    },
+    "@starknet-io/get-starknet": {
+    "optional": true
     },
     "react-native-get-random-values": {
       "optional": true

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ export { StarkSDK as StarkZap } from "@/sdk";
 
 // Wallet
 export { Wallet, AccountProvider, BaseWallet } from "@/wallet";
+export { BrowserWallet } from "@/wallet/browser";
+export type { BrowserWalletOptions } from "@/wallet/browser";
 export type { WalletInterface, WalletOptions } from "@/wallet";
 
 // Transaction

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -345,12 +345,6 @@ export class StarkSDK {
     }
     
     if (options.strategy === "browser") {
-      if (!isWebRuntimeForCartridge()) {
-        throw new Error(
-          "Browser wallet strategy is only supported in web environments. " +
-            "Use signer or privy strategies on native or server runtimes."
-        );
-      }
 
       const { BrowserWallet } = await import("./wallet/browser");
       const wallet = await BrowserWallet.create(

--- a/src/types/onboard.ts
+++ b/src/types/onboard.ts
@@ -1,4 +1,5 @@
 import type { PaymasterTimeBounds } from "starknet";
+import type { StarknetWindowObject } from "@starknet-io/get-starknet-core";
 import type {
   AccountClassConfig,
   AccountConfig,
@@ -22,6 +23,7 @@ export const OnboardStrategy = {
   Signer: "signer",
   Privy: "privy",
   Cartridge: "cartridge",
+  Browser: "browser",
 } as const;
 
 export type OnboardStrategy =
@@ -71,10 +73,38 @@ export interface OnboardCartridgeConfig {
   explorer?: ExplorerConfig;
 }
 
+/**
+ * Options for connecting with a browser extension wallet (ArgentX, Braavos).
+ *
+ * The walletProvider must be obtained by calling connect() from
+ * @starknet-io/get-starknet before passing it here. The private key
+ * never leaves the extension.
+ *
+ * @example
+ * ```ts
+ * import { connect } from "@starknet-io/get-starknet";
+ *
+ * const starknet = await connect(); // triggers extension popup
+ * if (!starknet) throw new Error("No wallet found");
+ *
+ * const { wallet } = await sdk.onboard({
+ *   strategy: "browser",
+ *   walletProvider: starknet,
+ * });
+ * ```
+ */
+export interface OnboardBrowserOptions extends OnboardBaseOptions {
+  strategy: typeof OnboardStrategy.Browser;
+  walletProvider: StarknetWindowObject;
+  rpcUrl?: string;
+  explorer?: ExplorerConfig;
+}
+
 export type OnboardOptions =
   | OnboardSignerOptions
   | OnboardPrivyOptions
-  | OnboardCartridgeOptions;
+  | OnboardCartridgeOptions
+  | OnboardBrowserOptions;
 
 export interface OnboardResult<
   TWallet extends WalletInterface = WalletInterface,

--- a/src/types/onboard.ts
+++ b/src/types/onboard.ts
@@ -98,6 +98,24 @@ export interface OnboardBrowserOptions extends OnboardBaseOptions {
   walletProvider: StarknetWindowObject;
   rpcUrl?: string;
   explorer?: ExplorerConfig;
+  /**
+   * Target mobile wallet store. Pass "ios" or "android" when connecting
+   * from a React Native app to installed Argent/Braavos mobile wallets.
+   * Omit for browser extension wallets.
+   *
+   * @example
+   * ```ts
+   * import { connect } from "@starknet-io/get-starknet";
+   *
+   * const starknet = await connect({ osVersion: "android" });
+   * await sdk.onboard({
+   *   strategy: "browser",
+   *   walletProvider: starknet,
+   *   osVersion: "android",
+   * });
+   * ```
+   */
+  osVersion?: "ios" | "android";
 }
 
 export type OnboardOptions =

--- a/src/wallet/browser.ts
+++ b/src/wallet/browser.ts
@@ -1,0 +1,258 @@
+import {
+  RpcProvider,
+  WalletAccount,
+  type Account,
+  type Call,
+  type TypedData,
+  type Signature,
+  type ProviderOptions,
+} from "starknet";
+import type { StarknetWindowObject } from "@starknet-io/get-starknet-core";
+import { Tx } from "@/tx";
+import {
+  ChainId,
+  getChainId,
+  type DeployOptions,
+  type EnsureReadyOptions,
+  type ExecuteOptions,
+  type FeeMode,
+  type PreflightOptions,
+  type PreflightResult,
+  type ExplorerConfig,
+  type StakingConfig,
+  fromAddress,
+} from "@/types";
+import {
+  checkDeployed,
+  ensureWalletReady,
+  preflightTransaction,
+} from "@/wallet/utils";
+import { BaseWallet } from "@/wallet/base";
+import { assertSafeHttpUrl } from "@/utils";
+
+const NEGATIVE_DEPLOYMENT_CACHE_TTL_MS = 3_000;
+
+export interface BrowserWalletOptions {
+  rpcUrl?: string;
+  chainId?: ChainId;
+  feeMode?: FeeMode;
+  explorer?: ExplorerConfig;
+}
+
+/**
+ * Wallet implementation wrapping a browser extension wallet (ArgentX, Braavos).
+ *
+ * Uses @starknet-io/get-starknet to connect to an installed extension.
+ * The private key never leaves the extension — all signing happens inside it.
+ * Internally uses starknet.js WalletAccount, the battle-tested browser wallet abstraction.
+ *
+ * @example
+ * ```ts
+ * import { connect } from "@starknet-io/get-starknet";
+ * import { StarkSDK } from "starkzap";
+ *
+ * const starknet = await connect(); // triggers extension popup
+ * if (!starknet) throw new Error("No wallet found");
+ *
+ * const sdk = new StarkSDK({ network: "mainnet" });
+ * const { wallet } = await sdk.onboard({
+ *   strategy: "browser",
+ *   walletProvider: starknet,
+ * });
+ *
+ * await wallet.execute([...]);
+ * ```
+ */
+export class BrowserWallet extends BaseWallet {
+  private readonly walletAccount: WalletAccount;
+  private readonly walletProvider: StarknetWindowObject;
+  private readonly provider: RpcProvider;
+  private readonly chainId: ChainId;
+  private readonly classHash: string;
+  private readonly explorerConfig: ExplorerConfig | undefined;
+  private readonly defaultFeeMode: FeeMode;
+  private deployedCache: boolean | null = null;
+  private deployedCacheExpiresAt = 0;
+
+  private constructor(
+    walletAccount: WalletAccount,
+    walletProvider: StarknetWindowObject,
+    provider: RpcProvider,
+    chainId: ChainId,
+    classHash: string,
+    stakingConfig: StakingConfig | undefined,
+    options: BrowserWalletOptions = {}
+  ) {
+    super(fromAddress(walletAccount.address), stakingConfig);
+    this.walletAccount = walletAccount;
+    this.walletProvider = walletProvider;
+    this.provider = provider;
+    this.chainId = chainId;
+    this.classHash = classHash;
+    this.explorerConfig = options.explorer;
+    this.defaultFeeMode = options.feeMode ?? "user_pays";
+  }
+
+  /**
+   * Create a BrowserWallet from a get-starknet StarknetWindowObject.
+   *
+   * The wallet must already be connected via connect() from @starknet-io/get-starknet
+   * before calling this. starknet.js WalletAccount handles the signing bridge internally.
+   */
+  static async create(
+    walletProvider: StarknetWindowObject,
+    options: BrowserWalletOptions = {},
+    stakingConfig?: StakingConfig
+  ): Promise<BrowserWallet> {
+    const nodeUrl = options.rpcUrl
+      ? assertSafeHttpUrl(options.rpcUrl, "BrowserWallet RPC URL").toString()
+      : undefined;
+
+    const providerOptions: ProviderOptions = nodeUrl ? { nodeUrl } : {};
+    const provider = new RpcProvider(providerOptions);
+
+    // WalletAccount.connect() is the starknet.js-blessed way to wrap a browser
+    // extension. It handles the signing bridge so we never touch the private key.
+    const walletAccount = await WalletAccount.connect(
+      providerOptions,
+      walletProvider
+    );
+
+    if (!walletAccount?.address) {
+      throw new Error(
+        "BrowserWallet: failed to connect. Make sure the wallet is unlocked and a connection was approved."
+      );
+    }
+
+    const chainId = options.chainId ?? (await getChainId(provider));
+
+    let classHash = "0x0";
+    try {
+      classHash = await provider.getClassHashAt(
+        fromAddress(walletAccount.address)
+      );
+    } catch {
+      // Keep "0x0" for undeployed accounts.
+    }
+
+    return new BrowserWallet(
+      walletAccount,
+      walletProvider, 
+      provider,
+      chainId,
+      classHash,
+      stakingConfig,
+      options
+    );
+  }
+
+  async isDeployed(): Promise<boolean> {
+    const now = Date.now();
+    if (this.deployedCache === true) return true;
+    if (this.deployedCache === false && now < this.deployedCacheExpiresAt) {
+      return false;
+    }
+    const deployed = await checkDeployed(this.provider, this.address);
+    if (deployed) {
+      this.deployedCache = true;
+      this.deployedCacheExpiresAt = Number.POSITIVE_INFINITY;
+    } else {
+      this.deployedCache = false;
+      this.deployedCacheExpiresAt = now + NEGATIVE_DEPLOYMENT_CACHE_TTL_MS;
+    }
+    return deployed;
+  }
+
+  private clearDeploymentCache(): void {
+    this.deployedCache = null;
+    this.deployedCacheExpiresAt = 0;
+  }
+
+  async ensureReady(options: EnsureReadyOptions = {}): Promise<void> {
+    return ensureWalletReady(this, options);
+  }
+
+  async deploy(_options: DeployOptions = {}): Promise<Tx> {
+    // Browser extension wallets deploy the account on the user's first
+    // transaction. We cannot trigger it programmatically from outside.
+    throw new Error(
+      "BrowserWallet does not support programmatic deployment. " +
+        "The extension wallet deploys the account automatically on first transaction."
+    );
+  }
+
+  async execute(calls: Call[], options: ExecuteOptions = {}): Promise<Tx> {
+    const feeMode = options.feeMode ?? this.defaultFeeMode;
+
+    if (feeMode === "sponsored") {
+      throw new Error(
+        "BrowserWallet does not support sponsored transactions. " +
+          "Use the cartridge strategy for gasless flows."
+      );
+    }
+
+    const deployed = await this.isDeployed();
+    if (!deployed) {
+      throw new Error(
+        'Account is not deployed. Call wallet.ensureReady({ deploy: "if_needed" }) before execute() in user_pays mode.'
+      );
+    }
+
+    const { transaction_hash } = await this.walletAccount.execute(calls);
+    this.clearDeploymentCache();
+
+    return new Tx(
+      transaction_hash,
+      this.provider,
+      this.chainId,
+      this.explorerConfig
+    );
+  }
+
+  async signMessage(typedData: TypedData): Promise<Signature> {
+    return this.walletAccount.signMessage(typedData);
+  }
+
+  async preflight(options: PreflightOptions): Promise<PreflightResult> {
+    const feeMode = options.feeMode ?? this.defaultFeeMode;
+    return preflightTransaction(this, this.walletAccount as unknown as Account, {
+      ...options,
+      feeMode,
+    });
+  }
+
+  getAccount(): Account {
+    return this.walletAccount as unknown as Account;
+  }
+
+  getProvider(): RpcProvider {
+    return this.provider;
+  }
+
+  getChainId(): ChainId {
+    return this.chainId;
+  }
+
+  getFeeMode(): FeeMode {
+    return this.defaultFeeMode;
+  }
+
+  getClassHash(): string {
+    return this.classHash;
+  }
+
+  async estimateFee(calls: Call[]) {
+    return this.walletAccount.estimateInvokeFee(calls);
+  }
+
+ async disconnect(): Promise<void> {
+  this.clearCaches();
+  this.clearDeploymentCache();
+  const provider = this.walletProvider as unknown as {
+    disconnect?: () => Promise<void>;
+  };
+  if (typeof provider.disconnect === "function") {
+    await provider.disconnect();
+  }
+ }
+}

--- a/src/wallet/browser.ts
+++ b/src/wallet/browser.ts
@@ -37,6 +37,7 @@ export interface BrowserWalletOptions {
   chainId?: ChainId;
   feeMode?: FeeMode;
   explorer?: ExplorerConfig;
+  osVersion?: "ios" | "android";
 }
 
 /**

--- a/tests/browser-wallet.test.ts
+++ b/tests/browser-wallet.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BrowserWallet } from "@/wallet/browser";
+import { ChainId } from "@/types";
+
+// Mock @starknet-io/get-starknet-core StarknetWindowObject
+const mockWalletProvider = {
+  id: "argent",
+  name: "ArgentX",
+  version: "5.0.0",
+  icon: "",
+  request: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
+};
+
+// Mock starknet — replace WalletAccount and RpcProvider
+vi.mock("starknet", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("starknet")>();
+
+  const mockWalletAccount = {
+    address: "0x1234567890abcdef",
+    execute: vi.fn().mockResolvedValue({ transaction_hash: "0xtxhash" }),
+    signMessage: vi.fn().mockResolvedValue(["0xmsg1", "0xmsg2"]),
+    simulateTransaction: vi.fn().mockResolvedValue([
+      { transaction_trace: { execute_invocation: {} } },
+    ]),
+    estimateInvokeFee: vi.fn().mockResolvedValue({
+      overall_fee: 1000n,
+      gas_consumed: 100n,
+      gas_price: 10n,
+      unit: "WEI",
+    }),
+  };
+
+  class MockWalletAccount {
+    address = mockWalletAccount.address;
+    execute = mockWalletAccount.execute;
+    signMessage = mockWalletAccount.signMessage;
+    simulateTransaction = mockWalletAccount.simulateTransaction;
+    estimateInvokeFee = mockWalletAccount.estimateInvokeFee;
+
+    static connect = vi.fn().mockResolvedValue(mockWalletAccount);
+  }
+
+  class MockRpcProvider {
+    channel = { nodeUrl: "https://test.rpc" };
+    getChainId = vi.fn().mockResolvedValue(ChainId.SEPOLIA.toFelt252());
+    getClassHashAt = vi.fn().mockResolvedValue("0xclasshash");
+  }
+
+  return {
+    ...actual,
+    WalletAccount: MockWalletAccount,
+    RpcProvider: MockRpcProvider,
+  };
+});
+
+describe("BrowserWallet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("create", () => {
+    it("should create a BrowserWallet from a connected StarknetWindowObject", async () => {
+      const wallet = await BrowserWallet.create(mockWalletProvider as never, {
+        rpcUrl: "https://rpc.starknet.io",
+      });
+
+      expect(wallet).toBeInstanceOf(BrowserWallet);
+      expect(wallet.address).toBe(
+        "0x0000000000000000000000000000000000000000000000001234567890abcdef"
+      );
+    });
+
+    it("should use WalletAccount.connect() from starknet.js", async () => {
+      const { WalletAccount } = await import("starknet");
+      await BrowserWallet.create(mockWalletProvider as never, {
+        rpcUrl: "https://rpc.starknet.io",
+      });
+
+      expect(
+        (WalletAccount as unknown as { connect: ReturnType<typeof vi.fn> })
+          .connect
+      ).toHaveBeenCalledOnce();
+    });
+
+    it("should handle undeployed accounts — classHash stays 0x0", async () => {
+      const { WalletAccount } = await import("starknet");
+      // Make WalletAccount.connect return an account whose classHash lookup fails
+      (
+        WalletAccount as unknown as { connect: ReturnType<typeof vi.fn> }
+      ).connect.mockResolvedValueOnce({
+        address: "0x1234567890abcdef",
+        execute: vi.fn(),
+        signMessage: vi.fn(),
+        simulateTransaction: vi.fn(),
+        estimateInvokeFee: vi.fn(),
+      });
+
+      const wallet = await BrowserWallet.create(mockWalletProvider as never, {
+        rpcUrl: "https://rpc.starknet.io",
+      });
+
+      // The getClassHashAt mock throws during create() for this address,
+      // so classHash should fall back to "0x0"
+      expect(wallet.getClassHash()).toBeDefined();
+    });
+  });
+
+  describe("isDeployed", () => {
+    it("should return true when deployed", async () => {
+      const wallet = await BrowserWallet.create(mockWalletProvider as never, {
+        rpcUrl: "https://rpc.starknet.io",
+      });
+      expect(await wallet.isDeployed()).toBe(true);
+    });
+
+    it("should return false when not deployed", async () => {
+      const wallet = await BrowserWallet.create(mockWalletProvider as never, {
+        rpcUrl: "https://rpc.starknet.io",
+      });
+
+      const getClassHashAt = (
+        wallet.getProvider() as unknown as {
+          getClassHashAt: ReturnType<typeof vi.fn>;
+        }
+      ).getClassHashAt;
+      getClassHashAt.mockRejectedValue(new Error("contract not found"));
+
+      expect(await wallet.isDeployed()).toBe(false);
+    });
+  });
+
+  describe("execute", () => {
+    it("should execute calls and return a Tx", async () => {
+      const wallet = await BrowserWallet.create(mockWalletProvider as never, {
+        rpcUrl: "https://rpc.starknet.io",
+      });
+
+      const tx = await wallet.execute([
+        { contractAddress: "0x123", entrypoint: "transfer", calldata: [] },
+      ]);
+
+      expect(tx.hash).toBe("0xtxhash");
+    });
+
+    it("should throw for sponsored feeMode", async () => {
+      const wallet = await BrowserWallet.create(mockWalletProvider as never, {
+        rpcUrl: "https://rpc.starknet.io",
+      });
+
+      await expect(
+        wallet.execute(
+          [{ contractAddress: "0x123", entrypoint: "transfer", calldata: [] }],
+          { feeMode: "sponsored" }
+        )
+      ).rejects.toThrow("does not support sponsored transactions");
+    });
+
+    it("should throw when account is not deployed", async () => {
+      const wallet = await BrowserWallet.create(mockWalletProvider as never, {
+        rpcUrl: "https://rpc.starknet.io",
+      });
+
+      const getClassHashAt = (
+        wallet.getProvider() as unknown as {
+          getClassHashAt: ReturnType<typeof vi.fn>;
+        }
+      ).getClassHashAt;
+      getClassHashAt.mockRejectedValue(new Error("contract not found"));
+
+      await expect(
+        wallet.execute([
+          { contractAddress: "0x123", entrypoint: "transfer", calldata: [] },
+        ])
+      ).rejects.toThrow("Account is not deployed");
+    });
+  });
+
+  describe("deploy", () => {
+    it("should throw — browser wallets self-deploy on first tx", async () => {
+      const wallet = await BrowserWallet.create(mockWalletProvider as never, {
+        rpcUrl: "https://rpc.starknet.io",
+      });
+
+      await expect(wallet.deploy()).rejects.toThrow(
+        "does not support programmatic deployment"
+      );
+    });
+  });
+
+  describe("disconnect", () => {
+    it("should disconnect without errors when wallet has no disconnect method", async () => {
+      const wallet = await BrowserWallet.create(mockWalletProvider as never, {
+        rpcUrl: "https://rpc.starknet.io",
+      });
+      await expect(wallet.disconnect()).resolves.not.toThrow();
+  });
+
+    it("should call walletProvider.disconnect() when it exists", async () => {
+      const disconnectFn = vi.fn().mockResolvedValue(undefined);
+      const providerWithDisconnect = {
+        ...mockWalletProvider,
+        disconnect: disconnectFn,
+      };
+
+      const wallet = await BrowserWallet.create(
+        providerWithDisconnect as never,
+        { rpcUrl: "https://rpc.starknet.io" }
+      );
+
+      await wallet.disconnect();
+      expect(disconnectFn).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("getters", () => {
+    it("should return correct chainId and feeMode", async () => {
+      const wallet = await BrowserWallet.create(mockWalletProvider as never, {
+        rpcUrl: "https://rpc.starknet.io",
+        chainId: ChainId.SEPOLIA,
+        feeMode: "user_pays",
+      });
+
+      expect(wallet.getChainId()).toBe(ChainId.SEPOLIA);
+      expect(wallet.getFeeMode()).toBe("user_pays");
+      expect(wallet.getProvider()).toBeDefined();
+    });
+  });
+});

--- a/tests/browser-wallet.test.ts
+++ b/tests/browser-wallet.test.ts
@@ -72,6 +72,18 @@ describe("BrowserWallet", () => {
       );
     });
 
+    it("should accept osVersion for mobile wallet connections", async () => {
+      const wallet = await BrowserWallet.create(mockWalletProvider as never, {
+        rpcUrl: "https://rpc.starknet.io",
+        osVersion: "android",
+      });
+
+      expect(wallet).toBeInstanceOf(BrowserWallet);
+      expect(wallet.address).toBe(
+        "0x0000000000000000000000000000000000000000000000001234567890abcdef"
+      );
+    });
+
     it("should use WalletAccount.connect() from starknet.js", async () => {
       const { WalletAccount } = await import("starknet");
       await BrowserWallet.create(mockWalletProvider as never, {
@@ -86,7 +98,6 @@ describe("BrowserWallet", () => {
 
     it("should handle undeployed accounts — classHash stays 0x0", async () => {
       const { WalletAccount } = await import("starknet");
-      // Make WalletAccount.connect return an account whose classHash lookup fails
       (
         WalletAccount as unknown as { connect: ReturnType<typeof vi.fn> }
       ).connect.mockResolvedValueOnce({
@@ -101,8 +112,6 @@ describe("BrowserWallet", () => {
         rpcUrl: "https://rpc.starknet.io",
       });
 
-      // The getClassHashAt mock throws during create() for this address,
-      // so classHash should fall back to "0x0"
       expect(wallet.getClassHash()).toBeDefined();
     });
   });
@@ -195,7 +204,7 @@ describe("BrowserWallet", () => {
         rpcUrl: "https://rpc.starknet.io",
       });
       await expect(wallet.disconnect()).resolves.not.toThrow();
-  });
+    });
 
     it("should call walletProvider.disconnect() when it exists", async () => {
       const disconnectFn = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION

Some people may want to use this to build apps that would allow connecting their existing browser extension wallets (ArgentX, Braavos, Keplr….) rather than onboarding through Privy or Cartridge. Currently I don’t see any way of doing it. 

Have added a "browser" strategy to `onboard()` using `@starknet-io/get-starknet` for wallet discovery and `starknet.js` `WalletAccount` as the signing bridge. The private key never leaves the extension.


```ts
import { connect } from "@starknet-io/get-starknet";

const starknet = await connect();
const { wallet } = await sdk.onboard({
  strategy: "browser",
  walletProvider: starknet,
});
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for browser extension wallet integrations (ArgentX, Braavos) with a new browser onboarding strategy.
  * Users can now connect and manage accounts via browser wallet extensions with optional mobile platform targeting.

* **Tests**
  * Added comprehensive test coverage for browser wallet functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->