### PR TITLE
fix: add .js extensions to ESM output

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,10 @@
     // Performance
     "skipLibCheck": true
   },
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "resolveFullExtension": ".js"
+  },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
I encountered this issue while building a CLI tool that uses starkzap as a dependency. Running the tool via npx was failing with ERR_MODULE_NOT_FOUND because Node.js couldn't resolve the extensionless imports in starkzap's compiled output.

## Problem

The compiled JavaScript output uses extensionless relative imports:

```js
export { StarkSDK } from "./sdk";       // ❌ missing .js
export { Wallet } from "./wallet";      // ❌ missing .js
```

Node.js ESM resolution [requires explicit file extensions](https://nodejs.org/api/esm.html#mandatory-file-extensions) for relative imports. Without them, consumers get:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../starkzap/dist/src/sdk'
```

**Bundler-based consumers** (Vite, Next.js, Webpack) are unaffected because bundlers resolve imports without extensions. **Direct Node.js consumers** (CLI tools, MCP servers, scripts) break at runtime.

## Root Cause

`tsc-alias` replaces `@/` path aliases with relative paths but does not append `.js` extensions by default. Since `moduleResolution` is set to `bundler`, TypeScript also does not enforce extensions at compile time.

## Fix

Enable `tsc-alias` built-in options for full path resolution in `tsconfig.json`:

```json
"tsc-alias": {
  "resolveFullPaths": true,
  "resolveFullExtension": ".js"
}
```

**After this change**, compiled output becomes:

```js
export { StarkSDK } from "./sdk.js";           // ✅
export { Wallet } from "./wallet/index.js";    // ✅
```

## Verification

- ✅ `npm run build` — clean compile
- ✅ `npm test` — **406 tests passed**, 3 skipped, 0 failures
- ✅ `node -e "import('./dist/src/index.js')"` — runtime import succeeds
- ✅ No source code changes — only build config


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript configuration to improve path resolution and output file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->