### PR TITLE
feat: sponsorship error type and fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     "./cartridge": {
       "types": "./dist/src/cartridge.d.ts",
       "import": "./dist/src/cartridge.js"
+    },
+    "./sponsorship": {
+      "types": "./dist/src/sponsorship.d.ts",
+      "import": "./dist/src/sponsorship.js"
     }
   },
   "peerDependencies": {

--- a/src/sponsorship.ts
+++ b/src/sponsorship.ts
@@ -1,0 +1,27 @@
+/**
+ * Sponsorship (paymaster) error handling.
+ *
+ * Import from here for a focused surface when you only need sponsorship types and helpers:
+ *
+ * @example
+ * ```ts
+ * import {
+ *   SponsorshipNotAvailableError,
+ *   getSponsorshipFriendlyMessage,
+ *   SPONSORSHIP_REASONS,
+ *   SPONSORSHIP_REASON_MESSAGES,
+ * } from "starkzap/sponsorship";
+ * ```
+ *
+ * All of these are also available from the main entry: `import { ... } from "starkzap"`.
+ */
+export {
+  SponsorshipNotAvailableError,
+  getSponsorshipFriendlyMessage,
+  SPONSORSHIP_REASONS,
+  SPONSORSHIP_REASON_MESSAGES,
+} from "@/types/sponsorship-error";
+export type {
+  SponsorshipReason,
+  SponsorshipProvider,
+} from "@/types/sponsorship-error";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export * from "@/types/address";
 export * from "@/types/amount";
 export * from "@/types/config";
 export * from "@/types/sponsorship";
+export * from "@/types/sponsorship-error";
 export * from "@/types/validator";
 export * from "@/types/wallet";
 export * from "@/types/onboard";

--- a/src/types/sponsorship-error.ts
+++ b/src/types/sponsorship-error.ts
@@ -1,0 +1,165 @@
+/**
+ * Sponsorship error types and helpers.
+ *
+ * **Import:** from main entry or focused subpath:
+ * - `import { SponsorshipNotAvailableError, getSponsorshipFriendlyMessage } from "starkzap"`
+ * - `import { SponsorshipNotAvailableError, getSponsorshipFriendlyMessage } from "starkzap/sponsorship"`
+ */
+
+/**
+ * Normalized reason for sponsorship being unavailable.
+ * Used by {@link SponsorshipNotAvailableError} so apps can show consistent UX
+ * regardless of whether the failure came from AVNU or Cartridge.
+ *
+ * @public
+ */
+export type SponsorshipReason =
+  | "policy_rejected"
+  | "policy_exceeded"
+  | "unsupported_asset"
+  | "invalid_paymaster_config"
+  | "network_unavailable"
+  | "account_not_ready"
+  | "unknown";
+
+/** All possible sponsorship reasons; use for exhaustiveness checks and autocomplete. @public */
+export const SPONSORSHIP_REASONS: readonly SponsorshipReason[] = [
+  "policy_rejected",
+  "policy_exceeded",
+  "unsupported_asset",
+  "invalid_paymaster_config",
+  "network_unavailable",
+  "account_not_ready",
+  "unknown",
+] as const;
+
+/**
+ * Sponsorship provider that reported the failure.
+ *
+ * @public
+ */
+export type SponsorshipProvider = "avnu" | "cartridge" | "unknown";
+
+/** Human-readable default messages per reason; override in your app for i18n or custom copy. @public */
+export const SPONSORSHIP_REASON_MESSAGES: Record<SponsorshipReason, string> = {
+  policy_rejected: "Sponsorship not allowed for this transaction.",
+  policy_exceeded: "Sponsorship quota exceeded. Fund the paymaster or pay gas.",
+  unsupported_asset: "This asset is not supported for sponsorship.",
+  invalid_paymaster_config: "Sponsorship is misconfigured. Check the documentations.",
+  network_unavailable: "Sponsorship service unavailable. Fund the paymaster or pay gas.",
+  account_not_ready: "Account not ready for sponsorship. Deploy or reconnect.",
+  unknown: "Sponsorship unavailable. Try again or pay gas.",
+};
+
+/**
+ * Returns a user-friendly message for a sponsorship reason.
+ * Use for toasts, alerts, or fallback copy; override with your own for i18n.
+ *
+ * @example
+ * ```ts
+ * catch (e) {
+ *   if (SponsorshipNotAvailableError.isSponsorshipError(e)) {
+ *     toast.error(e.toFriendlyMessage());
+ *   }
+ * }
+ * ```
+ * @public
+ */
+export function getSponsorshipFriendlyMessage(
+  reason: SponsorshipReason
+): string {
+  return SPONSORSHIP_REASON_MESSAGES[reason] ?? SPONSORSHIP_REASON_MESSAGES.unknown;
+}
+
+/**
+ * First-class SDK error when a sponsored (gasless) execution is unavailable.
+ *
+ * Use this to:
+ * - Catch sponsorship failures explicitly (`SponsorshipNotAvailableError.isSponsorshipError(e)` or `instanceof`)
+ * - Show UX from `reason` or `toFriendlyMessage()` (or customize with {@link SPONSORSHIP_REASON_MESSAGES})
+ * - Optionally enable fallback via `ExecuteOptions.fallbackTo: "user_pays"` and `onFallback`
+ *
+ * AVNU and Cartridge emit different raw errors; the SDK normalizes them into this single contract.
+ *
+ * @public
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await wallet.execute(calls, { feeMode: "sponsored" });
+ * } catch (e) {
+ *   if (SponsorshipNotAvailableError.isSponsorshipError(e)) {
+ *     toast.error(e.toFriendlyMessage());
+ *     if (e.reason === "policy_exceeded") trackQuotaHit();
+ *   }
+ *   throw e;
+ * }
+ * ```
+ *
+ * @example
+ * ```ts
+ * await wallet.execute(calls, {
+ *   feeMode: "sponsored",
+ *   fallbackTo: "user_pays",
+ *   onFallback: (err) => toast.warn(err.toFriendlyMessage()),
+ * });
+ * ```
+ */
+export class SponsorshipNotAvailableError extends Error {
+  readonly name = "SponsorshipNotAvailableError" as const;
+
+  /** Normalized reason; use for UX or switch on with {@link SPONSORSHIP_REASONS}. */
+  readonly reason: SponsorshipReason;
+
+  /** Provider that reported the failure (avnu, cartridge, or unknown). */
+  readonly provider: SponsorshipProvider;
+
+  /** Always true: user must pay fees if they retry without sponsorship. */
+  readonly fallbackFeeRequired = true as const;
+
+  /** Original error from the provider; for logging or debugging. */
+  readonly rawError: unknown;
+
+  constructor(params: {
+    reason: SponsorshipReason;
+    provider: SponsorshipProvider;
+    rawError: unknown;
+    message?: string;
+  }) {
+    const message =
+      params.message ??
+      `Sponsorship not available (${params.reason}, provider: ${params.provider})`;
+    super(message);
+    this.reason = params.reason;
+    this.provider = params.provider;
+    this.rawError = params.rawError;
+    if (typeof Object.setPrototypeOf === "function") {
+      Object.setPrototypeOf(this, SponsorshipNotAvailableError.prototype);
+    }
+  }
+
+  /**
+   * Type guard: use in catch blocks so TypeScript narrows to this error.
+   * @example
+   * ```ts
+   * catch (e) {
+   *   if (SponsorshipNotAvailableError.isSponsorshipError(e)) {
+   *     console.log(e.reason); // e is SponsorshipNotAvailableError
+   *   }
+   * }
+   * ```
+   */
+  static isSponsorshipError(
+    value: unknown
+  ): value is SponsorshipNotAvailableError {
+    return value instanceof SponsorshipNotAvailableError;
+  }
+
+  /**
+   * User-friendly message for this error's reason.
+   * Uses {@link SPONSORSHIP_REASON_MESSAGES}; override in your app for i18n.
+   */
+  toFriendlyMessage(): string {
+    return getSponsorshipFriendlyMessage(this.reason);
+  }
+}

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -1,6 +1,7 @@
 import type { Call, Calldata, PaymasterTimeBounds } from "starknet";
 import type { SignerInterface } from "@/signer/interface";
 import type { SwapProvider } from "@/swap/interface";
+import type { SponsorshipNotAvailableError } from "@/types/sponsorship-error";
 
 // ─── Account Class Configuration ─────────────────────────────────────────────
 
@@ -167,6 +168,16 @@ export interface ExecuteOptions {
   feeMode?: FeeMode;
   /** Optional time bounds for paymaster transactions */
   timeBounds?: PaymasterTimeBounds;
+  /**
+   * When sponsored execution fails with a sponsorship-related error, retry with user-paid fees.
+   * Only applies when `feeMode` is (or defaults to) `"sponsored"`.
+   */
+  fallbackTo?: "user_pays";
+  /**
+   * Called when sponsorship fails and a fallback (e.g. user_pays) is being attempted.
+   * Use for UX (e.g. toast: "Sponsorship unavailable, you'll pay gas").
+   */
+  onFallback?: (error: SponsorshipNotAvailableError) => void;
 }
 
 // ─── Preflight ───────────────────────────────────────────────────────────────

--- a/src/wallet/cartridge.ts
+++ b/src/wallet/cartridge.ts
@@ -26,7 +26,9 @@ import {
   preflightTransaction,
   sponsoredDetails,
 } from "@/wallet/utils";
+import { normalizeCartridgeSponsorshipError } from "@/wallet/sponsorship-errors";
 import { BaseWallet } from "@/wallet/base";
+import { SponsorshipNotAvailableError } from "@/types/sponsorship-error";
 import { assertSafeHttpUrl } from "@/utils";
 
 const NEGATIVE_DEPLOYMENT_CACHE_TTL_MS = 3_000;
@@ -302,17 +304,45 @@ export class CartridgeWallet extends BaseWallet {
     const feeMode = options.feeMode ?? this.defaultFeeMode;
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
 
-    let transaction_hash: string;
+    let transactionHash: string;
 
     if (feeMode === "sponsored") {
-      // Allow provider/controller implementations to handle undeployed accounts
-      // atomically via paymaster flow when supported.
-      transaction_hash = (
-        await this.walletAccount.executePaymasterTransaction(
-          calls,
-          sponsoredDetails(timeBounds)
-        )
-      ).transaction_hash;
+      try {
+        transactionHash = (
+          await this.walletAccount.executePaymasterTransaction(
+            calls,
+            sponsoredDetails(timeBounds)
+          )
+        ).transaction_hash;
+      } catch (rawError) {
+        const normalized = normalizeCartridgeSponsorshipError(rawError);
+        if (!normalized) throw rawError;
+
+        const sponsorshipError = new SponsorshipNotAvailableError({
+          reason: normalized.reason,
+          provider: normalized.provider,
+          rawError,
+        });
+
+        if (options.fallbackTo !== "user_pays") {
+          throw sponsorshipError;
+        }
+
+        const canUserPay = await this.isDeployed();
+        if (!canUserPay) {
+          throw new SponsorshipNotAvailableError({
+            reason: "account_not_ready",
+            provider: "unknown",
+            rawError: sponsorshipError,
+            message:
+              "Sponsorship failed and user_pays fallback is not available: account is not deployed.",
+          });
+        }
+
+        options.onFallback?.(sponsorshipError);
+        transactionHash = (await this.walletAccount.execute(calls))
+          .transaction_hash;
+      }
     } else {
       const deployed = await this.isDeployed();
       if (!deployed) {
@@ -320,12 +350,12 @@ export class CartridgeWallet extends BaseWallet {
           'Account is not deployed. Call wallet.ensureReady({ deploy: "if_needed" }) before execute() in user_pays mode.'
         );
       }
-      transaction_hash = (await this.walletAccount.execute(calls))
+      transactionHash = (await this.walletAccount.execute(calls))
         .transaction_hash;
     }
 
     return new Tx(
-      transaction_hash,
+      transactionHash,
       this.provider,
       this.chainId,
       this.explorerConfig

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -33,7 +33,9 @@ import {
   preflightTransaction,
   sponsoredDetails,
 } from "@/wallet/utils";
+import { normalizeAvnuSponsorshipError } from "@/wallet/sponsorship-errors";
 import { BaseWallet } from "@/wallet/base";
+import { SponsorshipNotAvailableError } from "@/types/sponsorship-error";
 import {
   BraavosPreset,
   BRAAVOS_IMPL_CLASS_HASH,
@@ -484,40 +486,35 @@ export class Wallet extends BaseWallet {
     let transactionHash: string;
 
     if (feeMode === "sponsored") {
-      const deployed = await this.isDeployed();
-      if (deployed) {
-        transactionHash = (
-          await this.account.executePaymasterTransaction(
-            calls,
-            sponsoredDetails(timeBounds)
-          )
-        ).transaction_hash;
-      } else {
-        transactionHash = await this.withSponsoredDeployLock(async () => {
-          const recheckedDeployed = await this.isDeployed();
-          if (recheckedDeployed) {
-            return (
-              await this.account.executePaymasterTransaction(
-                calls,
-                sponsoredDetails(timeBounds)
-              )
-            ).transaction_hash;
-          }
+      try {
+        transactionHash = await this.runSponsoredExecution(calls, timeBounds);
+      } catch (rawError) {
+        const normalized = normalizeAvnuSponsorshipError(rawError);
+        if (!normalized) throw rawError;
 
-          try {
-            return (await this.deployPaymasterWith(calls, timeBounds)).hash;
-          } catch (error) {
-            if (!isAlreadyDeployedError(error)) {
-              throw error;
-            }
-            return (
-              await this.account.executePaymasterTransaction(
-                calls,
-                sponsoredDetails(timeBounds)
-              )
-            ).transaction_hash;
-          }
+        const sponsorshipError = new SponsorshipNotAvailableError({
+          reason: normalized.reason,
+          provider: normalized.provider,
+          rawError,
         });
+
+        if (options.fallbackTo !== "user_pays") {
+          throw sponsorshipError;
+        }
+
+        const canUserPay = await this.isDeployed();
+        if (!canUserPay) {
+          throw new SponsorshipNotAvailableError({
+            reason: "account_not_ready",
+            provider: "unknown",
+            rawError: sponsorshipError,
+            message:
+              "Sponsorship failed and user_pays fallback is not available: account is not deployed.",
+          });
+        }
+
+        options.onFallback?.(sponsorshipError);
+        transactionHash = (await this.account.execute(calls)).transaction_hash;
       }
     } else {
       const deployed = await this.isDeployed();
@@ -535,6 +532,46 @@ export class Wallet extends BaseWallet {
       this.chainId,
       this.explorerConfig
     );
+  }
+
+  /** Runs sponsored path only; throws on failure. Used for try/catch + fallback. */
+  private async runSponsoredExecution(
+    calls: Call[],
+    timeBounds?: PaymasterTimeBounds
+  ): Promise<string> {
+    const deployed = await this.isDeployed();
+    if (deployed) {
+      return (
+        await this.account.executePaymasterTransaction(
+          calls,
+          sponsoredDetails(timeBounds)
+        )
+      ).transaction_hash;
+    }
+    return this.withSponsoredDeployLock(async () => {
+      const recheckedDeployed = await this.isDeployed();
+      if (recheckedDeployed) {
+        return (
+          await this.account.executePaymasterTransaction(
+            calls,
+            sponsoredDetails(timeBounds)
+          )
+        ).transaction_hash;
+      }
+      try {
+        return (await this.deployPaymasterWith(calls, timeBounds)).hash;
+      } catch (error) {
+        if (!isAlreadyDeployedError(error)) {
+          throw error;
+        }
+        return (
+          await this.account.executePaymasterTransaction(
+            calls,
+            sponsoredDetails(timeBounds)
+          )
+        ).transaction_hash;
+      }
+    });
   }
 
   async signMessage(typedData: TypedData): Promise<Signature> {

--- a/src/wallet/sponsorship-errors.ts
+++ b/src/wallet/sponsorship-errors.ts
@@ -1,0 +1,182 @@
+/**
+ * Internal normalization of AVNU and Cartridge sponsorship failures.
+ * Only failures that clearly mean "sponsorship unavailable" are normalized;
+ * ordinary transaction reverts are not converted.
+ */
+
+import type { SponsorshipReason } from "@/types/sponsorship-error";
+
+export type NormalizedSponsorshipFailure = {
+  reason: SponsorshipReason;
+  provider: "avnu" | "cartridge";
+};
+
+function messageAndCode(error: unknown): { message: string; code?: string } {
+  const message =
+    error instanceof Error ? error.message : String(error ?? "").slice(0, 2000);
+  let code: string | undefined;
+  if (error && typeof error === "object" && "code" in error) {
+    const c = (error as { code?: unknown }).code;
+    code = typeof c === "string" ? c : typeof c === "number" ? String(c) : undefined;
+  }
+  return code !== undefined ? { message, code } : { message };
+}
+
+function lower(s: string): string {
+  return s.toLowerCase();
+}
+
+/**
+ * Normalize errors from AVNU/starknet.js paymaster path.
+ * Returns null if the error is not clearly a sponsorship-unavailability failure.
+ */
+export function normalizeAvnuSponsorshipError(
+  raw: unknown
+): NormalizedSponsorshipFailure | null {
+  const { message, code } = messageAndCode(raw);
+  const m = lower(message);
+
+  // Config/setup: missing or invalid API key, auth, malformed endpoint
+  if (
+    m.includes("api key") ||
+    m.includes("apikey") ||
+    m.includes("api_key") ||
+    (m.includes("missing") && (m.includes("key") || m.includes("auth") || m.includes("header"))) ||
+    m.includes("invalid api key") ||
+    m.includes("unauthorized") ||
+    m.includes("forbidden") ||
+    m.includes("401") ||
+    m.includes("403") ||
+    code === "401" ||
+    code === "403" ||
+    (m.includes("malformed") && m.includes("paymaster")) ||
+    (m.includes("paymaster") && (m.includes("endpoint") || m.includes("config")))
+  ) {
+    return { reason: "invalid_paymaster_config", provider: "avnu" };
+  }
+
+  // Unsupported asset for sponsorship
+  if (
+    (m.includes("unsupported") && (m.includes("asset") || m.includes("token") || m.includes("gas"))) ||
+    m.includes("asset not supported") ||
+    m.includes("token not supported")
+  ) {
+    return { reason: "unsupported_asset", provider: "avnu" };
+  }
+
+  // Quota/limit
+  if (
+    m.includes("quota") ||
+    m.includes("limit exceeded") ||
+    m.includes("rate limit") ||
+    m.includes("policy_exceeded") ||
+    m.includes("exceeded")
+  ) {
+    return { reason: "policy_exceeded", provider: "avnu" };
+  }
+
+  // Network/paymaster outage
+  if (
+    (m.includes("network") && (m.includes("unavailable") || m.includes("error"))) ||
+    m.includes("timeout") ||
+    m.includes("econnrefused") ||
+    m.includes("enotfound") ||
+    m.includes("fetch failed") ||
+    (m.includes("paymaster") && (m.includes("unavailable") || m.includes("down") || m.includes("outage")))
+  ) {
+    return { reason: "network_unavailable", provider: "avnu" };
+  }
+
+  // Policy rejected (e.g. not allowed for this call)
+  if (m.includes("policy") && (m.includes("reject") || m.includes("denied"))) {
+    return { reason: "policy_rejected", provider: "avnu" };
+  }
+
+  // Generic paymaster/sponsor failure that is not a normal revert
+  if (
+    m.includes("paymaster") ||
+    m.includes("sponsor") ||
+    (m.includes("sponsored") && (m.includes("fail") || m.includes("error")))
+  ) {
+    return { reason: "unknown", provider: "avnu" };
+  }
+
+  return null;
+}
+
+/**
+ * Normalize errors from Cartridge controller/paymaster path.
+ * Returns null if the error is not clearly a sponsorship-unavailability failure.
+ */
+export function normalizeCartridgeSponsorshipError(
+  raw: unknown
+): NormalizedSponsorshipFailure | null {
+  const { message, code } = messageAndCode(raw);
+  const m = lower(message);
+
+  // Session/account not ready: disconnected, expired, not deployed in a way that blocks sponsorship
+  if (
+    m.includes("session") && (m.includes("expired") || m.includes("invalid") || m.includes("disconnect")) ||
+    m.includes("account not ready") ||
+    m.includes("account_not_ready") ||
+    m.includes("not connected") ||
+    m.includes("disconnected") ||
+    m.includes("session expired")
+  ) {
+    return { reason: "account_not_ready", provider: "cartridge" };
+  }
+
+  // Config/auth: misconfigured controller, backend auth/config mismatch
+  if (
+    m.includes("misconfigured") ||
+    m.includes("config") && (m.includes("fail") || m.includes("invalid")) ||
+    m.includes("auth") && (m.includes("fail") || m.includes("mismatch")) ||
+    m.includes("unauthorized") ||
+    m.includes("forbidden") ||
+    code === "401" ||
+    code === "403" ||
+    m.includes("backend") && (m.includes("refus") || m.includes("setup"))
+  ) {
+    return { reason: "invalid_paymaster_config", provider: "cartridge" };
+  }
+
+  // Policy rejected (e.g. missing or wrong session policy)
+  if (
+    m.includes("policy") && (m.includes("reject") || m.includes("denied") || m.includes("missing")) ||
+    m.includes("session policy") ||
+    m.includes("not allowed")
+  ) {
+    return { reason: "policy_rejected", provider: "cartridge" };
+  }
+
+  // Quota/limit
+  if (
+    m.includes("quota") ||
+    m.includes("limit exceeded") ||
+    m.includes("rate limit") ||
+    m.includes("exceeded")
+  ) {
+    return { reason: "policy_exceeded", provider: "cartridge" };
+  }
+
+  // Unsupported asset
+  if (
+    m.includes("unsupported") && (m.includes("asset") || m.includes("token")) ||
+    m.includes("asset not supported")
+  ) {
+    return { reason: "unsupported_asset", provider: "cartridge" };
+  }
+
+  // Transport/backend outage
+  if (
+    m.includes("network") && m.includes("unavailable") ||
+    m.includes("transport") ||
+    m.includes("backend") && (m.includes("outage") || m.includes("unavailable")) ||
+    m.includes("timeout") ||
+    m.includes("fetch failed")
+  ) {
+    return { reason: "network_unavailable", provider: "cartridge" };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Sponsorship error type and user_pays fallback

### Summary
Adds SDK error when sponsored (gasless) execution is unavailable and optional automatic fallback to user-paid fees. AVNU and Cartridge errors are normalized to a single contract so apps can show consistent UX.

### New public API
- **`SponsorshipNotAvailableError`** – Error with `reason`, `provider` (`"avnu"` | `"cartridge"` | `"unknown"`), `fallbackFeeRequired: true`, `rawError`
- **Normalized reasons:** `policy_rejected`, `policy_exceeded`, `unsupported_asset`, `invalid_paymaster_config`, `network_unavailable`, `account_not_ready`, `unknown`
- **DevX:** `SponsorshipNotAvailableError.isSponsorshipError(e)`, `toFriendlyMessage()`, `getSponsorshipFriendlyMessage(reason)`, `SPONSORSHIP_REASONS`, `SPONSORSHIP_REASON_MESSAGES`
- **Subpath:** `starkzap/sponsorship` for a focused import

### ExecuteOptions
- `fallbackTo?: "user_pays"` – On sponsorship failure, retry with user-paid fees
- `onFallback?: (error: SponsorshipNotAvailableError) => void` – Called before retry (e.g. toast)

### Behavior
- **Signer + Cartridge wallets:** Try sponsored execution; on failure, normalize (AVNU or Cartridge). If sponsorship error and `fallbackTo === "user_pays"`, ensure account is deployed, call `onFallback`, then retry with `user_pays`. Non-sponsorship errors are rethrown unchanged
- **Fallback preconditions:** If fallback requested but account not deployed, throw `SponsorshipNotAvailableError` with `reason: "account_not_ready"`
- **Scope:** Only failures that clearly mean “sponsorship unavailable” are normalized; contract reverts are not converted

### Internal
- **`src/wallet/sponsorship-errors.ts`** – `normalizeAvnuSponsorshipError()` and `normalizeCartridgeSponsorshipError()` (config/auth → `invalid_paymaster_config`, quota → `policy_exceeded`, etc.)

### Files changed
- `src/types/sponsorship-error.ts` (new)
- `src/types/wallet.ts` (ExecuteOptions + type import)
- `src/types/index.ts` (export)
- `src/wallet/sponsorship-errors.ts` (new)
- `src/wallet/index.ts` (fallback + `runSponsoredExecution`)
- `src/wallet/cartridge.ts` (fallback)
- `src/sponsorship.ts` (new)
- `package.json` (exports `./sponsorship`)

### Breaking changes
None. Additive only.