### PR TITLE
feat(mcp): add swap + batched balances tools with hardening

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -66,16 +66,16 @@ This server handles real funds. The following protections are built in:
 
 ### CLI Arguments
 
-| Argument                 | Default                | Description                                                                                                                                                                           |
-| ------------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--network`              | `mainnet`              | Network preset: `mainnet` or `sepolia` (validated at startup)                                                                                                                         |
-| `--max-amount`           | `1000`                 | Max tokens per individual amount-bearing operation                                                                                                                                    |
-| `--max-batch-amount`     | `same as --max-amount` | Max total tokens across one `starkzap_transfer` batch call                                                                                                                            |
-| `--rate-limit-rpm`       | `0` (disabled)         | Global MCP tool-call rate limit per minute                                                                                                                                            |
-| `--read-rate-limit-rpm`  | `0` (disabled)         | Optional read-only bucket (`starkzap_get_balance`, `starkzap_get_balances`, `starkzap_get_quote`, `starkzap_build_swap_calls`, `starkzap_get_pool_position`, `starkzap_estimate_fee`) |
-| `--write-rate-limit-rpm` | `0` (disabled)         | Optional state-changing bucket (transfer/staking/deploy/execute)                                                                                                                      |
-| `--enable-write`         | off                    | Enable state-changing tools (transfer, stake, deploy)                                                                                                                                 |
-| `--enable-execute`       | off                    | Enable only the unrestricted `starkzap_execute` tool                                                                                                                                  |
+| Argument                 | Default                | Description                                                                                                                                                                                                   |
+| ------------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--network`              | `mainnet`              | Network preset: `mainnet` or `sepolia` (validated at startup)                                                                                                                                                 |
+| `--max-amount`           | `1000`                 | Max tokens per individual amount-bearing operation                                                                                                                                                            |
+| `--max-batch-amount`     | `same as --max-amount` | Max total tokens across one `starkzap_transfer` batch call                                                                                                                                                    |
+| `--rate-limit-rpm`       | `0` (disabled)         | Global MCP tool-call rate limit per minute                                                                                                                                                                    |
+| `--read-rate-limit-rpm`  | `0` (disabled)         | Optional read-only bucket (`starkzap_get_account`, `starkzap_get_balance`, `starkzap_get_balances`, `starkzap_get_quote`, `starkzap_build_swap_calls`, `starkzap_get_pool_position`, `starkzap_estimate_fee`) |
+| `--write-rate-limit-rpm` | `0` (disabled)         | Optional state-changing bucket (transfer/swap/staking/deploy/execute)                                                                                                                                         |
+| `--enable-write`         | off                    | Enable state-changing tools (transfer, stake, deploy)                                                                                                                                                         |
+| `--enable-execute`       | off                    | Enable only the unrestricted `starkzap_execute` tool                                                                                                                                                          |
 
 ## MCP Client Configuration
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -56,6 +56,7 @@ This server handles real funds. The following protections are built in:
 | Variable                             | Required | Description                                                                                     |
 | ------------------------------------ | -------- | ----------------------------------------------------------------------------------------------- |
 | `STARKNET_PRIVATE_KEY`               | Yes      | Stark curve private key (`0x` + exactly 64 hex chars, cryptographically valid)                  |
+| `STARKNET_ACCOUNT_ADDRESS`           | No       | Override derived account address (useful for funded/deployed accounts from existing setups)     |
 | `STARKNET_RPC_URL`                   | No       | Custom RPC endpoint (overrides network preset; HTTPS required except localhost HTTP)            |
 | `STARKNET_PAYMASTER_URL`             | No       | Custom paymaster endpoint for sponsored tx (HTTPS required except localhost HTTP)               |
 | `AVNU_PAYMASTER_API_KEY`             | No       | API key sent as `x-paymaster-api-key` for sponsored tx on AVNU paymaster                        |

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -21,7 +21,7 @@ npm run build
 # Read-only mode (balance checks, fee estimates, and pool position if staking is configured)
 STARKNET_PRIVATE_KEY=0x... node dist/index.js --network mainnet
 
-# Enable transfers and staking writes
+# Enable transfers, swaps, and staking writes
 STARKNET_PRIVATE_KEY=0x... STARKNET_STAKING_CONTRACT=0x... node dist/index.js --network mainnet --enable-write
 ```
 
@@ -30,7 +30,7 @@ STARKNET_PRIVATE_KEY=0x... STARKNET_STAKING_CONTRACT=0x... node dist/index.js --
 This server handles real funds. The following protections are built in:
 
 1. **All state-changing tools are disabled by default.** Read-only tools are available without write flags. Write tools (`starkzap_transfer`, `starkzap_swap`, staking, `starkzap_deploy_account`) require `--enable-write`. The unrestricted `starkzap_execute` tool requires its own `--enable-execute` flag.
-2. **Amount caps are enforced for both single ops and transfer batches.** All amount-bearing operations (transfers and staking) are bounded by `--max-amount` (default: 1000 tokens). Transfer batches are also bounded by `--max-batch-amount` (default: same as `--max-amount`). For state-dependent staking exits/claims, caps use multi-check preflight validation and remain best-effort with a residual chain-state race window between final check and inclusion (typically 1-3 Starknet blocks). `starkzap_exit_pool` calls `wallet.exitPool(pool)`, which in StarkZap SDK delegates to pool `exit_delegation_pool_action(walletAddress)` (no amount argument). Preflight validates the latest observed `unpooling + rewards` snapshot, but final settlement is computed on-chain at inclusion time. Worst-case excess vs preflight is therefore not hard-capped by MCP and depends on pool/contract state transitions between final read and inclusion. Keep `--max-amount` conservative and reconcile tx hashes before retrying.
+2. **Amount caps are enforced for both single ops and transfer batches.** All amount-bearing operations (transfers, swaps, and staking) are bounded by `--max-amount` (default: 1000 tokens). Transfer batches are also bounded by `--max-batch-amount` (default: same as `--max-amount`). For state-dependent staking exits/claims, caps use multi-check preflight validation and remain best-effort with a residual chain-state race window between final check and inclusion (typically 1-3 Starknet blocks). `starkzap_exit_pool` calls `wallet.exitPool(pool)`, which in StarkZap SDK delegates to pool `exit_delegation_pool_action(walletAddress)` (no amount argument). Preflight validates the latest observed `unpooling + rewards` snapshot, but final settlement is computed on-chain at inclusion time. Worst-case excess vs preflight is therefore not hard-capped by MCP and depends on pool/contract state transitions between final read and inclusion. Keep `--max-amount` conservative and reconcile tx hashes before retrying.
 3. **Batch size limits.** Maximum 20 transfers per batch, 10 calls per execute batch.
 4. **Address validation.** All addresses are validated against Starknet felt252 format before use.
 5. **Runtime argument validation.** Every tool's arguments are validated with zod schemas before execution. Malformed inputs are rejected with clear error messages.
@@ -74,7 +74,7 @@ This server handles real funds. The following protections are built in:
 | `--rate-limit-rpm`       | `0` (disabled)         | Global MCP tool-call rate limit per minute                                                                                                                                                                    |
 | `--read-rate-limit-rpm`  | `0` (disabled)         | Optional read-only bucket (`starkzap_get_account`, `starkzap_get_balance`, `starkzap_get_balances`, `starkzap_get_quote`, `starkzap_build_swap_calls`, `starkzap_get_pool_position`, `starkzap_estimate_fee`) |
 | `--write-rate-limit-rpm` | `0` (disabled)         | Optional state-changing bucket (transfer/swap/staking/deploy/execute)                                                                                                                                         |
-| `--enable-write`         | off                    | Enable state-changing tools (transfer, stake, deploy)                                                                                                                                                         |
+| `--enable-write`         | off                    | Enable state-changing tools (transfer, swap, stake, deploy)                                                                                                                                                   |
 | `--enable-execute`       | off                    | Enable only the unrestricted `starkzap_execute` tool                                                                                                                                                          |
 
 ## MCP Client Configuration

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -53,17 +53,17 @@ This server handles real funds. The following protections are built in:
 
 ### Environment Variables
 
-| Variable                             | Required | Description                                                                                     |
-| ------------------------------------ | -------- | ----------------------------------------------------------------------------------------------- |
-| `STARKNET_PRIVATE_KEY`               | Yes      | Stark curve private key (`0x` + exactly 64 hex chars, cryptographically valid)                  |
-| `STARKNET_ACCOUNT_ADDRESS`           | No       | Override derived account address (useful for funded/deployed accounts from existing setups)     |
-| `STARKNET_RPC_URL`                   | No       | Custom RPC endpoint (overrides network preset; HTTPS required except localhost HTTP)            |
-| `STARKNET_PAYMASTER_URL`             | No       | Custom paymaster endpoint for sponsored tx (HTTPS required except localhost HTTP)               |
-| `AVNU_PAYMASTER_API_KEY`             | No       | API key sent as `x-paymaster-api-key` for sponsored tx on AVNU paymaster                        |
-| `STARKNET_RPC_TIMEOUT_MS`            | No       | RPC timeout in milliseconds (default: `30000`)                                                  |
-| `STARKNET_POOL_CACHE_TTL_MS`         | No       | Pool class-hash cache TTL in ms (default: `30000`, set `0` to disable cache)                    |
-| `STARKNET_STAKING_CONTRACT`          | No       | Staking contract address (enables staking tools)                                                |
-| `STARKNET_STAKING_POOL_CLASS_HASHES` | No       | Comma-separated allowlist of pool contract class hashes (0x...) for strict pool-type validation |
+| Variable                             | Required | Description                                                                                                 |
+| ------------------------------------ | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `STARKNET_PRIVATE_KEY`               | Yes      | Stark curve private key (`0x` + 1-64 hex chars; shorter keys are left-padded to 32 bytes before validation) |
+| `STARKNET_ACCOUNT_ADDRESS`           | No       | Override derived account address (useful for funded/deployed accounts from existing setups)                 |
+| `STARKNET_RPC_URL`                   | No       | Custom RPC endpoint (overrides network preset; HTTPS required except localhost HTTP)                        |
+| `STARKNET_PAYMASTER_URL`             | No       | Custom paymaster endpoint for sponsored tx (HTTPS required except localhost HTTP)                           |
+| `AVNU_PAYMASTER_API_KEY`             | No       | API key sent as `x-paymaster-api-key` for sponsored tx on AVNU paymaster                                    |
+| `STARKNET_RPC_TIMEOUT_MS`            | No       | RPC timeout in milliseconds (default: `30000`)                                                              |
+| `STARKNET_POOL_CACHE_TTL_MS`         | No       | Pool class-hash cache TTL in ms (default: `30000`, set `0` to disable cache)                                |
+| `STARKNET_STAKING_CONTRACT`          | No       | Staking contract address (enables staking tools)                                                            |
+| `STARKNET_STAKING_POOL_CLASS_HASHES` | No       | Comma-separated allowlist of pool contract class hashes (0x...) for strict pool-type validation             |
 
 ### CLI Arguments
 
@@ -219,7 +219,7 @@ Use this sequence when validating real writes (not just tests):
 
 Troubleshooting from live runs:
 
-- If startup says private key is invalid, check key length: it must be 64 hex chars after `0x` (32 bytes). If your source omits a leading zero, left-pad before use.
+- If startup says private key is invalid, check that it is a `0x`-prefixed hex string representing a valid Stark curve scalar. Shorter hex values are accepted and normalized by left-padding to 32 bytes.
 - If your expected wallet address does not match, trust `starkzap_get_account` output. The MCP either derives from `STARKNET_PRIVATE_KEY` or uses `STARKNET_ACCOUNT_ADDRESS` when provided.
 - If sponsored deploy/transfer fails with paymaster errors (e.g. invalid API key), use funded user-pays mode or configure a valid paymaster setup in your environment.
 - In sponsored mode, account class-hash validation runs after tx confirmation as a safety audit check. This detects unexpected account classes but cannot prevent a misbehaving paymaster from submitting the first tx.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -211,7 +211,7 @@ Use this sequence when validating real writes (not just tests):
 
 1. Start with write enabled:
    `STARKNET_PRIVATE_KEY=0x... node dist/index.js --network sepolia --enable-write`
-2. Call `starkzap_get_account` first to confirm the **derived** address and class hash.
+2. Call `starkzap_get_account` first to confirm the **effective connected account address** (derived by default, or overridden via `STARKNET_ACCOUNT_ADDRESS`) and class hash.
 3. Confirm fees balance with `starkzap_get_balance` for `STRK` (and optionally `ETH`).
 4. If account is not deployed, call `starkzap_deploy_account`.
 5. Execute a tiny self-transfer (e.g. `0.00001`) with `starkzap_transfer`.
@@ -220,7 +220,7 @@ Use this sequence when validating real writes (not just tests):
 Troubleshooting from live runs:
 
 - If startup says private key is invalid, check key length: it must be 64 hex chars after `0x` (32 bytes). If your source omits a leading zero, left-pad before use.
-- If your expected wallet address does not match, trust `starkzap_get_account` output. The MCP uses StarkZap wallet derivation from the private key.
+- If your expected wallet address does not match, trust `starkzap_get_account` output. The MCP either derives from `STARKNET_PRIVATE_KEY` or uses `STARKNET_ACCOUNT_ADDRESS` when provided.
 - If sponsored deploy/transfer fails with paymaster errors (e.g. invalid API key), use funded user-pays mode or configure a valid paymaster setup in your environment.
 - In sponsored mode, account class-hash validation runs after tx confirmation as a safety audit check. This detects unexpected account classes but cannot prevent a misbehaving paymaster from submitting the first tx.
 - If write tx fails with undeployed account errors, run `starkzap_deploy_account` first, then retry transfer.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -29,7 +29,7 @@ STARKNET_PRIVATE_KEY=0x... STARKNET_STAKING_CONTRACT=0x... node dist/index.js --
 
 This server handles real funds. The following protections are built in:
 
-1. **All state-changing tools are disabled by default.** Read-only tools are available without write flags. Write tools (`starkzap_transfer`, staking, `starkzap_deploy_account`) require `--enable-write`. The unrestricted `starkzap_execute` tool requires its own `--enable-execute` flag.
+1. **All state-changing tools are disabled by default.** Read-only tools are available without write flags. Write tools (`starkzap_transfer`, `starkzap_swap`, staking, `starkzap_deploy_account`) require `--enable-write`. The unrestricted `starkzap_execute` tool requires its own `--enable-execute` flag.
 2. **Amount caps are enforced for both single ops and transfer batches.** All amount-bearing operations (transfers and staking) are bounded by `--max-amount` (default: 1000 tokens). Transfer batches are also bounded by `--max-batch-amount` (default: same as `--max-amount`). For state-dependent staking exits/claims, caps use multi-check preflight validation and remain best-effort with a residual chain-state race window between final check and inclusion (typically 1-3 Starknet blocks). `starkzap_exit_pool` calls `wallet.exitPool(pool)`, which in StarkZap SDK delegates to pool `exit_delegation_pool_action(walletAddress)` (no amount argument). Preflight validates the latest observed `unpooling + rewards` snapshot, but final settlement is computed on-chain at inclusion time. Worst-case excess vs preflight is therefore not hard-capped by MCP and depends on pool/contract state transitions between final read and inclusion. Keep `--max-amount` conservative and reconcile tx hashes before retrying.
 3. **Batch size limits.** Maximum 20 transfers per batch, 10 calls per execute batch.
 4. **Address validation.** All addresses are validated against Starknet felt252 format before use.
@@ -66,16 +66,16 @@ This server handles real funds. The following protections are built in:
 
 ### CLI Arguments
 
-| Argument                 | Default                | Description                                                                                               |
-| ------------------------ | ---------------------- | --------------------------------------------------------------------------------------------------------- |
-| `--network`              | `mainnet`              | Network preset: `mainnet` or `sepolia` (validated at startup)                                             |
-| `--max-amount`           | `1000`                 | Max tokens per individual amount-bearing operation                                                        |
-| `--max-batch-amount`     | `same as --max-amount` | Max total tokens across one `starkzap_transfer` batch call                                                |
-| `--rate-limit-rpm`       | `0` (disabled)         | Global MCP tool-call rate limit per minute                                                                |
-| `--read-rate-limit-rpm`  | `0` (disabled)         | Optional read-only bucket (`starkzap_get_balance`, `starkzap_get_pool_position`, `starkzap_estimate_fee`) |
-| `--write-rate-limit-rpm` | `0` (disabled)         | Optional state-changing bucket (transfer/staking/deploy/execute)                                          |
-| `--enable-write`         | off                    | Enable state-changing tools (transfer, stake, deploy)                                                     |
-| `--enable-execute`       | off                    | Enable only the unrestricted `starkzap_execute` tool                                                      |
+| Argument                 | Default                | Description                                                                                                                                                                           |
+| ------------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--network`              | `mainnet`              | Network preset: `mainnet` or `sepolia` (validated at startup)                                                                                                                         |
+| `--max-amount`           | `1000`                 | Max tokens per individual amount-bearing operation                                                                                                                                    |
+| `--max-batch-amount`     | `same as --max-amount` | Max total tokens across one `starkzap_transfer` batch call                                                                                                                            |
+| `--rate-limit-rpm`       | `0` (disabled)         | Global MCP tool-call rate limit per minute                                                                                                                                            |
+| `--read-rate-limit-rpm`  | `0` (disabled)         | Optional read-only bucket (`starkzap_get_balance`, `starkzap_get_balances`, `starkzap_get_quote`, `starkzap_build_swap_calls`, `starkzap_get_pool_position`, `starkzap_estimate_fee`) |
+| `--write-rate-limit-rpm` | `0` (disabled)         | Optional state-changing bucket (transfer/staking/deploy/execute)                                                                                                                      |
+| `--enable-write`         | off                    | Enable state-changing tools (transfer, stake, deploy)                                                                                                                                 |
+| `--enable-execute`       | off                    | Enable only the unrestricted `starkzap_execute` tool                                                                                                                                  |
 
 ## MCP Client Configuration
 
@@ -133,10 +133,19 @@ const mcpServer = new McpServerStdio({
 | ------------------------- | ----------------------------------------------------------- |
 | `starkzap_get_account`    | Get connected account address/deployment/class hash details |
 | `starkzap_get_balance`    | Get ERC20 token balance (human-readable + raw)              |
+| `starkzap_get_balances`   | Get balances for multiple tokens in one tool call           |
 | `starkzap_transfer`       | Transfer tokens to one or more recipients                   |
 | `starkzap_execute`        | Execute raw contract calls atomically                       |
 | `starkzap_deploy_account` | Deploy the account contract on-chain                        |
 | `starkzap_estimate_fee`   | Estimate gas cost for contract calls                        |
+
+### Swap
+
+| Tool                        | Description                                                      |
+| --------------------------- | ---------------------------------------------------------------- |
+| `starkzap_get_quote`        | Get swap quote for tokenIn -> tokenOut                           |
+| `starkzap_swap`             | Execute swap transaction via configured provider (default: AVNU) |
+| `starkzap_build_swap_calls` | Build unsigned swap calls (approval + route) without executing   |
 
 ### Staking
 

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "starkzap-mcp",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "starkzap-mcp",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "starkzap": "1.0.0",
+        "starkzap": "^2.0.0",
         "zod": "^3.25.0"
       },
       "bin": {
@@ -71,12 +71,47 @@
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
       "license": "MIT"
     },
+    "node_modules/@avnu/avnu-sdk": {
+      "version": "4.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@avnu/avnu-sdk/-/avnu-sdk-4.1.0-rc.0.tgz",
+      "integrity": "sha512-f/y2898hzhjXpPk5e2mxcyHbbbBwqq9EdJLtjku04BlgkZwk9qfviMBgRPw2oKGTbGu9nd+WSKI+rNBfLUSVCg==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.19",
+        "moment": "^2.30.1",
+        "qs": "^6.14.1",
+        "zod": "^4.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "ethers": "^6.15.0",
+        "starknet": "^8.9.1 || ^9.0.0"
+      }
+    },
+    "node_modules/@avnu/avnu-sdk/node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
+    "node_modules/@avnu/avnu-sdk/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -87,6 +122,7 @@
       "integrity": "sha512-A4Umpi8B9/pqR78D1Yoze4xHyQaujioVRqqO3d6xuDFw9VRtjg6tK3bPlwE0aW+nVH/ntllCpPa2PbI8Rnjcug==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.0.0",
         "@noble/hashes": "1.4.0",
@@ -105,6 +141,7 @@
       "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -124,6 +161,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "^1.10.1",
         "@noble/curves": "^1.6.0",
@@ -148,6 +186,7 @@
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -159,6 +198,8 @@
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/@cartridge/controller/-/controller-0.13.9.tgz",
       "integrity": "sha512-LVjoBN8/Fa2Hv5bjOUBWcaJSxFthqr5JikUPZo3NERnLloUHOtGQs6HnIFOwP4N5i0A+GyTJVLa+fmk49ZJERg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@cartridge/controller-wasm": "0.9.4",
         "@cartridge/penpal": "^6.2.4",
@@ -179,13 +220,17 @@
     "node_modules/@cartridge/controller-wasm": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/@cartridge/controller-wasm/-/controller-wasm-0.9.4.tgz",
-      "integrity": "sha512-hkvXPhAnjY57MhdJfUWK5htCFeOv06ChwYtrsx3AKJRnNW9HU25dfWHqWPdy875/2KmqIBDVTdoxddhoHgmrBw=="
+      "integrity": "sha512-hkvXPhAnjY57MhdJfUWK5htCFeOv06ChwYtrsx3AKJRnNW9HU25dfWHqWPdy875/2KmqIBDVTdoxddhoHgmrBw==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@cartridge/controller/node_modules/@noble/curves": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
       "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.6.0"
       },
@@ -201,6 +246,8 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
       "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -213,6 +260,8 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
       "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -225,6 +274,8 @@
       "resolved": "https://registry.npmjs.org/starknet/-/starknet-8.9.2.tgz",
       "integrity": "sha512-+dp+o2w67fV6JyVOVkYeM1Ec71aORHc/JrF4VHLlfeGee0nLilooCQLE2u6hUcSGQG2x2/fvzkxYpIN+k1JBvA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/curves": "~1.7.0",
         "@noble/hashes": "~1.6.0",
@@ -245,7 +296,9 @@
       "version": "6.2.4",
       "resolved": "https://registry.npmjs.org/@cartridge/penpal/-/penpal-6.2.4.tgz",
       "integrity": "sha512-tdpOnSJJBFMlgLZ1+z9Ho5e6cG5EgMAb1Cmmh1lGT2tmplogU/XPMjLE6CwvKAPDoe6a38iMnbH+ySTAWWIOKA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
       "version": "2.2.0",
@@ -258,7 +311,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@cbor-extract/cbor-extract-darwin-x64": {
       "version": "2.2.0",
@@ -271,7 +325,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@cbor-extract/cbor-extract-linux-arm": {
       "version": "2.2.0",
@@ -284,7 +339,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@cbor-extract/cbor-extract-linux-arm64": {
       "version": "2.2.0",
@@ -297,7 +353,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@cbor-extract/cbor-extract-linux-x64": {
       "version": "2.2.0",
@@ -310,7 +367,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@cbor-extract/cbor-extract-win32-x64": {
       "version": "2.2.0",
@@ -323,7 +381,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@coinbase/cdp-sdk": {
       "version": "1.44.1",
@@ -331,6 +390,7 @@
       "integrity": "sha512-O7sikX7gTZdF4xy9b0xAMPOKWk8z6E7an4EGVBukPdfChooBL15Zt6B8Wn5th/LC1V1nIf3J/tlTTQCJLkKZ6A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana-program/system": "^0.10.0",
         "@solana-program/token": "^0.9.0",
@@ -805,6 +865,8 @@
       "resolved": "https://registry.npmjs.org/@hpke/chacha20poly1305/-/chacha20poly1305-1.7.1.tgz",
       "integrity": "sha512-Zp8IwRIkdCucu877wCNqDp3B8yOhAnAah/YDDkO94pPr/KKV7IGnBbpwIjDB3BsAySWBMrhhdE0JKYw3N4FCag==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@hpke/common": "^1.8.1"
       },
@@ -817,6 +879,8 @@
       "resolved": "https://registry.npmjs.org/@hpke/common/-/common-1.8.1.tgz",
       "integrity": "sha512-PSI4QSxH8XDli0TqAsWycVfrLLCM/bBe+hVlJwtuJJiKIvCaFS3CXX/WtRfJceLJye9NHc2J7GvHVCY9B1BEbA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=16.0.0"
       }
@@ -826,6 +890,8 @@
       "resolved": "https://registry.npmjs.org/@hpke/core/-/core-1.7.5.tgz",
       "integrity": "sha512-4xfckZuPaIodeu0HpuTRIdtmajhRHXM/6rjS2N62Ns9aOCkGbbeYRwktqR3bUScuhCwyEBsEQqtIh9f0iLP3WQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@hpke/common": "^1.8.1"
       },
@@ -838,6 +904,8 @@
       "resolved": "https://registry.npmjs.org/@hpke/dhkem-x25519/-/dhkem-x25519-1.6.4.tgz",
       "integrity": "sha512-TTkZ3hjMDO6TweSTSAN/qL30WubOXJXTe/1eNL4cprlGokcjJq3SldcePI2BbC1eOYq903N1X6zwDjVG5OelfA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@hpke/common": "^1.8.1"
       },
@@ -850,6 +918,8 @@
       "resolved": "https://registry.npmjs.org/@hpke/dhkem-x448/-/dhkem-x448-1.6.4.tgz",
       "integrity": "sha512-xyR4SqS4MjDmQIrIQmqPWLNgwM6Ul6G8UWQsFKZw6PLv8pxVk1nYj2WJrdZ+Ecs9+qY/NYQItv8KVMXge3gFKQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@hpke/common": "^1.8.1"
       },
@@ -900,7 +970,9 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
       "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@lit/react": {
       "version": "1.0.8",
@@ -908,6 +980,7 @@
       "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "17 || 18 || 19"
       }
@@ -917,6 +990,8 @@
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
       "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
@@ -966,6 +1041,8 @@
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
       "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -975,6 +1052,8 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.5.3.tgz",
       "integrity": "sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -1011,6 +1090,8 @@
       "resolved": "https://registry.npmjs.org/@phosphor-icons/webcomponents/-/webcomponents-2.1.5.tgz",
       "integrity": "sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "lit": "^3"
       }
@@ -1021,6 +1102,8 @@
       "integrity": "sha512-7JjEp+JNxRUDOa7CxOCbUbG8uYVo38ojc9FN/fuzJuJADUzKDaH287MLV9qI1ZyQyXA8qXvhXRqjtw+3xo2/7A==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@reown/appkit-common": "1.8.17-wc-circular-dependencies-fix.0",
         "@reown/appkit-controllers": "1.8.17-wc-circular-dependencies-fix.0",
@@ -1045,6 +1128,8 @@
       "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.17-wc-circular-dependencies-fix.0.tgz",
       "integrity": "sha512-wf53EzDmCJ5ICtDY5B1MddVeCwoqDGPVmaxD4wQJLR9uanhBXfKq1sJou+Uj8lZCyI72Z+r9YlsePOlYH2Ge3A==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "big.js": "6.2.2",
         "dayjs": "1.11.13",
@@ -1056,6 +1141,8 @@
       "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.17-wc-circular-dependencies-fix.0.tgz",
       "integrity": "sha512-wY5yvMB0o2AwitwDHHO0u2tmqR+n3Crv0AHjIcY037PC3mhF9TPEUKqE9vlrFImQWQRxl0WRfuKfzmUAPxZExw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@reown/appkit-common": "1.8.17-wc-circular-dependencies-fix.0",
         "@reown/appkit-wallet": "1.8.17-wc-circular-dependencies-fix.0",
@@ -1068,13 +1155,17 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@reown/appkit-controllers/node_modules/@msgpack/msgpack": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.2.tgz",
       "integrity": "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -1084,6 +1175,8 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1096,6 +1189,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.2.tgz",
       "integrity": "sha512-KkaTELRu8t/mt3J9doCQ1fBGCbYsCNfpo2JpKdCwKQR7PVjVKeVpYQK/blVkA5m6uLPpBtVRbOMKjnHW1m7JLw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-provider": "1.0.14",
@@ -1124,6 +1219,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.2.tgz",
       "integrity": "sha512-LL5KgmJHvY5NqQn+ZHQJLia1p6fpUWXHtiG97S5rNfyuPx6gT/Jkkwqc2LwdmAjFkr61t8zTagHC9ETq203mNA==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/core": "2.23.2",
         "@walletconnect/events": "1.0.1",
@@ -1141,6 +1238,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.2.tgz",
       "integrity": "sha512-5dxBCdUM+4Dqe1/A7uqkm2tWPXce4UUGSr+ImfI0YjwEExQS8+TzdOlhMt3n32ncnBCllU5paG+fsndT06R0iw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
@@ -1155,6 +1254,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.2.tgz",
       "integrity": "sha512-vs9iorPUAiVesFJ95O6XvLjmRgF+B2TspxJNL90ZULbrkRw4JFsmaRdb965PZKc+s182k1MkS/MQ0o964xRcEw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -1175,6 +1276,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.2.tgz",
       "integrity": "sha512-ReSjU3kX+3i3tYJQZbVfetY5SSUL+iM6uiIVVD1PJalePa/5A40VgLVRTF7sDCJTIFfpf3Mt4bFjeaYuoxWtIw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@msgpack/msgpack": "3.1.2",
         "@noble/ciphers": "1.3.0",
@@ -1203,6 +1306,8 @@
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
       "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -1224,6 +1329,8 @@
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.3.tgz",
       "integrity": "sha512-Qb/TCFCldgOy8lZ5uC7nLGdqJwSabkQiYQShmw4jyiPk1pZzaYWTwaYKYP7EgLccWYgZocMrtItrwh683voaww==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "workspaces": [
         "docs",
         "benchmarks"
@@ -1240,6 +1347,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "^1.11.0",
         "@noble/ciphers": "^1.3.0",
@@ -1264,6 +1373,8 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
       "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -1279,6 +1390,8 @@
       "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.17-wc-circular-dependencies-fix.0.tgz",
       "integrity": "sha512-sVE8UT7CDA8zsg3opvbGjSZHSnohOVPF77vP6Ln4G0+vfoiXNhZaZa89Pg0MDjh+KGy0OulWVUdXuZ9jJQFvPg==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@reown/appkit-common": "1.8.17-wc-circular-dependencies-fix.0",
         "@reown/appkit-controllers": "1.8.17-wc-circular-dependencies-fix.0",
@@ -1293,6 +1406,8 @@
       "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.17-wc-circular-dependencies-fix.0.tgz",
       "integrity": "sha512-OyYavslCegfUlKu8Ah6BZhbqQrK7bImvUm+EKjjvnfNN9J0F9uWMFwbTpZxenBcfAI6cyaD9aTTUunMn5no1Og==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "buffer": "6.0.3"
       }
@@ -1302,6 +1417,8 @@
       "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.17-wc-circular-dependencies-fix.0.tgz",
       "integrity": "sha512-f+SYFGDy+uY1EAvWcH6vZgga1bOuzBvYSKYiRX2QQy8INtZqwwiLLvS4cgm5Yp1WvYRal5RdfZkKl5qha498gw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@reown/appkit-common": "1.8.17-wc-circular-dependencies-fix.0",
         "@reown/appkit-controllers": "1.8.17-wc-circular-dependencies-fix.0",
@@ -1317,6 +1434,8 @@
       "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.17-wc-circular-dependencies-fix.0.tgz",
       "integrity": "sha512-E1u2ZVZV0iFDSgrgtdQTZAXNbI+Lakj8E8V+jJQ47JaEVKv9SROvPu2fVqfIrqHQF68NmAk1dnbYi4luOiM0Fg==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@phosphor-icons/webcomponents": "2.1.5",
         "@reown/appkit-common": "1.8.17-wc-circular-dependencies-fix.0",
@@ -1331,6 +1450,8 @@
       "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.17-wc-circular-dependencies-fix.0.tgz",
       "integrity": "sha512-9El8sYbXDaMYxg4R6LujA965yYQGjNcPMXqympLtzNl1es5qkniW7eAdEpLmZrsaqNrfTaHT1G65wYy7sA595w==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@reown/appkit-common": "1.8.17-wc-circular-dependencies-fix.0",
         "@reown/appkit-controllers": "1.8.17-wc-circular-dependencies-fix.0",
@@ -1355,13 +1476,17 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@reown/appkit-utils/node_modules/@msgpack/msgpack": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.2.tgz",
       "integrity": "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -1371,6 +1496,8 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1383,6 +1510,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.2.tgz",
       "integrity": "sha512-KkaTELRu8t/mt3J9doCQ1fBGCbYsCNfpo2JpKdCwKQR7PVjVKeVpYQK/blVkA5m6uLPpBtVRbOMKjnHW1m7JLw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-provider": "1.0.14",
@@ -1411,6 +1540,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.2.tgz",
       "integrity": "sha512-LL5KgmJHvY5NqQn+ZHQJLia1p6fpUWXHtiG97S5rNfyuPx6gT/Jkkwqc2LwdmAjFkr61t8zTagHC9ETq203mNA==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/core": "2.23.2",
         "@walletconnect/events": "1.0.1",
@@ -1428,6 +1559,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.2.tgz",
       "integrity": "sha512-5dxBCdUM+4Dqe1/A7uqkm2tWPXce4UUGSr+ImfI0YjwEExQS8+TzdOlhMt3n32ncnBCllU5paG+fsndT06R0iw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
@@ -1442,6 +1575,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.2.tgz",
       "integrity": "sha512-vs9iorPUAiVesFJ95O6XvLjmRgF+B2TspxJNL90ZULbrkRw4JFsmaRdb965PZKc+s182k1MkS/MQ0o964xRcEw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -1462,6 +1597,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.2.tgz",
       "integrity": "sha512-ReSjU3kX+3i3tYJQZbVfetY5SSUL+iM6uiIVVD1PJalePa/5A40VgLVRTF7sDCJTIFfpf3Mt4bFjeaYuoxWtIw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@msgpack/msgpack": "3.1.2",
         "@noble/ciphers": "1.3.0",
@@ -1490,6 +1627,8 @@
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
       "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -1511,6 +1650,8 @@
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.3.tgz",
       "integrity": "sha512-Qb/TCFCldgOy8lZ5uC7nLGdqJwSabkQiYQShmw4jyiPk1pZzaYWTwaYKYP7EgLccWYgZocMrtItrwh683voaww==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "workspaces": [
         "docs",
         "benchmarks"
@@ -1527,6 +1668,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "^1.11.0",
         "@noble/ciphers": "^1.3.0",
@@ -1551,6 +1694,8 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
       "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -1566,6 +1711,8 @@
       "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.17-wc-circular-dependencies-fix.0.tgz",
       "integrity": "sha512-s0RTVNtgPtXGs+eZELVvTu1FRLuN15MyhVS//3/4XafVQkBBJarciXk9pFP71xeSHRzjYR1lXHnVw28687cUvQ==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@reown/appkit-common": "1.8.17-wc-circular-dependencies-fix.0",
         "@reown/appkit-polyfills": "1.8.17-wc-circular-dependencies-fix.0",
@@ -1578,6 +1725,8 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -1586,13 +1735,17 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@reown/appkit/node_modules/@msgpack/msgpack": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.2.tgz",
       "integrity": "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -1602,6 +1755,8 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1614,6 +1769,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.2.tgz",
       "integrity": "sha512-KkaTELRu8t/mt3J9doCQ1fBGCbYsCNfpo2JpKdCwKQR7PVjVKeVpYQK/blVkA5m6uLPpBtVRbOMKjnHW1m7JLw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-provider": "1.0.14",
@@ -1642,6 +1799,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.2.tgz",
       "integrity": "sha512-LL5KgmJHvY5NqQn+ZHQJLia1p6fpUWXHtiG97S5rNfyuPx6gT/Jkkwqc2LwdmAjFkr61t8zTagHC9ETq203mNA==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/core": "2.23.2",
         "@walletconnect/events": "1.0.1",
@@ -1659,6 +1818,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.2.tgz",
       "integrity": "sha512-5dxBCdUM+4Dqe1/A7uqkm2tWPXce4UUGSr+ImfI0YjwEExQS8+TzdOlhMt3n32ncnBCllU5paG+fsndT06R0iw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
@@ -1673,6 +1834,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.2.tgz",
       "integrity": "sha512-vs9iorPUAiVesFJ95O6XvLjmRgF+B2TspxJNL90ZULbrkRw4JFsmaRdb965PZKc+s182k1MkS/MQ0o964xRcEw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -1693,6 +1856,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.2.tgz",
       "integrity": "sha512-ReSjU3kX+3i3tYJQZbVfetY5SSUL+iM6uiIVVD1PJalePa/5A40VgLVRTF7sDCJTIFfpf3Mt4bFjeaYuoxWtIw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@msgpack/msgpack": "3.1.2",
         "@noble/ciphers": "1.3.0",
@@ -1721,6 +1886,8 @@
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
       "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -1742,6 +1909,8 @@
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.3.tgz",
       "integrity": "sha512-Qb/TCFCldgOy8lZ5uC7nLGdqJwSabkQiYQShmw4jyiPk1pZzaYWTwaYKYP7EgLccWYgZocMrtItrwh683voaww==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "workspaces": [
         "docs",
         "benchmarks"
@@ -1758,6 +1927,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "^1.11.0",
         "@noble/ciphers": "^1.3.0",
@@ -1782,6 +1953,8 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
       "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -2148,6 +2321,7 @@
       "integrity": "sha512-4LhMmjPWlIO8TTDC2AwLk44XKXaK6hfBTWyljDm0HQ6TWlOEijVWNrt2s3OCVMSxlXAcEzYfqyu1daHZooTC2Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@safe-global/safe-apps-sdk": "^9.1.0",
         "events": "^3.3.0"
@@ -2159,6 +2333,7 @@
       "integrity": "sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
         "viem": "^2.1.1"
@@ -2170,6 +2345,7 @@
       "integrity": "sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -2268,6 +2444,7 @@
       "integrity": "sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "peerDependencies": {
         "@solana/kit": "^5.0"
       }
@@ -2278,6 +2455,7 @@
       "integrity": "sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "peerDependencies": {
         "@solana/kit": "^5.0"
       }
@@ -2288,6 +2466,7 @@
       "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -2314,6 +2493,7 @@
       "integrity": "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/assertions": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -2339,6 +2519,7 @@
       "integrity": "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1"
       },
@@ -2360,6 +2541,7 @@
       "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "buffer": "~6.0.3"
       },
@@ -2373,6 +2555,7 @@
       "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
         "@solana/codecs-data-structures": "5.5.1",
@@ -2398,6 +2581,7 @@
       "integrity": "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1"
       },
@@ -2419,6 +2603,7 @@
       "integrity": "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
         "@solana/codecs-numbers": "5.5.1",
@@ -2442,6 +2627,7 @@
       "integrity": "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
         "@solana/errors": "5.5.1"
@@ -2464,6 +2650,7 @@
       "integrity": "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
         "@solana/codecs-numbers": "5.5.1",
@@ -2491,6 +2678,7 @@
       "integrity": "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "chalk": "5.6.2",
         "commander": "14.0.2"
@@ -2516,6 +2704,7 @@
       "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -2526,6 +2715,7 @@
       "integrity": "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -2544,6 +2734,7 @@
       "integrity": "sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -2562,6 +2753,7 @@
       "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/instructions": "5.5.1",
@@ -2588,6 +2780,7 @@
       "integrity": "sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
         "@solana/errors": "5.5.1"
@@ -2610,6 +2803,7 @@
       "integrity": "sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/assertions": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -2635,6 +2829,7 @@
       "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.5.1",
         "@solana/addresses": "5.5.1",
@@ -2677,6 +2872,7 @@
       "integrity": "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -2695,6 +2891,7 @@
       "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -2723,6 +2920,7 @@
       "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
         "@solana/codecs-data-structures": "5.5.1",
@@ -2748,6 +2946,7 @@
       "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -2766,6 +2965,7 @@
       "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/errors": "5.5.1"
@@ -2788,6 +2988,7 @@
       "integrity": "sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -2806,6 +3007,7 @@
       "integrity": "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/fast-stable-stringify": "5.5.1",
@@ -2835,6 +3037,7 @@
       "integrity": "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -2866,6 +3069,7 @@
       "integrity": "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -2884,6 +3088,7 @@
       "integrity": "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/rpc-spec-types": "5.5.1"
@@ -2906,6 +3111,7 @@
       "integrity": "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -2924,6 +3130,7 @@
       "integrity": "sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/fast-stable-stringify": "5.5.1",
@@ -2955,6 +3162,7 @@
       "integrity": "sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/keys": "5.5.1",
@@ -2982,6 +3190,7 @@
       "integrity": "sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/functional": "5.5.1",
@@ -3007,6 +3216,7 @@
       "integrity": "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/promises": "5.5.1",
@@ -3031,6 +3241,7 @@
       "integrity": "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/functional": "5.5.1",
@@ -3056,6 +3267,7 @@
       "integrity": "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/rpc-spec": "5.5.1",
@@ -3079,7 +3291,8 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.22.0.tgz",
       "integrity": "sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@solana/rpc-types": {
       "version": "5.5.1",
@@ -3087,6 +3300,7 @@
       "integrity": "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -3113,6 +3327,7 @@
       "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -3142,6 +3357,7 @@
       "integrity": "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1"
       },
@@ -3163,6 +3379,7 @@
       "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.5.1",
         "@solana/codecs": "5.5.1",
@@ -3187,6 +3404,7 @@
       "integrity": "sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-strings": "5.5.1",
@@ -3217,6 +3435,7 @@
       "integrity": "sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -3246,6 +3465,7 @@
       "integrity": "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -3278,6 +3498,7 @@
       "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "@noble/curves": "^1.4.2",
@@ -3302,6 +3523,7 @@
       "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0"
       },
@@ -3318,6 +3540,7 @@
       "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
         "@solana/errors": "2.3.0"
@@ -3335,6 +3558,7 @@
       "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^14.0.0"
@@ -3355,6 +3579,7 @@
       "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -3365,6 +3590,7 @@
       "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "base-x": "^3.0.2"
       }
@@ -3375,6 +3601,7 @@
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -3391,6 +3618,8 @@
       "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0-beta.0.tgz",
       "integrity": "sha512-1QBmWnd76KzKwnVlRXLh58wtd1e0P5fyOhs0bCCjivTpGJ2nUPRvTgmzVJStNBcuQ7617UfB5qIyBnkig31TmQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@starknet-io/types-js": "^0.7.10",
         "@wallet-standard/base": "^1.1.0",
@@ -3402,7 +3631,9 @@
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
       "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@starknet-io/starknet-types-010": {
       "name": "@starknet-io/types-js",
@@ -3416,7 +3647,9 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.8.4.tgz",
       "integrity": "sha512-0RZ3TZHcLsUTQaq1JhDSCM8chnzO4/XNsSCozwDET64JK5bjFDIf2ZUkta+tl5Nlbf4usoU7uZiDI/Q57kt2SQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@starknet-io/starknet-types-09": {
       "name": "@starknet-io/types-js",
@@ -3429,7 +3662,9 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.9.1.tgz",
       "integrity": "sha512-ngLjOFuWOI4EFij8V+nl5tgHVACr6jqgLNUQbgD+AgnTcAN33SemBPXDIsovwK1Mz1U04Cz3qjDOnTq7067ZQw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.19",
@@ -3437,6 +3672,7 @@
       "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -3446,7 +3682,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@telegram-apps/bridge": {
       "version": "1.9.2",
@@ -3454,6 +3691,8 @@
       "integrity": "sha512-SJLcNWLXhbbZr9MiqFH/g2ceuitSJKMxUIZysK4zUNyTUNuonrQG80Q/yrO+XiNbKUj8WdDNM86NBARhuyyinQ==",
       "deprecated": "This package is not supported anymore. Use @tma.js/bridge instead",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@telegram-apps/signals": "^1.1.1",
         "@telegram-apps/toolkit": "^1.1.1",
@@ -3465,13 +3704,17 @@
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/@telegram-apps/navigation/-/navigation-1.0.14.tgz",
       "integrity": "sha512-bqNgF/J8Po7ZtsELm3E1a6aPr7awwxO3sIqD8J6u12urOlGoW5+1KxKKbkPa58mgXuQdsltd8apI+OVy0IYiUA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@telegram-apps/sdk": {
       "version": "2.11.3",
       "resolved": "https://registry.npmjs.org/@telegram-apps/sdk/-/sdk-2.11.3.tgz",
       "integrity": "sha512-KdULzgRe1gcR8B3Z/t3hQrEaDmLGrfsL2IePtPP6ehtMn5tT0uPfnjtDLjDNQMyI7D4Tv2ZOzvDx45wOhhreXg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@telegram-apps/bridge": "^1.9.2",
         "@telegram-apps/navigation": "^1.0.13",
@@ -3484,13 +3727,17 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@telegram-apps/signals/-/signals-1.1.2.tgz",
       "integrity": "sha512-1P1kdCLX7MfETGPxH7f3UZKIsdE7Tz5S7QmN4Km1sbYQMakD5Bi1NecSMR7/wnHp50gWMI1JzENcMtCEmouhSg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@telegram-apps/toolkit": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@telegram-apps/toolkit/-/toolkit-1.1.1.tgz",
       "integrity": "sha512-+vhKx6ngfvjyTE6Xagl3z1TPVbfx5s7xAkcYzCdHYUo6T60jLIqLgyZMcI1UPoIAMuMu1pHoO+p8QNCj/+tFmw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@telegram-apps/transformers": {
       "version": "1.2.2",
@@ -3498,6 +3745,8 @@
       "integrity": "sha512-vvMwXckd1D7Ozc0h66PSUwF5QLrRV9HlGJFFeBuUex8QEk5mSPtsJkLiqB8aBbwuFDa91+TUSM/CxqPZO/e9YQ==",
       "deprecated": "This package is not supported anymore. Use @tma.js/transfomers instead",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@telegram-apps/toolkit": "^1.1.1",
         "@telegram-apps/types": "^1.2.1"
@@ -3508,13 +3757,17 @@
       "resolved": "https://registry.npmjs.org/@telegram-apps/types/-/types-1.2.1.tgz",
       "integrity": "sha512-so4HLh7clur0YyMthi9KVIgWoGpZdXlFOuQjk3+Q5NAvJZ11nAheBSwPlGw/Ko92+zwvrSBE/lQyN2+p17RP+w==",
       "deprecated": "This package is not supported anymore. Use @tma.js/types instead",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@turnkey/api-key-stamper": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/@turnkey/api-key-stamper/-/api-key-stamper-0.4.5.tgz",
       "integrity": "sha512-8UeYt/2WtMrK2uSFzjiRXdCVc9SmKlMVuA4f1Z+SlxcsW0wlEpNM/7bd8N4VVVAjoE8Yy50Vhk3ylfQFtlaKsQ==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/curves": "^1.3.0",
         "@turnkey/encoding": "0.4.0",
@@ -3529,6 +3782,8 @@
       "resolved": "https://registry.npmjs.org/@turnkey/crypto/-/crypto-2.3.1.tgz",
       "integrity": "sha512-fHKCw0inuThEKIpZnC8pvz16egZHf08wES0LdSkM9XrGDcI7p0eqF7nAHgfAMW/0qNVZD8AKW+g/5O97HBwZ4w==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/ciphers": "0.5.3",
         "@noble/curves": "1.4.0",
@@ -3546,6 +3801,8 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
       "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.4.0"
       },
@@ -3558,6 +3815,8 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
       "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -3569,13 +3828,17 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
       "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@turnkey/crypto/node_modules/bs58": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
       "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "base-x": "^4.0.0"
       }
@@ -3585,6 +3848,8 @@
       "resolved": "https://registry.npmjs.org/@turnkey/encoding/-/encoding-0.4.0.tgz",
       "integrity": "sha512-ptLgcpWVt34KTPx0omF2QLJrosW6I//clCJ4G2+yngYFCzrdR0yBchV/BOcfME67mK1v3MmauyXl9AAnQTmB4Q==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -3594,6 +3859,8 @@
       "resolved": "https://registry.npmjs.org/@turnkey/http/-/http-3.3.0.tgz",
       "integrity": "sha512-m1fP8aqQcI0U4j7Gw89UbavavWP7AWGmEwoJl5nBhQz88mtep6AaZTsUoDDU4HXg0ch+aQ2/lfl0KFPp8s2u5Q==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@turnkey/api-key-stamper": "0.4.5",
         "@turnkey/encoding": "0.4.0",
@@ -3609,6 +3876,8 @@
       "resolved": "https://registry.npmjs.org/@turnkey/iframe-stamper/-/iframe-stamper-2.5.0.tgz",
       "integrity": "sha512-XjntbA5CNjxGRH+loceAlVLL9PG9Q4Y7p5zjBm4DeKclhD6lpUl9h8INArMEXIFbfLwLjjS6Q+SmQG4BHvNY6A==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -3618,6 +3887,8 @@
       "resolved": "https://registry.npmjs.org/@turnkey/sdk-browser/-/sdk-browser-4.3.0.tgz",
       "integrity": "sha512-TBAWpA28PnqFOeD45Ljzq5RfAabj4Qlnvo1toekt+yf6Hk13Nsm6R5FEiivHUMSNcvKBAwf5uQg+MPbBndymlQ==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@turnkey/api-key-stamper": "0.4.5",
         "@turnkey/crypto": "2.3.1",
@@ -3640,6 +3911,8 @@
       "resolved": "https://registry.npmjs.org/@turnkey/wallet-stamper/-/wallet-stamper-1.0.3.tgz",
       "integrity": "sha512-8DMuVPo/u8oIzQ9Snsa24ZQO3nXVMfpd8VnlPLfZiW2jjZHPFyBGCJOYSArfp+W2xoudpYVu//JElBAVxk/u/g==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@turnkey/crypto": "2.3.1",
         "@turnkey/encoding": "0.4.0"
@@ -3653,6 +3926,8 @@
       "resolved": "https://registry.npmjs.org/@turnkey/webauthn-stamper/-/webauthn-stamper-0.5.0.tgz",
       "integrity": "sha512-iUbTUwD4f4ibdLy5PWWb7ITEz4S4VAP9/mNjFhoRY3cKVVTDfmykrVTKjPOIHWzDgAmLtgrLvySIIC9ZBVENBw==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "sha256-uint8array": "^0.10.7"
       },
@@ -3677,6 +3952,7 @@
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3720,14 +3996,17 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
@@ -3735,6 +4014,7 @@
       "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3876,6 +4156,8 @@
       "resolved": "https://registry.npmjs.org/@wallet-standard/wallet/-/wallet-1.1.0.tgz",
       "integrity": "sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@wallet-standard/base": "^1.1.0"
       },
@@ -3888,6 +4170,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.6.tgz",
       "integrity": "sha512-rAV0Hgd/uPzeo2nWv2MZfGaP5diniKZICMVATGwzrsgGqDMeC1WYRkX3hXnIGJhMF4mhZxjaKFHcms03bqm/jw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-provider": "1.0.14",
@@ -3916,6 +4200,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
       "integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "1.14.1"
       }
@@ -3925,6 +4211,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.23.6.tgz",
       "integrity": "sha512-bJfW31wLLKpQ7W5BiKeCNGWTPa1eZGo4EZgiXPbIY0HhiSp6Ts9B7yyCehtRs/lj8AC52mZMDYhr5XALf46npg==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@reown/appkit": "1.8.17-wc-circular-dependencies-fix.0",
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -3945,6 +4233,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
       "integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0",
         "tslib": "1.14.1"
@@ -3955,6 +4245,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.2.tgz",
       "integrity": "sha512-uASiRmC5MwhuRuf05vq4AT48Pq8RMi876zV8rr8cV969uTOzWdB/k+Lj5yI2PBtB1bGQisGen7MM1GcZlQTBXw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/time": "^1.0.2",
@@ -3966,6 +4258,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.8.tgz",
       "integrity": "sha512-+B7cRuaxijLeFDJUq5hAzNyef3e3tBDIxyaCNmFtjwnod5AGis3RToNqzFU33vpVcxFhofkpE7Cx+5MYejbMGw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.1",
@@ -3978,6 +4272,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.14.tgz",
       "integrity": "sha512-rtsNY1XqHvWj0EtITNeuf8PHMvlCLiS3EjQL+WOkxEOA4KPxsohFnBDeyPYiNm4ZvkQdLnece36opYidmtbmow==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/safe-json": "^1.0.2",
@@ -3989,6 +4285,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.4.tgz",
       "integrity": "sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "events": "^3.3.0",
         "keyvaluestorage-interface": "^1.0.0"
@@ -3999,6 +4297,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
       "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/environment": "^1.0.1",
         "@walletconnect/jsonrpc-types": "^1.0.3",
@@ -4010,6 +4310,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
       "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -4022,6 +4324,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -4043,6 +4347,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
       "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.1",
         "idb-keyval": "^6.2.1",
@@ -4062,6 +4368,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
       "integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.2",
         "pino": "10.0.0"
@@ -4072,6 +4380,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.11.tgz",
       "integrity": "sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/jsonrpc-types": "^1.0.2"
       }
@@ -4081,6 +4391,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.1.0.tgz",
       "integrity": "sha512-qFw+a9uRz26jRCDgL7Q5TA9qYIgcNY8jpJzI1zAWNZ8i7mQjaijRnWFKsCHAU9CyGjvt6RKrRXyFtFOpWTVmCQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/curves": "1.8.0",
         "@noble/hashes": "1.7.0",
@@ -4094,6 +4406,8 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.0.tgz",
       "integrity": "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.7.0"
       },
@@ -4109,6 +4423,8 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
       "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4121,6 +4437,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
       "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "1.14.1"
       }
@@ -4130,6 +4448,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.6.tgz",
       "integrity": "sha512-cqMZFmq9ABkQOVML1EZPYbfPenI4jBIbzfsqa0A17notdRJR2Dio4GTNoA9jyLFP6JxqwaH635dc98EUFvre5w==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/core": "2.23.6",
         "@walletconnect/events": "1.0.1",
@@ -4147,6 +4467,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
       "integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "1.14.1"
       }
@@ -4156,6 +4478,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.6.tgz",
       "integrity": "sha512-ZoAa/TnNzq1hfh4b7J+GU5IXaYidWw469N4nSji5irPg2KQXvQWW+mhzswGrzYEzD3K/OTFzo0bdkhYVrvTTMw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
@@ -4170,6 +4494,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.6.tgz",
       "integrity": "sha512-18dnV9LUH28oqntA1Grg3Hsc7V5BJmYTsojbk5J5SyS/6ewkTUBxUpgbB3Gw2oFIi9WcZq359chClrqkIrwjxQ==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -4190,6 +4516,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.6.tgz",
       "integrity": "sha512-xQMwUHSkNXheUFv/b+hhzyDi6tUKLZE8AJD3vnd+oQm7LB/Sbu0MfgR5SlWMFeSqlELZeL+49q7uJdbUO3gUtg==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@msgpack/msgpack": "3.1.3",
         "@noble/ciphers": "1.3.0",
@@ -4216,13 +4544,17 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@walletconnect/utils/node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4235,6 +4567,8 @@
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
       "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -4262,6 +4596,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "^1.11.0",
         "@noble/ciphers": "^1.3.0",
@@ -4286,6 +4622,8 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
       "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -4301,6 +4639,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
       "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "1.14.1"
       }
@@ -4310,6 +4650,8 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
       "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.1",
         "tslib": "1.14.1"
@@ -4448,7 +4790,8 @@
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
@@ -4456,6 +4799,7 @@
       "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -4538,6 +4882,8 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -4551,6 +4897,8 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -4573,13 +4921,16 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4590,6 +4941,7 @@
       "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -4602,6 +4954,7 @@
       "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "is-retry-allowed": "^2.2.0"
       },
@@ -4613,7 +4966,9 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
       "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -4633,13 +4988,17 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/big.js": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.2.tgz",
       "integrity": "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "*"
       },
@@ -4652,14 +5011,17 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
       "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/bn.js": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
       "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -4691,6 +5053,7 @@
       "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bn.js": "^5.2.0",
         "bs58": "^4.0.0",
@@ -4703,6 +5066,7 @@
       "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -4713,6 +5077,7 @@
       "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "base-x": "^3.0.2"
       }
@@ -4722,6 +5087,8 @@
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
       "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "base-x": "^5.0.0"
       }
@@ -4731,6 +5098,8 @@
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
       "integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bs58": "^5.0.0"
@@ -4740,13 +5109,17 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
       "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/bs58check/node_modules/bs58": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
       "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "base-x": "^4.0.0"
       }
@@ -4770,6 +5143,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -4782,6 +5157,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -4794,6 +5170,8 @@
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
       "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "run-applescript": "^7.0.0"
       },
@@ -4873,6 +5251,8 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4897,6 +5277,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "node-gyp-build-optional-packages": "5.1.1"
       },
@@ -4917,6 +5298,8 @@
       "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.6.0.tgz",
       "integrity": "sha512-0kareyRwHSkL6ws5VXHEf8uY1liitysCVJjlmhaLG+IXLqhSaOO+t63coaso7yjwEzWZzLy8fJo06gZDVQM9Qg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "optionalDependencies": {
         "cbor-extract": "^2.2.0"
       }
@@ -4937,6 +5320,7 @@
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -4950,6 +5334,7 @@
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -4975,6 +5360,8 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
       "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -4987,6 +5374,7 @@
       "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5015,6 +5403,7 @@
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -5084,7 +5473,9 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
       "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -5117,6 +5508,8 @@
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
       "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -5140,6 +5533,8 @@
       "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
       "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
@@ -5150,6 +5545,7 @@
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -5166,7 +5562,9 @@
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -5190,6 +5588,8 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5199,6 +5599,8 @@
       "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
       "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "bundle-name": "^4.1.0",
         "default-browser-id": "^5.0.0"
@@ -5215,6 +5617,8 @@
       "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
       "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -5227,6 +5631,8 @@
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5238,7 +5644,9 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/delay": {
       "version": "5.0.0",
@@ -5246,6 +5654,7 @@
       "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5259,6 +5668,7 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5276,13 +5686,17 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/detect-browser": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
       "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -5290,6 +5704,7 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5298,7 +5713,9 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5330,7 +5747,9 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
       "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -5384,6 +5803,7 @@
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -5399,6 +5819,8 @@
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
       "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "workspaces": [
         "docs",
         "benchmarks"
@@ -5409,7 +5831,8 @@
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
       "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/es6-promisify": {
       "version": "5.0.0",
@@ -5417,6 +5840,7 @@
       "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "es6-promise": "^4.0.3"
       }
@@ -5525,6 +5949,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -5543,6 +5968,7 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -5555,6 +5981,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -5567,6 +5994,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -5575,19 +6003,22 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/ethers/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ethers/node_modules/ws": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5615,6 +6046,8 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -5716,6 +6149,7 @@
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "> 0.1.90"
       }
@@ -5731,7 +6165,8 @@
       "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -5793,6 +6228,8 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -5825,6 +6262,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -5840,6 +6278,7 @@
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5857,6 +6296,7 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5867,6 +6307,7 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -5999,6 +6440,8 @@
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.5.tgz",
       "integrity": "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "cookie-es": "^1.2.2",
         "crossws": "^0.3.5",
@@ -6029,6 +6472,7 @@
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -6065,6 +6509,8 @@
       "resolved": "https://registry.npmjs.org/hpke-js/-/hpke-js-1.6.5.tgz",
       "integrity": "sha512-amUFmHr6Z16370Wn57lYOkl+gb3wDBUc0nyPlx9ODMTaJ09kAVY0MrOU7JCzJJjL0bN8nKPU5vfXLBRjCmREOw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@hpke/chacha20poly1305": "^1.7.0",
         "@hpke/common": "^1.8.1",
@@ -6102,6 +6548,7 @@
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ms": "^2.0.0"
       }
@@ -6126,7 +6573,9 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
       "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -6146,7 +6595,9 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -6177,6 +6628,8 @@
       "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
       "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
       }
@@ -6186,13 +6639,16 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
       "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -6217,6 +6673,8 @@
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
       "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "is-docker": "^3.0.0"
       },
@@ -6242,6 +6700,7 @@
       "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6254,6 +6713,8 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
       "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "is-inside-container": "^1.0.0"
       },
@@ -6276,6 +6737,7 @@
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "peerDependencies": {
         "ws": "*"
       }
@@ -6291,6 +6753,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "peerDependencies": {
         "ws": "*"
       }
@@ -6301,6 +6765,7 @@
       "integrity": "sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/connect": "^3.4.33",
         "@types/node": "^12.12.54",
@@ -6327,14 +6792,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/jayson/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
@@ -6342,6 +6809,7 @@
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -6394,7 +6862,8 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",
@@ -6412,7 +6881,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
       "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -6439,6 +6910,8 @@
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
       "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -6450,6 +6923,8 @@
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
       "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.1.0",
@@ -6461,6 +6936,8 @@
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
       "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -6480,6 +6957,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -6498,6 +6977,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -6527,6 +7008,7 @@
       "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "charenc": "0.0.2",
         "crypt": "0.0.2",
@@ -6559,6 +7041,8 @@
       "resolved": "https://registry.npmjs.org/micro-packed/-/micro-packed-0.7.3.tgz",
       "integrity": "sha512-2Milxs+WNC00TRlem41oRswvw31146GiSaoCT7s3Xi2gMUglW5QBeqlQaZeHr5tJx9nm3i57LNXPqxOOaWtTYg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@scure/base": "~1.2.5"
       },
@@ -6571,6 +7055,8 @@
       "resolved": "https://registry.npmjs.org/micro-sol-signer/-/micro-sol-signer-0.5.0.tgz",
       "integrity": "sha512-4D5mGHuWuAC1w7HXXs+mlugw9n0hk3Gk0pFjQYkzE6zbvwEEioyb6l8375hivcqD6830/tCDCyQv+i3jfVFC+w==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/curves": "^1.8.0",
         "@noble/hashes": "^1.7.0",
@@ -6617,6 +7103,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "peerDependencies": {
         "typescript": ">=5.0.4"
       },
@@ -6639,6 +7127,15 @@
         "ufo": "^1.6.1"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6649,7 +7146,9 @@
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-      "license": "(Apache-2.0 AND MIT)"
+      "license": "(Apache-2.0 AND MIT)",
+      "optional": true,
+      "peer": true
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -6696,6 +7195,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6715,7 +7216,9 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
@@ -6723,6 +7226,7 @@
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -6735,6 +7239,7 @@
       "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.1"
       },
@@ -6748,13 +7253,17 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
       "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6796,6 +7305,8 @@
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
       "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "destr": "^2.0.5",
         "node-fetch-native": "^1.6.7",
@@ -6807,6 +7318,8 @@
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -6837,6 +7350,8 @@
       "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
       "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",
@@ -6884,6 +7399,8 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -6899,6 +7416,8 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -6911,6 +7430,8 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6935,6 +7456,8 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6990,6 +7513,8 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
       "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "on-exit-leak-free": "^2.1.0",
@@ -7012,6 +7537,8 @@
       "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
       "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "split2": "^4.0.0"
       }
@@ -7020,7 +7547,9 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/pirates": {
       "version": "4.0.7",
@@ -7058,6 +7587,8 @@
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
       "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -7140,6 +7671,7 @@
       "integrity": "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -7159,7 +7691,9 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -7178,20 +7712,25 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
       "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/qrcode": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
       "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "dijkstrajs": "^1.0.1",
         "encode-utf8": "^1.0.3",
@@ -7224,13 +7763,17 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/radix3": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -7275,6 +7818,8 @@
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 12.13.0"
       }
@@ -7310,7 +7855,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
@@ -7389,6 +7936,7 @@
       "integrity": "sha512-OkCsBBzrwxX4DoSv4Zlf9DgXKRB0MzVfCFg5MC+fNnf9ktr4SMWjsri0VNZQlDbCnGcImT6KNEv4ZoxktQhdpA==",
       "license": "LGPL-3.0-only",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/uuid": "^8.3.4",
@@ -7413,6 +7961,7 @@
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -7422,6 +7971,8 @@
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
       "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7448,13 +7999,16 @@
         }
       ],
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -7470,6 +8024,8 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7526,7 +8082,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -7538,7 +8096,9 @@
       "version": "0.10.7",
       "resolved": "https://registry.npmjs.org/sha256-uint8array/-/sha256-uint8array-0.10.7.tgz",
       "integrity": "sha512-1Q6JQU4tX9NqsDGodej6pkrUVQVNapLZnvkwIhddH/JqzBZF1fSaxSWNY6sziXBE8aEa2twtGkXUrwzGeZCMpQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7644,13 +8204,17 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
       "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
       "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -7680,6 +8244,8 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -7771,22 +8337,49 @@
       "license": "MIT"
     },
     "node_modules/starkzap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/starkzap/-/starkzap-1.0.0.tgz",
-      "integrity": "sha512-6SrwECz82I9PHJz2X59MMoySikmiq9vlV2iG4xWhtu71iEoJb46TPkfZ4IsGdAi3ab1JVUHC3sCRLRmYJSIRpQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/starkzap/-/starkzap-2.0.0.tgz",
+      "integrity": "sha512-U2REwOLCVUftw8SZZCqR2rxR3v1t+SvXXfWDI2PyU8PpmeN6oSahBqOUTgkNefEo1hXx8ZnU5BIsl7ArntWseg==",
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
-        "@cartridge/controller": "^0.13.9",
+        "@avnu/avnu-sdk": "^4.1.0-rc.0",
         "starknet": "^9.2.1"
       },
       "peerDependencies": {
-        "@cartridge/controller": "^0.13.9"
+        "@cartridge/controller": "^0.13.9",
+        "@fatsolutions/tongo-sdk": "^1.3.2",
+        "@hyperlane-xyz/registry": "^19.4.0",
+        "@hyperlane-xyz/sdk": "^14.4.0",
+        "@hyperlane-xyz/utils": "^14.4.0",
+        "@solana/web3.js": "^1.98.4",
+        "ethers": "^6.16.0"
       },
       "peerDependenciesMeta": {
         "@cartridge/controller": {
           "optional": true
         },
         "@ethersproject/shims": {
+          "optional": true
+        },
+        "@fatsolutions/tongo-sdk": {
+          "optional": true
+        },
+        "@hyperlane-xyz/registry": {
+          "optional": true
+        },
+        "@hyperlane-xyz/sdk": {
+          "optional": true
+        },
+        "@hyperlane-xyz/utils": {
+          "optional": true
+        },
+        "@solana/web3.js": {
+          "optional": true
+        },
+        "ethers": {
           "optional": true
         },
         "fast-text-encoding": {
@@ -7818,7 +8411,8 @@
       "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
       "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
       "license": "BSD-3-Clause",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/stream-json": {
       "version": "1.9.1",
@@ -7826,6 +8420,7 @@
       "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "stream-chain": "^2.2.5"
       }
@@ -7885,6 +8480,7 @@
       "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -7893,7 +8489,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
       "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -7923,6 +8520,8 @@
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
       "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "real-require": "^0.2.0"
       }
@@ -7981,7 +8580,9 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -8010,7 +8611,9 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -8097,6 +8700,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/uint8arrays": {
@@ -8104,6 +8708,8 @@
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
       "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "multiformats": "^9.4.2"
       }
@@ -8112,7 +8718,9 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -8144,6 +8752,8 @@
       "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.4.tgz",
       "integrity": "sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "anymatch": "^3.1.3",
         "chokidar": "^5.0.0",
@@ -8240,6 +8850,8 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -8255,6 +8867,8 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -8270,6 +8884,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -8283,6 +8898,7 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -8292,6 +8908,8 @@
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.7.tgz",
       "integrity": "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "proxy-compare": "^3.0.1"
       },
@@ -8331,6 +8949,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -8354,13 +8974,17 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/viem/node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -8373,6 +8997,8 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
       "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -8388,6 +9014,8 @@
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
       "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -8415,6 +9043,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "^1.11.0",
         "@noble/ciphers": "^1.3.0",
@@ -8439,6 +9069,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -8622,13 +9254,17 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -8653,7 +9289,9 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
@@ -8677,6 +9315,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -8697,6 +9337,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -8718,6 +9360,8 @@
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
       "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "is-wsl": "^3.1.0"
       },
@@ -8732,13 +9376,17 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
       "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -8761,6 +9409,8 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
       "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -8793,6 +9443,7 @@
       "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -17,7 +17,7 @@
     "dev": "tsup src/index.ts --format esm --watch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "check": "npm run typecheck && npm run test",
+    "check": "npm run typecheck && npm run test && npm run build",
     "prepublishOnly": "npm run check && npm pack --dry-run >/dev/null && npm view starkzap@2.0.0 version >/dev/null"
   },
   "dependencies": {

--- a/packages/mcp-server/src/core.ts
+++ b/packages/mcp-server/src/core.ts
@@ -496,6 +496,8 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
             maxItems: 32,
             items: {
               type: "string",
+              minLength: 1,
+              maxLength: 128,
               description:
                 "Token symbol (ETH, STRK, USDC, etc.) or contract address",
             },

--- a/packages/mcp-server/src/core.ts
+++ b/packages/mcp-server/src/core.ts
@@ -321,12 +321,14 @@ const tokenBatchSchema = z
   );
 
 const slippageBpsSchema = z.number().int().min(0).max(9999);
+export const PROVIDER_ID_REGEX = /^[A-Za-z0-9._:-]+$/;
+
 const providerSchema = z
   .string()
   .min(1)
   .max(64)
   .regex(
-    /^[A-Za-z0-9._:-]+$/,
+    PROVIDER_ID_REGEX,
     "Provider id may only contain letters, numbers, dot, underscore, colon, and hyphen"
   );
 

--- a/packages/mcp-server/src/core.ts
+++ b/packages/mcp-server/src/core.ts
@@ -620,10 +620,12 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
         properties: {
           tokenIn: {
             type: "string",
+            maxLength: 128,
             description: "Input token symbol or contract address",
           },
           tokenOut: {
             type: "string",
+            maxLength: 128,
             description: "Output token symbol or contract address",
           },
           amountIn: {
@@ -641,6 +643,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
           provider: {
             type: "string",
             maxLength: 64,
+            pattern: "^[A-Za-z0-9._:-]+$",
             description:
               "Optional swap provider id (defaults to wallet provider, e.g. avnu)",
           },
@@ -665,10 +668,12 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
         properties: {
           tokenIn: {
             type: "string",
+            maxLength: 128,
             description: "Input token symbol or contract address",
           },
           tokenOut: {
             type: "string",
+            maxLength: 128,
             description: "Output token symbol or contract address",
           },
           amountIn: {
@@ -686,6 +691,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
           provider: {
             type: "string",
             maxLength: 64,
+            pattern: "^[A-Za-z0-9._:-]+$",
             description:
               "Optional swap provider id (defaults to wallet provider, e.g. avnu)",
           },
@@ -714,10 +720,12 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
         properties: {
           tokenIn: {
             type: "string",
+            maxLength: 128,
             description: "Input token symbol or contract address",
           },
           tokenOut: {
             type: "string",
+            maxLength: 128,
             description: "Output token symbol or contract address",
           },
           amountIn: {
@@ -735,6 +743,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
           provider: {
             type: "string",
             maxLength: 64,
+            pattern: "^[A-Za-z0-9._:-]+$",
             description:
               "Optional swap provider id (defaults to wallet provider, e.g. avnu)",
           },

--- a/packages/mcp-server/src/core.ts
+++ b/packages/mcp-server/src/core.ts
@@ -283,20 +283,44 @@ export const amountSchema = z
     message: "Amount must be greater than zero",
   });
 
+const tokenIdentifierSchema = z
+  .string()
+  .min(1)
+  .max(128, "Token identifier too long (max 128 chars)");
+
 const tokenBatchSchema = z
-  .array(z.string().min(1))
+  .array(tokenIdentifierSchema)
   .min(1)
   .max(32, "Maximum 32 tokens per balance batch");
 
 const slippageBpsSchema = z.number().int().min(0).max(9999);
+const providerSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(
+    /^[A-Za-z0-9._:-]+$/,
+    "Provider id may only contain letters, numbers, dot, underscore, colon, and hyphen"
+  );
 
-const swapInputSchema = z.object({
-  tokenIn: z.string().min(1),
-  tokenOut: z.string().min(1),
-  amountIn: amountSchema,
-  slippageBps: slippageBpsSchema.optional(),
-  provider: z.string().min(1).max(64).optional(),
-});
+const swapInputBaseSchema = z
+  .object({
+    tokenIn: tokenIdentifierSchema,
+    tokenOut: tokenIdentifierSchema,
+    amountIn: amountSchema,
+    slippageBps: slippageBpsSchema.optional(),
+    provider: providerSchema.optional(),
+  })
+  .strict();
+
+const swapInputSchema = swapInputBaseSchema.refine(
+  (value) =>
+    value.tokenIn.trim().toLowerCase() !== value.tokenOut.trim().toLowerCase(),
+  {
+    message: "tokenIn and tokenOut must be different",
+    path: ["tokenOut"],
+  }
+);
 
 const entrypointSchema = z
   .string()
@@ -326,9 +350,11 @@ export const schemas = {
   starkzap_get_balance: z.object({
     token: z.string().min(1),
   }),
-  starkzap_get_balances: z.object({
-    tokens: tokenBatchSchema,
-  }),
+  starkzap_get_balances: z
+    .object({
+      tokens: tokenBatchSchema,
+    })
+    .strict(),
   starkzap_transfer: z.object({
     token: z.string().min(1),
     transfers: z
@@ -395,9 +421,19 @@ export const schemas = {
       .max(10, "Maximum 10 calls per estimate batch"),
   }),
   starkzap_get_quote: swapInputSchema,
-  starkzap_swap: swapInputSchema.extend({
-    sponsored: z.boolean().optional(),
-  }),
+  starkzap_swap: swapInputBaseSchema
+    .extend({
+      sponsored: z.boolean().optional(),
+    })
+    .refine(
+      (value) =>
+        value.tokenIn.trim().toLowerCase() !==
+        value.tokenOut.trim().toLowerCase(),
+      {
+        message: "tokenIn and tokenOut must be different",
+        path: ["tokenOut"],
+      }
+    ),
   starkzap_build_swap_calls: swapInputSchema,
 } as const;
 
@@ -452,6 +488,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
       },
       inputSchema: {
         type: "object" as const,
+        additionalProperties: false,
         properties: {
           tokens: {
             type: "array",
@@ -579,6 +616,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
       },
       inputSchema: {
         type: "object" as const,
+        additionalProperties: false,
         properties: {
           tokenIn: {
             type: "string",
@@ -623,6 +661,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
       },
       inputSchema: {
         type: "object" as const,
+        additionalProperties: false,
         properties: {
           tokenIn: {
             type: "string",
@@ -671,6 +710,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
       },
       inputSchema: {
         type: "object" as const,
+        additionalProperties: false,
         properties: {
           tokenIn: {
             type: "string",
@@ -1004,14 +1044,28 @@ function getArrayBounds(
   };
 }
 
+function getObjectSchema(type: z.ZodTypeAny): z.AnyZodObject | null {
+  const unwrapped = unwrapZodType(type);
+  if (unwrapped instanceof z.ZodObject) {
+    return unwrapped;
+  }
+  return null;
+}
+
 export function schemaParityMismatches(tools: readonly Tool[]): string[] {
   const mismatches: string[] = [];
   const schemaEntries = Object.entries(schemas) as Array<
-    [keyof typeof schemas, z.AnyZodObject]
+    [keyof typeof schemas, z.ZodTypeAny]
   >;
   const toolByName = new Map(tools.map((tool) => [tool.name, tool]));
 
-  for (const [name, schema] of schemaEntries) {
+  for (const [name, rawSchema] of schemaEntries) {
+    const schema = getObjectSchema(rawSchema);
+    if (!schema) {
+      mismatches.push(`Schema "${name}" is not an object schema`);
+      continue;
+    }
+
     const tool = toolByName.get(name);
     if (!tool) {
       mismatches.push(`Missing tool definition for schema "${name}"`);

--- a/packages/mcp-server/src/core.ts
+++ b/packages/mcp-server/src/core.ts
@@ -283,6 +283,21 @@ export const amountSchema = z
     message: "Amount must be greater than zero",
   });
 
+const tokenBatchSchema = z
+  .array(z.string().min(1))
+  .min(1)
+  .max(32, "Maximum 32 tokens per balance batch");
+
+const slippageBpsSchema = z.number().int().min(0).max(9999);
+
+const swapInputSchema = z.object({
+  tokenIn: z.string().min(1),
+  tokenOut: z.string().min(1),
+  amountIn: amountSchema,
+  slippageBps: slippageBpsSchema.optional(),
+  provider: z.string().min(1).max(64).optional(),
+});
+
 const entrypointSchema = z
   .string()
   .max(64, "Entrypoint name too long (max 64 chars)")
@@ -310,6 +325,9 @@ export const schemas = {
   starkzap_get_account: z.object({}),
   starkzap_get_balance: z.object({
     token: z.string().min(1),
+  }),
+  starkzap_get_balances: z.object({
+    tokens: tokenBatchSchema,
   }),
   starkzap_transfer: z.object({
     token: z.string().min(1),
@@ -376,6 +394,11 @@ export const schemas = {
       .min(1)
       .max(10, "Maximum 10 calls per estimate batch"),
   }),
+  starkzap_get_quote: swapInputSchema,
+  starkzap_swap: swapInputSchema.extend({
+    sponsored: z.boolean().optional(),
+  }),
+  starkzap_build_swap_calls: swapInputSchema,
 } as const;
 
 export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
@@ -415,6 +438,34 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
           },
         },
         required: ["token"],
+      },
+    },
+    {
+      name: "starkzap_get_balances",
+      description:
+        "Get ERC20 balances for multiple tokens in one tool call. Returns human-readable and raw values for each token.",
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          tokens: {
+            type: "array",
+            minItems: 1,
+            maxItems: 32,
+            items: {
+              type: "string",
+              description:
+                "Token symbol (ETH, STRK, USDC, etc.) or contract address",
+            },
+            description: "One or more token symbols/addresses (max 32)",
+          },
+        },
+        required: ["tokens"],
       },
     },
     {
@@ -513,6 +564,142 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
           },
         },
         required: ["calls"],
+      },
+    },
+    {
+      name: "starkzap_get_quote",
+      description:
+        `Get a swap quote for tokenIn -> tokenOut via the wallet's configured swap provider. ` +
+        `Maximum ${maxAmount} tokens for amountIn per operation.`,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          tokenIn: {
+            type: "string",
+            description: "Input token symbol or contract address",
+          },
+          tokenOut: {
+            type: "string",
+            description: "Output token symbol or contract address",
+          },
+          amountIn: {
+            type: "string",
+            maxLength: 32,
+            pattern: "^\\d+(\\.\\d+)?$",
+            description: 'Human-readable amount in tokenIn units (e.g. "10.5")',
+          },
+          slippageBps: {
+            type: "number",
+            minimum: 0,
+            maximum: 9999,
+            description: "Optional slippage tolerance in basis points (0-9999)",
+          },
+          provider: {
+            type: "string",
+            maxLength: 64,
+            description:
+              "Optional swap provider id (defaults to wallet provider, e.g. avnu)",
+          },
+        },
+        required: ["tokenIn", "tokenOut", "amountIn"],
+      },
+    },
+    {
+      name: "starkzap_swap",
+      description:
+        `Execute a token swap via the wallet's configured swap provider. ` +
+        `Maximum ${maxAmount} tokens for amountIn per operation.`,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          tokenIn: {
+            type: "string",
+            description: "Input token symbol or contract address",
+          },
+          tokenOut: {
+            type: "string",
+            description: "Output token symbol or contract address",
+          },
+          amountIn: {
+            type: "string",
+            maxLength: 32,
+            pattern: "^\\d+(\\.\\d+)?$",
+            description: 'Human-readable amount in tokenIn units (e.g. "10.5")',
+          },
+          slippageBps: {
+            type: "number",
+            minimum: 0,
+            maximum: 9999,
+            description: "Optional slippage tolerance in basis points (0-9999)",
+          },
+          provider: {
+            type: "string",
+            maxLength: 64,
+            description:
+              "Optional swap provider id (defaults to wallet provider, e.g. avnu)",
+          },
+          sponsored: {
+            type: "boolean",
+            description: "Use paymaster for gasless tx (default: false)",
+          },
+        },
+        required: ["tokenIn", "tokenOut", "amountIn"],
+      },
+    },
+    {
+      name: "starkzap_build_swap_calls",
+      description:
+        `Build unsigned swap calls (approval + route) without executing. ` +
+        `Maximum ${maxAmount} tokens for amountIn per operation.`,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          tokenIn: {
+            type: "string",
+            description: "Input token symbol or contract address",
+          },
+          tokenOut: {
+            type: "string",
+            description: "Output token symbol or contract address",
+          },
+          amountIn: {
+            type: "string",
+            maxLength: 32,
+            pattern: "^\\d+(\\.\\d+)?$",
+            description: 'Human-readable amount in tokenIn units (e.g. "10.5")',
+          },
+          slippageBps: {
+            type: "number",
+            minimum: 0,
+            maximum: 9999,
+            description: "Optional slippage tolerance in basis points (0-9999)",
+          },
+          provider: {
+            type: "string",
+            maxLength: 64,
+            description:
+              "Optional swap provider id (defaults to wallet provider, e.g. avnu)",
+          },
+        },
+        required: ["tokenIn", "tokenOut", "amountIn"],
       },
     },
     {
@@ -740,6 +927,9 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
 export const READ_ONLY_TOOLS = new Set([
   "starkzap_get_account",
   "starkzap_get_balance",
+  "starkzap_get_balances",
+  "starkzap_get_quote",
+  "starkzap_build_swap_calls",
   "starkzap_get_pool_position",
   "starkzap_estimate_fee",
 ]);

--- a/packages/mcp-server/src/core.ts
+++ b/packages/mcp-server/src/core.ts
@@ -292,7 +292,13 @@ const tokenIdentifierSchema = z
 const tokenBatchSchema = z
   .array(tokenIdentifierSchema)
   .min(1)
-  .max(32, "Maximum 32 tokens per balance batch");
+  .max(32, "Maximum 32 tokens per balance batch")
+  .refine(
+    (tokens) =>
+      new Set(tokens.map((token) => token.toLowerCase())).size ===
+      tokens.length,
+    { message: "Duplicate tokens are not allowed" }
+  );
 
 const slippageBpsSchema = z.number().int().min(0).max(9999);
 const providerSchema = z
@@ -495,6 +501,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
             type: "array",
             minItems: 1,
             maxItems: 32,
+            uniqueItems: true,
             items: {
               type: "string",
               minLength: 1,

--- a/packages/mcp-server/src/core.ts
+++ b/packages/mcp-server/src/core.ts
@@ -468,7 +468,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
-        idempotentHint: true,
+        idempotentHint: false,
         openWorldHint: true,
       },
       inputSchema: {
@@ -490,7 +490,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
-        idempotentHint: true,
+        idempotentHint: false,
         openWorldHint: true,
       },
       inputSchema: {
@@ -730,7 +730,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
-        idempotentHint: true,
+        idempotentHint: false,
         openWorldHint: true,
       },
       inputSchema: {

--- a/packages/mcp-server/src/core.ts
+++ b/packages/mcp-server/src/core.ts
@@ -446,7 +446,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
-        idempotentHint: true,
+        idempotentHint: false,
         openWorldHint: true,
       },
       inputSchema: {

--- a/packages/mcp-server/src/core.ts
+++ b/packages/mcp-server/src/core.ts
@@ -285,7 +285,8 @@ export const amountSchema = z
 
 const tokenIdentifierSchema = z
   .string()
-  .min(1)
+  .trim()
+  .min(1, "Token identifier cannot be empty")
   .max(128, "Token identifier too long (max 128 chars)");
 
 const tokenBatchSchema = z
@@ -498,6 +499,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
               type: "string",
               minLength: 1,
               maxLength: 128,
+              pattern: ".*\\S.*",
               description:
                 "Token symbol (ETH, STRK, USDC, etc.) or contract address",
             },
@@ -622,12 +624,16 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
         properties: {
           tokenIn: {
             type: "string",
+            minLength: 1,
             maxLength: 128,
+            pattern: ".*\\S.*",
             description: "Input token symbol or contract address",
           },
           tokenOut: {
             type: "string",
+            minLength: 1,
             maxLength: 128,
+            pattern: ".*\\S.*",
             description: "Output token symbol or contract address",
           },
           amountIn: {
@@ -670,12 +676,16 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
         properties: {
           tokenIn: {
             type: "string",
+            minLength: 1,
             maxLength: 128,
+            pattern: ".*\\S.*",
             description: "Input token symbol or contract address",
           },
           tokenOut: {
             type: "string",
+            minLength: 1,
             maxLength: 128,
+            pattern: ".*\\S.*",
             description: "Output token symbol or contract address",
           },
           amountIn: {
@@ -722,12 +732,16 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
         properties: {
           tokenIn: {
             type: "string",
+            minLength: 1,
             maxLength: 128,
+            pattern: ".*\\S.*",
             description: "Input token symbol or contract address",
           },
           tokenOut: {
             type: "string",
+            minLength: 1,
             maxLength: 128,
+            pattern: ".*\\S.*",
             description: "Output token symbol or contract address",
           },
           amountIn: {

--- a/packages/mcp-server/src/core.ts
+++ b/packages/mcp-server/src/core.ts
@@ -6,6 +6,9 @@ import { z } from "zod";
 export const FELT_REGEX = /^0x[0-9a-fA-F]{1,64}$/;
 export const VALID_NETWORKS = ["mainnet", "sepolia"] as const;
 export type Network = (typeof VALID_NETWORKS)[number];
+const STARK_CURVE_ORDER = BigInt(
+  "0x0800000000000011000000000000000000000000000000000000000000000001"
+);
 
 export interface CliConfig {
   network: Network;
@@ -26,6 +29,23 @@ const tokensByNetwork: Record<Network, Record<string, Token>> = {
 export function normalizeStarknetAddress(address: string): string {
   return fromAddress(address).toLowerCase();
 }
+
+export function normalizePrivateKeyHex(value: string): string {
+  const hex = value.slice(2);
+  return `0x${hex.padStart(64, "0")}`;
+}
+
+export const privateKeySchema = z
+  .string()
+  .regex(
+    /^0x[0-9a-fA-F]{1,64}$/,
+    "Must be a 0x-prefixed hex private key (1-64 hex chars)"
+  )
+  .transform(normalizePrivateKeyHex)
+  .refine((value) => {
+    const key = BigInt(value);
+    return key !== 0n && key < STARK_CURVE_ORDER;
+  }, "Private key must be cryptographically valid (non-zero and less than Stark curve order)");
 
 function getReferenceToken(network: Network): Token {
   const tokens = tokensByNetwork[network];

--- a/packages/mcp-server/src/core.ts
+++ b/packages/mcp-server/src/core.ts
@@ -342,14 +342,30 @@ const swapInputBaseSchema = z
   })
   .strict();
 
+function hasDistinctSwapTokenInputs(value: {
+  tokenIn: string;
+  tokenOut: string;
+}): boolean {
+  return (
+    value.tokenIn.trim().toLowerCase() !== value.tokenOut.trim().toLowerCase()
+  );
+}
+
+const distinctSwapTokenInputIssue = {
+  message: "tokenIn and tokenOut must be different",
+  path: ["tokenOut"],
+};
+
 const swapInputSchema = swapInputBaseSchema.refine(
-  (value) =>
-    value.tokenIn.trim().toLowerCase() !== value.tokenOut.trim().toLowerCase(),
-  {
-    message: "tokenIn and tokenOut must be different",
-    path: ["tokenOut"],
-  }
+  hasDistinctSwapTokenInputs,
+  distinctSwapTokenInputIssue
 );
+
+const swapExecutionInputSchema = swapInputBaseSchema
+  .extend({
+    sponsored: z.boolean().optional(),
+  })
+  .refine(hasDistinctSwapTokenInputs, distinctSwapTokenInputIssue);
 
 const entrypointSchema = z
   .string()
@@ -450,19 +466,7 @@ export const schemas = {
       .max(10, "Maximum 10 calls per estimate batch"),
   }),
   starkzap_get_quote: swapInputSchema,
-  starkzap_swap: swapInputBaseSchema
-    .extend({
-      sponsored: z.boolean().optional(),
-    })
-    .refine(
-      (value) =>
-        value.tokenIn.trim().toLowerCase() !==
-        value.tokenOut.trim().toLowerCase(),
-      {
-        message: "tokenIn and tokenOut must be different",
-        path: ["tokenOut"],
-      }
-    ),
+  starkzap_swap: swapExecutionInputSchema,
   starkzap_build_swap_calls: swapInputSchema,
 } as const;
 
@@ -553,6 +557,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
       },
       inputSchema: {
         type: "object" as const,
+        additionalProperties: false,
         properties: {
           token: {
             type: "string",
@@ -564,6 +569,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
             maxItems: 20,
             items: {
               type: "object",
+              additionalProperties: false,
               properties: {
                 to: {
                   type: "string",
@@ -600,6 +606,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
       },
       inputSchema: {
         type: "object" as const,
+        additionalProperties: false,
         properties: {
           calls: {
             type: "array",
@@ -607,6 +614,7 @@ export function buildTools(maxAmount: string, maxBatchAmount: string): Tool[] {
             maxItems: 10,
             items: {
               type: "object",
+              additionalProperties: false,
               properties: {
                 contractAddress: {
                   type: "string",

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -537,6 +537,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+const FELT252_UPPER_BOUND = BigInt(
+  "0x800000000000011000000000000000000000000000000000000000000000001"
+);
+
 type AmountMethod =
   | "toUnit"
   | "toFormatted"
@@ -692,9 +696,15 @@ function normalizeCallCalldataForResponse(
 ): string[] {
   const MAX_CALLDATA_ITEMS = 2048;
   const MAX_CALLDATA_ITEM_CHARS = 256;
-  const MAX_FELT_HEX_CHARS = 64;
   const CALLDATA_DECIMAL_REGEX = /^\d+$/;
   const CALLDATA_HEX_REGEX = /^0x[0-9a-fA-F]{1,64}$/;
+  const assertFelt252Value = (value: bigint, index: number): void => {
+    if (value >= FELT252_UPPER_BOUND) {
+      throw new Error(
+        `Invalid ${label} returned by SDK: calldata_${index} exceeds felt range.`
+      );
+    }
+  };
 
   if (!Array.isArray(calldata)) {
     throw new Error(
@@ -713,13 +723,8 @@ function normalizeCallCalldataForResponse(
           `Invalid ${label} returned by SDK: calldata_${index} must be non-negative.`
         );
       }
-      const hexValue = item.toString(16);
-      if (hexValue.length > MAX_FELT_HEX_CHARS) {
-        throw new Error(
-          `Invalid ${label} returned by SDK: calldata_${index} exceeds felt range.`
-        );
-      }
-      return `0x${hexValue}`;
+      assertFelt252Value(item, index);
+      return `0x${item.toString(16)}`;
     }
     if (typeof item === "number") {
       if (!Number.isSafeInteger(item) || item < 0) {
@@ -727,6 +732,7 @@ function normalizeCallCalldataForResponse(
           `Invalid ${label} returned by SDK: calldata_${index} must be a non-negative safe integer.`
         );
       }
+      assertFelt252Value(BigInt(item), index);
       return item.toString(10);
     }
     if (typeof item === "string") {
@@ -738,14 +744,11 @@ function normalizeCallCalldataForResponse(
       }
       if (CALLDATA_DECIMAL_REGEX.test(trimmed)) {
         const decimalValue = BigInt(trimmed);
-        if (decimalValue.toString(16).length > MAX_FELT_HEX_CHARS) {
-          throw new Error(
-            `Invalid ${label} returned by SDK: calldata_${index} exceeds felt range.`
-          );
-        }
+        assertFelt252Value(decimalValue, index);
         return trimmed;
       }
       if (CALLDATA_HEX_REGEX.test(trimmed)) {
+        assertFelt252Value(BigInt(trimmed), index);
         return trimmed;
       }
       throw new Error(
@@ -1492,6 +1495,8 @@ function buildToolErrorText(error: unknown): string {
     "Sponsored ",
     "Transaction ",
     "Address ",
+    "Swap ",
+    "Build swap calls:",
     "starkzap_",
   ];
   const hasSafePrefix = safeMessagePrefixes.some((prefix) =>
@@ -1782,6 +1787,19 @@ async function handleTool(
       assertDistinctSwapTokens(tokenIn, tokenOut, "Swap execution");
       const amountIn = parseAmountWithContext(parsed.amountIn, tokenIn, "swap");
       assertAmountWithinCap(amountIn, tokenIn, maxAmount);
+      const quote = await withTimeout("Swap quote precheck", () =>
+        wallet.getQuote({
+          tokenIn,
+          tokenOut,
+          amountIn,
+          ...(parsed.slippageBps !== undefined && {
+            slippageBps: BigInt(parsed.slippageBps),
+          }),
+          ...(parsed.provider !== undefined && { provider: parsed.provider }),
+        })
+      );
+      assertSwapQuoteShape(quote);
+      const quotedOutAmount = Amount.fromRaw(quote.amountOutBase, tokenOut);
       const feeMode: "sponsored" | undefined = parsed.sponsored
         ? "sponsored"
         : undefined;
@@ -1817,6 +1835,19 @@ async function handleTool(
         tokenOutAddress: tokenOut.address,
         amountIn: amountIn.toUnit(),
         amountInRaw: amountIn.toBase().toString(),
+        amountOut: quotedOutAmount.toUnit(),
+        amountOutRaw: quote.amountOutBase.toString(),
+        amountOutSource: "pretrade_quote",
+        ...(quote.routeCallCount !== undefined && {
+          routeCallCount: quote.routeCallCount,
+        }),
+        ...(quote.priceImpactBps !== undefined && {
+          priceImpactBps:
+            quote.priceImpactBps === null
+              ? null
+              : quote.priceImpactBps.toString(),
+        }),
+        ...(quote.provider !== undefined && { provider: quote.provider }),
       });
     }
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -488,10 +488,17 @@ function withTransactionReference(
   error: unknown,
   txResult: { hash: string; explorerUrl?: string }
 ): Error {
-  const reason = error instanceof Error ? error.message : String(error);
-  return new Error(
+  const reason =
+    error instanceof Error
+      ? error.message
+      : isRecord(error) && typeof error.message === "string"
+        ? error.message
+        : summarizeError(error);
+  const wrapped = new Error(
     `${reason} Transaction hash: ${txResult.hash}. Reconcile on-chain state before retrying.`
   );
+  (wrapped as Error & { cause?: unknown }).cause = error;
+  return wrapped;
 }
 
 async function assertWalletAccountClassHashAfterSubmission(

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -608,6 +608,7 @@ function assertSwapQuoteShape(quote: unknown): asserts quote is {
   priceImpactBps?: bigint | null;
   provider?: string;
 } {
+  const PROVIDER_ID_REGEX = /^[A-Za-z0-9._:-]+$/;
   if (!isRecord(quote)) {
     throw new Error(
       "Invalid swap quote returned by SDK: expected object shape."
@@ -644,9 +645,15 @@ function assertSwapQuoteShape(quote: unknown): asserts quote is {
       "Invalid swap quote returned by SDK: priceImpactBps must be bigint or null."
     );
   }
-  if (quote.provider !== undefined && typeof quote.provider !== "string") {
+  if (
+    quote.provider !== undefined &&
+    (typeof quote.provider !== "string" ||
+      quote.provider.length === 0 ||
+      quote.provider.length > 64 ||
+      !PROVIDER_ID_REGEX.test(quote.provider))
+  ) {
     throw new Error(
-      "Invalid swap quote returned by SDK: provider must be a string."
+      "Invalid swap quote returned by SDK: provider must be a safe provider id."
     );
   }
 }
@@ -674,7 +681,7 @@ function normalizeCallCalldataForResponse(
     if (typeof item === "bigint") {
       if (item < 0n) {
         throw new Error(
-          `Invalid ${label} returned by SDK: calldata[${index}] must be non-negative.`
+          `Invalid ${label} returned by SDK: calldata_${index} must be non-negative.`
         );
       }
       return `0x${item.toString(16)}`;
@@ -682,7 +689,7 @@ function normalizeCallCalldataForResponse(
     if (typeof item === "number") {
       if (!Number.isSafeInteger(item) || item < 0) {
         throw new Error(
-          `Invalid ${label} returned by SDK: calldata[${index}] must be a non-negative safe integer.`
+          `Invalid ${label} returned by SDK: calldata_${index} must be a non-negative safe integer.`
         );
       }
       return item.toString(10);
@@ -691,7 +698,7 @@ function normalizeCallCalldataForResponse(
       const trimmed = item.trim();
       if (!trimmed || trimmed.length > MAX_CALLDATA_ITEM_CHARS) {
         throw new Error(
-          `Invalid ${label} returned by SDK: calldata[${index}] must be a felt-like hex or decimal string.`
+          `Invalid ${label} returned by SDK: calldata_${index} must be a felt-like hex or decimal string.`
         );
       }
       if (CALLDATA_DECIMAL_REGEX.test(trimmed)) {
@@ -701,11 +708,11 @@ function normalizeCallCalldataForResponse(
         return trimmed;
       }
       throw new Error(
-        `Invalid ${label} returned by SDK: calldata[${index}] must be a felt-like hex or decimal string.`
+        `Invalid ${label} returned by SDK: calldata_${index} must be a felt-like hex or decimal string.`
       );
     }
     throw new Error(
-      `Invalid ${label} returned by SDK: calldata[${index}] has unsupported type.`
+      `Invalid ${label} returned by SDK: calldata_${index} has unsupported type.`
     );
   });
 }
@@ -714,6 +721,7 @@ function normalizeCallForResponse(
   call: unknown,
   label: string
 ): { contractAddress: Address; entrypoint: string; calldata: string[] } {
+  const ENTRYPOINT_IDENTIFIER_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
   if (!isRecord(call)) {
     throw new Error(
       `Invalid ${label} returned by SDK: call must be an object.`
@@ -728,17 +736,20 @@ function normalizeCallForResponse(
     call.contractAddress,
     "contract"
   );
+  const entrypoint =
+    typeof call.entrypoint === "string" ? call.entrypoint.trim() : "";
   if (
-    typeof call.entrypoint !== "string" ||
-    call.entrypoint.trim().length === 0
+    entrypoint.length === 0 ||
+    entrypoint.length > 64 ||
+    !ENTRYPOINT_IDENTIFIER_REGEX.test(entrypoint)
   ) {
     throw new Error(
-      `Invalid ${label} returned by SDK: entrypoint must be a non-empty string.`
+      `Invalid ${label} returned by SDK: entrypoint must be a valid Cairo identifier.`
     );
   }
   return {
     contractAddress,
-    entrypoint: call.entrypoint.trim(),
+    entrypoint,
     calldata: normalizeCallCalldataForResponse(call.calldata ?? [], label),
   };
 }
@@ -1761,7 +1772,7 @@ async function handleTool(
         "build_swap_calls"
       );
       assertAmountWithinCap(amountIn, tokenIn, maxAmount);
-      const calls = await withTimeout("Swap call build", async () =>
+      const rawCalls = await withTimeout("Swap call build", async () =>
         wallet
           .tx()
           .swap({
@@ -1775,8 +1786,17 @@ async function handleTool(
           })
           .calls()
       );
-      const formattedCalls = calls.map((call, index) =>
-        normalizeCallForResponse(call, `swap call[${index}]`)
+      if (
+        !Array.isArray(rawCalls) ||
+        rawCalls.length === 0 ||
+        rawCalls.length > 10
+      ) {
+        throw new Error(
+          "Invalid swap calls returned by SDK: expected 1-10 calls."
+        );
+      }
+      const formattedCalls = rawCalls.map((call, index) =>
+        normalizeCallForResponse(call, `swap_call_${index}`)
       );
       return ok({
         tokenIn: sanitizeTokenSymbol(tokenIn.symbol),

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -655,9 +655,19 @@ function normalizeCallCalldataForResponse(
   calldata: unknown,
   label: string
 ): string[] {
+  const MAX_CALLDATA_ITEMS = 2048;
+  const MAX_CALLDATA_ITEM_CHARS = 256;
+  const CALLDATA_DECIMAL_REGEX = /^\d+$/;
+  const CALLDATA_HEX_REGEX = /^0x[0-9a-fA-F]{1,64}$/;
+
   if (!Array.isArray(calldata)) {
     throw new Error(
       `Invalid ${label} returned by SDK: calldata must be an array.`
+    );
+  }
+  if (calldata.length > MAX_CALLDATA_ITEMS) {
+    throw new Error(
+      `Invalid ${label} returned by SDK: calldata exceeds ${MAX_CALLDATA_ITEMS} items.`
     );
   }
   return calldata.map((item, index) => {
@@ -670,21 +680,29 @@ function normalizeCallCalldataForResponse(
       return `0x${item.toString(16)}`;
     }
     if (typeof item === "number") {
-      if (!Number.isInteger(item) || item < 0) {
+      if (!Number.isSafeInteger(item) || item < 0) {
         throw new Error(
-          `Invalid ${label} returned by SDK: calldata[${index}] must be a non-negative integer.`
+          `Invalid ${label} returned by SDK: calldata[${index}] must be a non-negative safe integer.`
         );
       }
       return item.toString(10);
     }
     if (typeof item === "string") {
       const trimmed = item.trim();
-      if (!trimmed) {
+      if (!trimmed || trimmed.length > MAX_CALLDATA_ITEM_CHARS) {
         throw new Error(
-          `Invalid ${label} returned by SDK: calldata[${index}] must be non-empty.`
+          `Invalid ${label} returned by SDK: calldata[${index}] must be a felt-like hex or decimal string.`
         );
       }
-      return trimmed;
+      if (CALLDATA_DECIMAL_REGEX.test(trimmed)) {
+        return trimmed;
+      }
+      if (CALLDATA_HEX_REGEX.test(trimmed)) {
+        return trimmed;
+      }
+      throw new Error(
+        `Invalid ${label} returned by SDK: calldata[${index}] must be a felt-like hex or decimal string.`
+      );
     }
     throw new Error(
       `Invalid ${label} returned by SDK: calldata[${index}] has unsupported type.`

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -477,26 +477,65 @@ async function assertWalletAccountClassHash(
   wallet: Wallet,
   context: string
 ): Promise<void> {
-  const provider = wallet.getProvider();
-  let deployedClassHash: string;
+  const deploymentStatus = await getWalletDeploymentStatus(
+    wallet,
+    "Wallet account class-hash verification"
+  );
+  if (!deploymentStatus.deployed) {
+    throw new Error(
+      `${context} succeeded but wallet account is still not deployed on-chain.`
+    );
+  }
+  const expectedClassHash = fromAddress(wallet.getClassHash());
+  if (deploymentStatus.deployedClassHash !== expectedClassHash) {
+    throw new Error(
+      `${context} detected account class hash mismatch at ${wallet.address}. expected=${expectedClassHash} actual=${deploymentStatus.deployedClassHash}`
+    );
+  }
+}
+
+type WalletDeploymentStatus =
+  | { deployed: false }
+  | { deployed: true; deployedClassHash: string };
+
+async function getWalletDeploymentStatus(
+  wallet: Wallet,
+  timeoutLabel: string
+): Promise<WalletDeploymentStatus> {
   try {
-    deployedClassHash = fromAddress(
-      await withTimeout("Wallet account class-hash verification", () =>
-        provider.getClassHashAt(wallet.address)
+    const deployedClassHash = fromAddress(
+      await withTimeout(timeoutLabel, () =>
+        wallet.getProvider().getClassHashAt(wallet.address)
       )
     );
+    return {
+      deployed: true,
+      deployedClassHash,
+    };
   } catch (error) {
     if (isClassHashNotFoundError(error)) {
-      throw new Error(
-        `${context} succeeded but wallet account is still not deployed on-chain.`
-      );
+      return { deployed: false };
     }
     throw error;
   }
+}
+
+async function assertWalletAccountClassHashIfDeployed(
+  wallet: Wallet,
+  context: string
+): Promise<void> {
+  const deploymentStatus = await getWalletDeploymentStatus(
+    wallet,
+    `${context} deployment check`
+  );
+  if (!deploymentStatus.deployed) {
+    return;
+  }
+
   const expectedClassHash = fromAddress(wallet.getClassHash());
-  if (deployedClassHash !== expectedClassHash) {
+  if (deploymentStatus.deployedClassHash !== expectedClassHash) {
     throw new Error(
-      `${context} detected account class hash mismatch at ${wallet.address}. expected=${expectedClassHash} actual=${deployedClassHash}`
+      `${context} detected account class hash mismatch at ${wallet.address}. expected=${expectedClassHash} actual=${deploymentStatus.deployedClassHash}`
     );
   }
 }
@@ -1720,11 +1759,9 @@ async function handleTool(
         maxBatchAmount
       );
 
-      const feeMode = parsed.sponsored
-        ? ({ type: "paymaster" } as const)
-        : undefined;
-      if (feeMode === "sponsored") {
-        await assertWalletAccountClassHash(
+      const feeMode = parsed.sponsored ? "sponsored" : undefined;
+      if (parsed.sponsored) {
+        await assertWalletAccountClassHashIfDeployed(
           wallet,
           "Sponsored transfer preflight"
         );
@@ -1764,11 +1801,9 @@ async function handleTool(
         entrypoint: call.entrypoint,
         calldata: call.calldata ?? [],
       }));
-      const feeMode = parsed.sponsored
-        ? ({ type: "paymaster" } as const)
-        : undefined;
-      if (feeMode === "sponsored") {
-        await assertWalletAccountClassHash(
+      const feeMode = parsed.sponsored ? "sponsored" : undefined;
+      if (parsed.sponsored) {
+        await assertWalletAccountClassHashIfDeployed(
           wallet,
           "Sponsored execute preflight"
         );
@@ -1815,8 +1850,11 @@ async function handleTool(
       const feeMode: "sponsored" | undefined = parsed.sponsored
         ? "sponsored"
         : undefined;
-      if (feeMode === "sponsored") {
-        await assertWalletAccountClassHash(wallet, "Sponsored swap preflight");
+      if (parsed.sponsored) {
+        await assertWalletAccountClassHashIfDeployed(
+          wallet,
+          "Sponsored swap preflight"
+        );
       }
       const tx = await withTimeout("Swap transaction submission", () =>
         wallet.swap(
@@ -1961,9 +1999,7 @@ async function handleTool(
           address: wallet.address,
         });
       }
-      const feeMode = parsed.sponsored
-        ? ({ type: "paymaster" } as const)
-        : undefined;
+      const feeMode = parsed.sponsored ? "sponsored" : undefined;
       const tx = await withTimeout("Account deployment submission", () =>
         wallet.deploy({
           ...(feeMode && { feeMode }),

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -595,6 +595,30 @@ function assertDistinctSwapTokens(
   }
 }
 
+async function mapWithConcurrencyLimit<T, R>(
+  items: readonly T[],
+  limit: number,
+  mapper: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error(`Invalid concurrency limit: ${limit}`);
+  }
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (nextIndex < items.length) {
+        const currentIndex = nextIndex;
+        nextIndex += 1;
+        results[currentIndex] = await mapper(items[currentIndex], currentIndex);
+      }
+    }
+  );
+  await Promise.all(workers);
+  return results;
+}
+
 function assertOverallFeeIsBigInt(fee: unknown): asserts fee is {
   overall_fee: bigint;
 } {
@@ -1576,8 +1600,10 @@ async function handleTool(
       const resolvedTokens = parsed.tokens.map((tokenInput) =>
         resolveToken(tokenInput)
       );
-      const balances = await Promise.all(
-        resolvedTokens.map(async (token) => {
+      const balances = await mapWithConcurrencyLimit(
+        resolvedTokens,
+        8,
+        async (token) => {
           const balance = await withTimeout(
             `Token balance query (${token.symbol})`,
             () => wallet.balanceOf(token)
@@ -1596,7 +1622,7 @@ async function handleTool(
             raw: balance.toBase().toString(),
             decimals: balance.getDecimals(),
           };
-        })
+        }
       );
       return ok({
         balances,

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -130,6 +130,7 @@ function isSecureRpcUrl(rawUrl: string): boolean {
 
 const envSchema = z.object({
   STARKNET_PRIVATE_KEY: privateKeySchema,
+  STARKNET_ACCOUNT_ADDRESS: contractAddressSchema.optional(),
   STARKNET_RPC_URL: z
     .string()
     .url()
@@ -431,6 +432,9 @@ async function getWallet(): Promise<Wallet> {
         account: {
           signer: new StarkSigner(env.STARKNET_PRIVATE_KEY),
         },
+        ...(env.STARKNET_ACCOUNT_ADDRESS && {
+          accountAddress: env.STARKNET_ACCOUNT_ADDRESS,
+        }),
       })
     )
       .then((wallet) => {
@@ -1461,6 +1465,7 @@ function buildToolErrorText(error: unknown): string {
     "Total ",
     "Could ",
     "Rate ",
+    "Sponsored ",
     "Transaction ",
     "Address ",
     "starkzap_",
@@ -1675,6 +1680,12 @@ async function handleTool(
       const feeMode = parsed.sponsored
         ? ({ type: "paymaster" } as const)
         : undefined;
+      if (feeMode === "sponsored") {
+        await assertWalletAccountClassHash(
+          wallet,
+          "Sponsored transfer preflight"
+        );
+      }
       const tx = await withTimeout("Token transfer submission", () =>
         wallet.transfer(token, transfers, {
           ...(feeMode && { feeMode }),
@@ -1713,6 +1724,12 @@ async function handleTool(
       const feeMode = parsed.sponsored
         ? ({ type: "paymaster" } as const)
         : undefined;
+      if (feeMode === "sponsored") {
+        await assertWalletAccountClassHash(
+          wallet,
+          "Sponsored execute preflight"
+        );
+      }
       const tx = await withTimeout("Contract execution submission", () =>
         wallet.execute(calls, {
           ...(feeMode && { feeMode }),
@@ -1742,6 +1759,9 @@ async function handleTool(
       const feeMode: "sponsored" | undefined = parsed.sponsored
         ? "sponsored"
         : undefined;
+      if (feeMode === "sponsored") {
+        await assertWalletAccountClassHash(wallet, "Sponsored swap preflight");
+      }
       const tx = await withTimeout("Swap transaction submission", () =>
         wallet.swap(
           {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -81,9 +81,18 @@ const {
 // ---------------------------------------------------------------------------
 // Environment
 // ---------------------------------------------------------------------------
+function normalizePrivateKeyHex(value: string): string {
+  const hex = value.slice(2);
+  return `0x${hex.padStart(64, "0")}`;
+}
+
 const privateKeySchema = z
   .string()
-  .regex(/^0x[0-9a-fA-F]{64}$/, "Must be a 0x-prefixed 32-byte hex private key")
+  .regex(
+    /^0x[0-9a-fA-F]{1,64}$/,
+    "Must be a 0x-prefixed hex private key (1-64 hex chars)"
+  )
+  .transform(normalizePrivateKeyHex)
   .refine((value) => {
     const key = BigInt(value);
     return key !== 0n && key < STARK_CURVE_ORDER;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -664,6 +664,7 @@ function normalizeCallCalldataForResponse(
 ): string[] {
   const MAX_CALLDATA_ITEMS = 2048;
   const MAX_CALLDATA_ITEM_CHARS = 256;
+  const MAX_FELT_HEX_CHARS = 64;
   const CALLDATA_DECIMAL_REGEX = /^\d+$/;
   const CALLDATA_HEX_REGEX = /^0x[0-9a-fA-F]{1,64}$/;
 
@@ -684,7 +685,13 @@ function normalizeCallCalldataForResponse(
           `Invalid ${label} returned by SDK: calldata_${index} must be non-negative.`
         );
       }
-      return `0x${item.toString(16)}`;
+      const hexValue = item.toString(16);
+      if (hexValue.length > MAX_FELT_HEX_CHARS) {
+        throw new Error(
+          `Invalid ${label} returned by SDK: calldata_${index} exceeds felt range.`
+        );
+      }
+      return `0x${hexValue}`;
     }
     if (typeof item === "number") {
       if (!Number.isSafeInteger(item) || item < 0) {
@@ -702,6 +709,12 @@ function normalizeCallCalldataForResponse(
         );
       }
       if (CALLDATA_DECIMAL_REGEX.test(trimmed)) {
+        const decimalValue = BigInt(trimmed);
+        if (decimalValue.toString(16).length > MAX_FELT_HEX_CHARS) {
+          throw new Error(
+            `Invalid ${label} returned by SDK: calldata_${index} exceeds felt range.`
+          );
+        }
         return trimmed;
       }
       if (CALLDATA_HEX_REGEX.test(trimmed)) {
@@ -1798,6 +1811,28 @@ async function handleTool(
       const formattedCalls = rawCalls.map((call, index) =>
         normalizeCallForResponse(call, `swap_call_${index}`)
       );
+      const totalCalldataItems = formattedCalls.reduce(
+        (sum, call) => sum + call.calldata.length,
+        0
+      );
+      const MAX_SWAP_CALLDATA_ITEMS = 4096;
+      if (totalCalldataItems > MAX_SWAP_CALLDATA_ITEMS) {
+        throw new Error(
+          `Invalid swap calls returned by SDK: calldata item count exceeds ${MAX_SWAP_CALLDATA_ITEMS}.`
+        );
+      }
+      const totalCalldataChars = formattedCalls.reduce(
+        (sum, call) =>
+          sum +
+          call.calldata.reduce((callSum, value) => callSum + value.length, 0),
+        0
+      );
+      const MAX_SWAP_CALLDATA_CHARS = 65_536;
+      if (totalCalldataChars > MAX_SWAP_CALLDATA_CHARS) {
+        throw new Error(
+          `Invalid swap calls returned by SDK: calldata payload exceeds ${MAX_SWAP_CALLDATA_CHARS} characters.`
+        );
+      }
       return ok({
         tokenIn: sanitizeTokenSymbol(tokenIn.symbol),
         tokenInAddress: tokenIn.address,

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -427,13 +427,16 @@ async function getWallet(): Promise<Wallet> {
     );
   }
   if (!walletInitPromise) {
+    const accountAddressOverride = env.STARKNET_ACCOUNT_ADDRESS
+      ? validateAddressOrThrow(env.STARKNET_ACCOUNT_ADDRESS, "account")
+      : undefined;
     walletInitPromise = withTimeout("Wallet initialization", () =>
       getSdk().connectWallet({
         account: {
           signer: new StarkSigner(env.STARKNET_PRIVATE_KEY),
         },
-        ...(env.STARKNET_ACCOUNT_ADDRESS && {
-          accountAddress: env.STARKNET_ACCOUNT_ADDRESS,
+        ...(accountAddressOverride && {
+          accountAddress: accountAddressOverride,
         }),
       })
     )

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -37,6 +37,7 @@ import {
   FELT_REGEX,
   formatZodError,
   isClassHashNotFoundError,
+  privateKeySchema,
   parseCliConfig,
   READ_ONLY_TOOLS,
   requireResourceBounds,
@@ -53,9 +54,6 @@ const require = createRequire(import.meta.url);
 // CLI args
 // ---------------------------------------------------------------------------
 const cliArgs = process.argv.slice(2);
-const STARK_CURVE_ORDER = BigInt(
-  "0x0800000000000011000000000000000000000000000000000000000000000001"
-);
 
 const cliConfig = (() => {
   try {
@@ -81,23 +79,6 @@ const {
 // ---------------------------------------------------------------------------
 // Environment
 // ---------------------------------------------------------------------------
-function normalizePrivateKeyHex(value: string): string {
-  const hex = value.slice(2);
-  return `0x${hex.padStart(64, "0")}`;
-}
-
-const privateKeySchema = z
-  .string()
-  .regex(
-    /^0x[0-9a-fA-F]{1,64}$/,
-    "Must be a 0x-prefixed hex private key (1-64 hex chars)"
-  )
-  .transform(normalizePrivateKeyHex)
-  .refine((value) => {
-    const key = BigInt(value);
-    return key !== 0n && key < STARK_CURVE_ORDER;
-  }, "Private key must be cryptographically valid (non-zero and less than Stark curve order)");
-
 const contractAddressSchema = z
   .string()
   .regex(FELT_REGEX, "Must be a 0x-prefixed hex string (1-64 hex chars)")
@@ -450,6 +431,14 @@ async function getWallet(): Promise<Wallet> {
       })
     )
       .then((wallet) => {
+        if (
+          accountAddressOverride &&
+          fromAddress(wallet.address) !== accountAddressOverride
+        ) {
+          throw new Error(
+            `Requested account override ${accountAddressOverride}, but SDK connected ${fromAddress(wallet.address)}.`
+          );
+        }
         walletSingleton = wallet;
         walletInitFailureCount = 0;
         walletInitBackoffUntilMs = 0;
@@ -491,6 +480,28 @@ async function assertWalletAccountClassHash(
     throw new Error(
       `${context} detected account class hash mismatch at ${wallet.address}. expected=${expectedClassHash} actual=${deploymentStatus.deployedClassHash}`
     );
+  }
+}
+
+function withTransactionReference(
+  error: unknown,
+  txResult: { hash: string; explorerUrl?: string }
+): Error {
+  const reason = error instanceof Error ? error.message : String(error);
+  return new Error(
+    `${reason} Transaction hash: ${txResult.hash}. Reconcile on-chain state before retrying.`
+  );
+}
+
+async function assertWalletAccountClassHashAfterSubmission(
+  wallet: Wallet,
+  context: string,
+  txResult: { hash: string; explorerUrl?: string }
+): Promise<void> {
+  try {
+    await assertWalletAccountClassHash(wallet, context);
+  } catch (error) {
+    throw withTransactionReference(error, txResult);
   }
 }
 
@@ -650,6 +661,20 @@ function assertDistinctSwapTokens(
   }
 }
 
+function assertUniqueResolvedTokens(tokens: readonly Token[]): void {
+  const seen = new Map<string, string>();
+  for (const token of tokens) {
+    const normalizedAddress = fromAddress(token.address);
+    const previousSymbol = seen.get(normalizedAddress);
+    if (previousSymbol) {
+      throw new Error(
+        `Duplicate token requested after resolution: ${sanitizeTokenSymbol(previousSymbol)} and ${sanitizeTokenSymbol(token.symbol)} resolve to ${normalizedAddress}.`
+      );
+    }
+    seen.set(normalizedAddress, token.symbol);
+  }
+}
+
 async function mapWithConcurrencyLimit<T, R>(
   items: readonly T[],
   limit: number,
@@ -702,9 +727,19 @@ function assertSwapQuoteShape(quote: unknown): asserts quote is {
       "Invalid swap quote returned by SDK: amountInBase must be bigint."
     );
   }
+  if (quote.amountInBase <= 0n) {
+    throw new Error(
+      "Invalid swap quote returned by SDK: amountInBase must be a positive bigint."
+    );
+  }
   if (typeof quote.amountOutBase !== "bigint") {
     throw new Error(
       "Invalid swap quote returned by SDK: amountOutBase must be bigint."
+    );
+  }
+  if (quote.amountOutBase <= 0n) {
+    throw new Error(
+      "Invalid swap quote returned by SDK: amountOutBase must be a positive bigint."
     );
   }
   const routeCallCount = quote.routeCallCount;
@@ -1543,6 +1578,7 @@ function buildToolErrorText(error: unknown): string {
     "Total ",
     "Could ",
     "Rate ",
+    "Duplicate ",
     "Sponsored ",
     "Transaction ",
     "Address ",
@@ -1656,6 +1692,7 @@ async function handleTool(
       const resolvedTokens = parsed.tokens.map((tokenInput) =>
         resolveToken(tokenInput)
       );
+      assertUniqueResolvedTokens(resolvedTokens);
       const balances = await mapWithConcurrencyLimit(
         resolvedTokens,
         8,
@@ -1772,10 +1809,11 @@ async function handleTool(
         })
       );
       const txResult = await waitForTrackedTransaction(tx);
-      if (feeMode) {
-        await assertWalletAccountClassHash(
+      if (parsed.sponsored) {
+        await assertWalletAccountClassHashAfterSubmission(
           wallet,
-          "Sponsored transfer post-check"
+          "Sponsored transfer post-check",
+          txResult
         );
       }
       return ok({
@@ -1814,10 +1852,11 @@ async function handleTool(
         })
       );
       const txResult = await waitForTrackedTransaction(tx);
-      if (feeMode) {
-        await assertWalletAccountClassHash(
+      if (parsed.sponsored) {
+        await assertWalletAccountClassHashAfterSubmission(
           wallet,
-          "Sponsored execute post-check"
+          "Sponsored execute post-check",
+          txResult
         );
       }
       return ok({
@@ -1873,8 +1912,12 @@ async function handleTool(
         )
       );
       const txResult = await waitForTrackedTransaction(tx);
-      if (feeMode === "sponsored") {
-        await assertWalletAccountClassHash(wallet, "Sponsored swap post-check");
+      if (parsed.sponsored) {
+        await assertWalletAccountClassHashAfterSubmission(
+          wallet,
+          "Sponsored swap post-check",
+          txResult
+        );
       }
       return ok({
         hash: txResult.hash,
@@ -2006,7 +2049,11 @@ async function handleTool(
         })
       );
       const txResult = await waitForTrackedTransaction(tx);
-      await assertWalletAccountClassHash(wallet, "Deploy account post-check");
+      await assertWalletAccountClassHashAfterSubmission(
+        wallet,
+        "Deploy account post-check",
+        txResult
+      );
       return ok({
         status: "deployed",
         hash: txResult.hash,

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -587,6 +587,130 @@ function assertOverallFeeIsBigInt(fee: unknown): asserts fee is {
   }
 }
 
+function assertSwapQuoteShape(quote: unknown): asserts quote is {
+  amountInBase: bigint;
+  amountOutBase: bigint;
+  routeCallCount?: number;
+  priceImpactBps?: bigint | null;
+  provider?: string;
+} {
+  if (!isRecord(quote)) {
+    throw new Error(
+      "Invalid swap quote returned by SDK: expected object shape."
+    );
+  }
+  if (typeof quote.amountInBase !== "bigint") {
+    throw new Error(
+      "Invalid swap quote returned by SDK: amountInBase must be bigint."
+    );
+  }
+  if (typeof quote.amountOutBase !== "bigint") {
+    throw new Error(
+      "Invalid swap quote returned by SDK: amountOutBase must be bigint."
+    );
+  }
+  const routeCallCount = quote.routeCallCount;
+  if (routeCallCount !== undefined) {
+    if (
+      typeof routeCallCount !== "number" ||
+      !Number.isInteger(routeCallCount) ||
+      routeCallCount < 0
+    ) {
+      throw new Error(
+        "Invalid swap quote returned by SDK: routeCallCount must be a non-negative integer."
+      );
+    }
+  }
+  if (
+    quote.priceImpactBps !== undefined &&
+    quote.priceImpactBps !== null &&
+    typeof quote.priceImpactBps !== "bigint"
+  ) {
+    throw new Error(
+      "Invalid swap quote returned by SDK: priceImpactBps must be bigint or null."
+    );
+  }
+  if (quote.provider !== undefined && typeof quote.provider !== "string") {
+    throw new Error(
+      "Invalid swap quote returned by SDK: provider must be a string."
+    );
+  }
+}
+
+function normalizeCallCalldataForResponse(
+  calldata: unknown,
+  label: string
+): string[] {
+  if (!Array.isArray(calldata)) {
+    throw new Error(
+      `Invalid ${label} returned by SDK: calldata must be an array.`
+    );
+  }
+  return calldata.map((item, index) => {
+    if (typeof item === "bigint") {
+      if (item < 0n) {
+        throw new Error(
+          `Invalid ${label} returned by SDK: calldata[${index}] must be non-negative.`
+        );
+      }
+      return `0x${item.toString(16)}`;
+    }
+    if (typeof item === "number") {
+      if (!Number.isInteger(item) || item < 0) {
+        throw new Error(
+          `Invalid ${label} returned by SDK: calldata[${index}] must be a non-negative integer.`
+        );
+      }
+      return item.toString(10);
+    }
+    if (typeof item === "string") {
+      const trimmed = item.trim();
+      if (!trimmed) {
+        throw new Error(
+          `Invalid ${label} returned by SDK: calldata[${index}] must be non-empty.`
+        );
+      }
+      return trimmed;
+    }
+    throw new Error(
+      `Invalid ${label} returned by SDK: calldata[${index}] has unsupported type.`
+    );
+  });
+}
+
+function normalizeCallForResponse(
+  call: unknown,
+  label: string
+): { contractAddress: Address; entrypoint: string; calldata: string[] } {
+  if (!isRecord(call)) {
+    throw new Error(
+      `Invalid ${label} returned by SDK: call must be an object.`
+    );
+  }
+  if (typeof call.contractAddress !== "string") {
+    throw new Error(
+      `Invalid ${label} returned by SDK: contractAddress must be a string.`
+    );
+  }
+  const contractAddress = validateAddressOrThrow(
+    call.contractAddress,
+    "contract"
+  );
+  if (
+    typeof call.entrypoint !== "string" ||
+    call.entrypoint.trim().length === 0
+  ) {
+    throw new Error(
+      `Invalid ${label} returned by SDK: entrypoint must be a non-empty string.`
+    );
+  }
+  return {
+    contractAddress,
+    entrypoint: call.entrypoint.trim(),
+    calldata: normalizeCallCalldataForResponse(call.calldata ?? [], label),
+  };
+}
+
 function requireFeeUnit(unit: unknown): string {
   if (typeof unit !== "string" || unit.trim().length === 0) {
     throw new Error(`Invalid fee.unit type from SDK: ${String(unit)}`);
@@ -1386,6 +1510,84 @@ async function handleTool(
       });
     }
 
+    case "starkzap_get_balances": {
+      const parsed = args as z.infer<typeof schemas.starkzap_get_balances>;
+      const resolvedTokens = parsed.tokens.map((tokenInput) =>
+        resolveToken(tokenInput)
+      );
+      const balances = await Promise.all(
+        resolvedTokens.map(async (token) => {
+          const balance = await withTimeout(
+            `Token balance query (${token.symbol})`,
+            () => wallet.balanceOf(token)
+          );
+          assertAmountMethods(balance, "balance", [
+            "toUnit",
+            "toFormatted",
+            "toBase",
+            "getDecimals",
+          ]);
+          return {
+            token: sanitizeTokenSymbol(token.symbol),
+            address: token.address,
+            balance: balance.toUnit(),
+            formatted: balance.toFormatted(),
+            raw: balance.toBase().toString(),
+            decimals: balance.getDecimals(),
+          };
+        })
+      );
+      return ok({
+        balances,
+      });
+    }
+
+    case "starkzap_get_quote": {
+      const parsed = args as z.infer<typeof schemas.starkzap_get_quote>;
+      const tokenIn = resolveToken(parsed.tokenIn);
+      const tokenOut = resolveToken(parsed.tokenOut);
+      const amountIn = parseAmountWithContext(
+        parsed.amountIn,
+        tokenIn,
+        "quote"
+      );
+      assertAmountWithinCap(amountIn, tokenIn, maxAmount);
+      const quote = await withTimeout("Swap quote query", () =>
+        wallet.getQuote({
+          tokenIn,
+          tokenOut,
+          amountIn,
+          ...(parsed.slippageBps !== undefined && {
+            slippageBps: BigInt(parsed.slippageBps),
+          }),
+          ...(parsed.provider !== undefined && { provider: parsed.provider }),
+        })
+      );
+      assertSwapQuoteShape(quote);
+      const quotedInAmount = Amount.fromRaw(quote.amountInBase, tokenIn);
+      const quotedOutAmount = Amount.fromRaw(quote.amountOutBase, tokenOut);
+      return ok({
+        tokenIn: sanitizeTokenSymbol(tokenIn.symbol),
+        tokenInAddress: tokenIn.address,
+        tokenOut: sanitizeTokenSymbol(tokenOut.symbol),
+        tokenOutAddress: tokenOut.address,
+        amountIn: quotedInAmount.toUnit(),
+        amountInRaw: quote.amountInBase.toString(),
+        amountOut: quotedOutAmount.toUnit(),
+        amountOutRaw: quote.amountOutBase.toString(),
+        ...(quote.routeCallCount !== undefined && {
+          routeCallCount: quote.routeCallCount,
+        }),
+        ...(quote.priceImpactBps !== undefined && {
+          priceImpactBps:
+            quote.priceImpactBps === null
+              ? null
+              : quote.priceImpactBps.toString(),
+        }),
+        ...(quote.provider !== undefined && { provider: quote.provider }),
+      });
+    }
+
     case "starkzap_transfer": {
       const parsed = args as z.infer<typeof schemas.starkzap_transfer>;
       const token = resolveToken(parsed.token);
@@ -1470,6 +1672,85 @@ async function handleTool(
         hash: txResult.hash,
         explorerUrl: txResult.explorerUrl,
         callCount: calls.length,
+      });
+    }
+
+    case "starkzap_swap": {
+      const parsed = args as z.infer<typeof schemas.starkzap_swap>;
+      const tokenIn = resolveToken(parsed.tokenIn);
+      const tokenOut = resolveToken(parsed.tokenOut);
+      const amountIn = parseAmountWithContext(parsed.amountIn, tokenIn, "swap");
+      assertAmountWithinCap(amountIn, tokenIn, maxAmount);
+      const feeMode: "sponsored" | undefined = parsed.sponsored
+        ? "sponsored"
+        : undefined;
+      const tx = await withTimeout("Swap transaction submission", () =>
+        wallet.swap(
+          {
+            tokenIn,
+            tokenOut,
+            amountIn,
+            ...(parsed.slippageBps !== undefined && {
+              slippageBps: BigInt(parsed.slippageBps),
+            }),
+            ...(parsed.provider !== undefined && { provider: parsed.provider }),
+          },
+          {
+            ...(feeMode && { feeMode }),
+          }
+        )
+      );
+      const txResult = await waitForTrackedTransaction(tx);
+      if (feeMode === "sponsored") {
+        await assertWalletAccountClassHash(wallet, "Sponsored swap post-check");
+      }
+      return ok({
+        hash: txResult.hash,
+        explorerUrl: txResult.explorerUrl,
+        tokenIn: sanitizeTokenSymbol(tokenIn.symbol),
+        tokenInAddress: tokenIn.address,
+        tokenOut: sanitizeTokenSymbol(tokenOut.symbol),
+        tokenOutAddress: tokenOut.address,
+        amountIn: amountIn.toUnit(),
+        amountInRaw: amountIn.toBase().toString(),
+      });
+    }
+
+    case "starkzap_build_swap_calls": {
+      const parsed = args as z.infer<typeof schemas.starkzap_build_swap_calls>;
+      const tokenIn = resolveToken(parsed.tokenIn);
+      const tokenOut = resolveToken(parsed.tokenOut);
+      const amountIn = parseAmountWithContext(
+        parsed.amountIn,
+        tokenIn,
+        "build_swap_calls"
+      );
+      assertAmountWithinCap(amountIn, tokenIn, maxAmount);
+      const calls = await withTimeout("Swap call build", async () =>
+        wallet
+          .tx()
+          .swap({
+            tokenIn,
+            tokenOut,
+            amountIn,
+            ...(parsed.slippageBps !== undefined && {
+              slippageBps: BigInt(parsed.slippageBps),
+            }),
+            ...(parsed.provider !== undefined && { provider: parsed.provider }),
+          })
+          .calls()
+      );
+      const formattedCalls = calls.map((call, index) =>
+        normalizeCallForResponse(call, `swap call[${index}]`)
+      );
+      return ok({
+        tokenIn: sanitizeTokenSymbol(tokenIn.symbol),
+        tokenInAddress: tokenIn.address,
+        tokenOut: sanitizeTokenSymbol(tokenOut.symbol),
+        tokenOutAddress: tokenOut.address,
+        amountIn: amountIn.toUnit(),
+        amountInRaw: amountIn.toBase().toString(),
+        calls: formattedCalls,
       });
     }
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -39,6 +39,7 @@ import {
   isClassHashNotFoundError,
   privateKeySchema,
   parseCliConfig,
+  PROVIDER_ID_REGEX,
   READ_ONLY_TOOLS,
   requireResourceBounds,
   schemas,
@@ -716,7 +717,6 @@ function assertSwapQuoteShape(quote: unknown): asserts quote is {
   priceImpactBps?: bigint | null;
   provider?: string;
 } {
-  const PROVIDER_ID_REGEX = /^[A-Za-z0-9._:-]+$/;
   if (!isRecord(quote)) {
     throw new Error(
       "Invalid swap quote returned by SDK: expected object shape."
@@ -772,6 +772,20 @@ function assertSwapQuoteShape(quote: unknown): asserts quote is {
   ) {
     throw new Error(
       "Invalid swap quote returned by SDK: provider must be a safe provider id."
+    );
+  }
+}
+
+function amountFromRawForSwapResponse(
+  raw: bigint,
+  token: Token,
+  context: string
+): ReturnType<typeof Amount.fromRaw> {
+  try {
+    return Amount.fromRaw(raw, token);
+  } catch (error) {
+    throw new Error(
+      `Invalid swap quote returned by SDK: ${context} could not be formatted. ${summarizeError(error)}`
     );
   }
 }
@@ -1579,7 +1593,10 @@ function buildToolErrorText(error: unknown): string {
     "Could ",
     "Rate ",
     "Duplicate ",
-    "Sponsored ",
+    "Sponsored transfer",
+    "Sponsored execute",
+    "Sponsored swap",
+    "Deploy account post-check",
     "Transaction ",
     "Address ",
     "Swap ",
@@ -1745,8 +1762,16 @@ async function handleTool(
         })
       );
       assertSwapQuoteShape(quote);
-      const quotedInAmount = Amount.fromRaw(quote.amountInBase, tokenIn);
-      const quotedOutAmount = Amount.fromRaw(quote.amountOutBase, tokenOut);
+      const quotedInAmount = amountFromRawForSwapResponse(
+        quote.amountInBase,
+        tokenIn,
+        "amountInBase"
+      );
+      const quotedOutAmount = amountFromRawForSwapResponse(
+        quote.amountOutBase,
+        tokenOut,
+        "amountOutBase"
+      );
       return ok({
         tokenIn: sanitizeTokenSymbol(tokenIn.symbol),
         tokenInAddress: tokenIn.address,
@@ -1885,7 +1910,11 @@ async function handleTool(
         })
       );
       assertSwapQuoteShape(quote);
-      const quotedOutAmount = Amount.fromRaw(quote.amountOutBase, tokenOut);
+      const quotedOutAmount = amountFromRawForSwapResponse(
+        quote.amountOutBase,
+        tokenOut,
+        "amountOutBase"
+      );
       const feeMode: "sponsored" | undefined = parsed.sponsored
         ? "sponsored"
         : undefined;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -577,6 +577,20 @@ function parseAmountWithContext(
   }
 }
 
+function assertDistinctSwapTokens(
+  tokenIn: Token,
+  tokenOut: Token,
+  context: string
+): void {
+  const normalizedIn = fromAddress(tokenIn.address);
+  const normalizedOut = fromAddress(tokenOut.address);
+  if (normalizedIn === normalizedOut) {
+    throw new Error(
+      `${context}: tokenIn and tokenOut resolve to the same token (${sanitizeTokenSymbol(tokenIn.symbol)}).`
+    );
+  }
+}
+
 function assertOverallFeeIsBigInt(fee: unknown): asserts fee is {
   overall_fee: bigint;
 } {
@@ -1546,6 +1560,7 @@ async function handleTool(
       const parsed = args as z.infer<typeof schemas.starkzap_get_quote>;
       const tokenIn = resolveToken(parsed.tokenIn);
       const tokenOut = resolveToken(parsed.tokenOut);
+      assertDistinctSwapTokens(tokenIn, tokenOut, "Swap quote");
       const amountIn = parseAmountWithContext(
         parsed.amountIn,
         tokenIn,
@@ -1679,6 +1694,7 @@ async function handleTool(
       const parsed = args as z.infer<typeof schemas.starkzap_swap>;
       const tokenIn = resolveToken(parsed.tokenIn);
       const tokenOut = resolveToken(parsed.tokenOut);
+      assertDistinctSwapTokens(tokenIn, tokenOut, "Swap execution");
       const amountIn = parseAmountWithContext(parsed.amountIn, tokenIn, "swap");
       assertAmountWithinCap(amountIn, tokenIn, maxAmount);
       const feeMode: "sponsored" | undefined = parsed.sponsored
@@ -1720,6 +1736,7 @@ async function handleTool(
       const parsed = args as z.infer<typeof schemas.starkzap_build_swap_calls>;
       const tokenIn = resolveToken(parsed.tokenIn);
       const tokenOut = resolveToken(parsed.tokenOut);
+      assertDistinctSwapTokens(tokenIn, tokenOut, "Build swap calls");
       const amountIn = parseAmountWithContext(
         parsed.amountIn,
         tokenIn,

--- a/packages/mcp-server/tests/core.test.ts
+++ b/packages/mcp-server/tests/core.test.ts
@@ -160,6 +160,41 @@ describe("schema hardening", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("rejects same token pairs in swap schemas", () => {
+    const parsed = schemas.starkzap_get_quote.safeParse({
+      tokenIn: "STRK",
+      tokenOut: "strk",
+      amountIn: "1",
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects unknown fields in hardened swap/get-balances schemas", () => {
+    const balancesParsed = schemas.starkzap_get_balances.safeParse({
+      tokens: ["STRK"],
+      unexpected: true,
+    });
+    expect(balancesParsed.success).toBe(false);
+
+    const quoteParsed = schemas.starkzap_get_quote.safeParse({
+      tokenIn: "STRK",
+      tokenOut: "USDC",
+      amountIn: "1",
+      unexpected: true,
+    });
+    expect(quoteParsed.success).toBe(false);
+  });
+
+  it("bounds token identifiers in swap schemas", () => {
+    const tooLong = "A".repeat(129);
+    const parsed = schemas.starkzap_get_quote.safeParse({
+      tokenIn: tooLong,
+      tokenOut: "USDC",
+      amountIn: "1",
+    });
+    expect(parsed.success).toBe(false);
+  });
+
   it("bounds calldata payload size", () => {
     const oversized = "a".repeat(257);
     const parsed = schemas.starkzap_execute.safeParse({

--- a/packages/mcp-server/tests/core.test.ts
+++ b/packages/mcp-server/tests/core.test.ts
@@ -150,6 +150,13 @@ describe("schema hardening", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("rejects duplicate token identifiers in get-balances schema", () => {
+    const parsed = schemas.starkzap_get_balances.safeParse({
+      tokens: ["STRK", "strk"],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
   it("validates swap slippage bps bounds", () => {
     const parsed = schemas.starkzap_get_quote.safeParse({
       tokenIn: "STRK",

--- a/packages/mcp-server/tests/core.test.ts
+++ b/packages/mcp-server/tests/core.test.ts
@@ -144,6 +144,22 @@ describe("schema hardening", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("bounds get-balances token batches at 32", () => {
+    const tokens = Array.from({ length: 33 }, (_, index) => `TOKEN_${index}`);
+    const parsed = schemas.starkzap_get_balances.safeParse({ tokens });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("validates swap slippage bps bounds", () => {
+    const parsed = schemas.starkzap_get_quote.safeParse({
+      tokenIn: "STRK",
+      tokenOut: "USDC",
+      amountIn: "1",
+      slippageBps: 10_000,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
   it("bounds calldata payload size", () => {
     const oversized = "a".repeat(257);
     const parsed = schemas.starkzap_execute.safeParse({
@@ -219,6 +235,10 @@ describe("tool gating and parity", () => {
     });
     const names = new Set(readOnlyOnly.map((tool) => tool.name));
     expect(names.has("starkzap_get_account")).toBe(true);
+    expect(names.has("starkzap_get_balances")).toBe(true);
+    expect(names.has("starkzap_get_quote")).toBe(true);
+    expect(names.has("starkzap_build_swap_calls")).toBe(true);
+    expect(names.has("starkzap_swap")).toBe(false);
   });
 
   it("hides staking tools when staking config is absent", () => {

--- a/packages/mcp-server/tests/core.test.ts
+++ b/packages/mcp-server/tests/core.test.ts
@@ -330,6 +330,16 @@ describe("tool gating and parity", () => {
     }
   });
 
+  it("marks build_swap_calls as non-idempotent despite being read-only", () => {
+    const tools = buildTools("100", "150");
+    const buildSwapCalls = tools.find(
+      (tool) => tool.name === "starkzap_build_swap_calls"
+    );
+    expect(buildSwapCalls).toBeDefined();
+    expect(buildSwapCalls?.annotations?.readOnlyHint).toBe(true);
+    expect(buildSwapCalls?.annotations?.idempotentHint).toBe(false);
+  });
+
   it("keeps swap tool inputSchema constraints aligned with runtime validation", () => {
     const tools = buildTools("100", "150");
     const quoteTool = tools.find((tool) => tool.name === "starkzap_get_quote");

--- a/packages/mcp-server/tests/core.test.ts
+++ b/packages/mcp-server/tests/core.test.ts
@@ -314,6 +314,24 @@ describe("tool gating and parity", () => {
       expect(typeof tool.annotations?.destructiveHint).toBe("boolean");
     }
   });
+
+  it("keeps swap tool inputSchema constraints aligned with runtime validation", () => {
+    const tools = buildTools("100", "150");
+    const quoteTool = tools.find((tool) => tool.name === "starkzap_get_quote");
+    expect(quoteTool).toBeDefined();
+
+    const inputSchema = quoteTool?.inputSchema as
+      | {
+          properties?: Record<string, { maxLength?: number; pattern?: string }>;
+        }
+      | undefined;
+    expect(inputSchema?.properties?.tokenIn?.maxLength).toBe(128);
+    expect(inputSchema?.properties?.tokenOut?.maxLength).toBe(128);
+    expect(inputSchema?.properties?.provider?.maxLength).toBe(64);
+    expect(inputSchema?.properties?.provider?.pattern).toBe(
+      "^[A-Za-z0-9._:-]+$"
+    );
+  });
 });
 
 describe("amount and token guards", () => {

--- a/packages/mcp-server/tests/core.test.ts
+++ b/packages/mcp-server/tests/core.test.ts
@@ -330,11 +330,18 @@ describe("tool gating and parity", () => {
 
     const inputSchema = quoteTool?.inputSchema as
       | {
-          properties?: Record<string, { maxLength?: number; pattern?: string }>;
+          properties?: Record<
+            string,
+            { minLength?: number; maxLength?: number; pattern?: string }
+          >;
         }
       | undefined;
+    expect(inputSchema?.properties?.tokenIn?.minLength).toBe(1);
     expect(inputSchema?.properties?.tokenIn?.maxLength).toBe(128);
+    expect(inputSchema?.properties?.tokenIn?.pattern).toBe(".*\\S.*");
+    expect(inputSchema?.properties?.tokenOut?.minLength).toBe(1);
     expect(inputSchema?.properties?.tokenOut?.maxLength).toBe(128);
+    expect(inputSchema?.properties?.tokenOut?.pattern).toBe(".*\\S.*");
     expect(inputSchema?.properties?.provider?.maxLength).toBe(64);
     expect(inputSchema?.properties?.provider?.pattern).toBe(
       "^[A-Za-z0-9._:-]+$"

--- a/packages/mcp-server/tests/core.test.ts
+++ b/packages/mcp-server/tests/core.test.ts
@@ -195,6 +195,14 @@ describe("schema hardening", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("bounds token identifiers in get-balances schema", () => {
+    const tooLong = "A".repeat(129);
+    const parsed = schemas.starkzap_get_balances.safeParse({
+      tokens: [tooLong],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
   it("bounds calldata payload size", () => {
     const oversized = "a".repeat(257);
     const parsed = schemas.starkzap_execute.safeParse({

--- a/packages/mcp-server/tests/index.integration.test.ts
+++ b/packages/mcp-server/tests/index.integration.test.ts
@@ -588,6 +588,39 @@ describe("index integration hardening", () => {
     );
   });
 
+  it("rejects build_swap_calls when decimal calldata exceeds felt range", async () => {
+    const tooLargeDecimal = "9".repeat(90);
+    const callsFn = vi.fn().mockResolvedValue([
+      {
+        contractAddress: "0x1",
+        entrypoint: "swap_exact_tokens",
+        calldata: [tooLargeDecimal],
+      },
+    ]);
+    const swapFn = vi.fn().mockReturnValue({ calls: callsFn });
+    testing.setWalletSingleton({
+      tx: vi.fn().mockReturnValue({
+        swap: swapFn,
+      }),
+    } as unknown as Wallet);
+
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_build_swap_calls",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "1",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain(
+      "Invalid swap_call_0 returned by SDK: calldata_0 exceeds felt range."
+    );
+  });
+
   it("rejects build_swap_calls when tokenIn/tokenOut resolve to the same token", async () => {
     const callsFn = vi.fn();
     const swapFn = vi.fn().mockReturnValue({ calls: callsFn });
@@ -663,6 +696,49 @@ describe("index integration hardening", () => {
     expect(response.isError).toBe(true);
     expect(response.content[0]?.text).toContain(
       "Invalid swap_call_0 returned by SDK: entrypoint must be a valid Cairo identifier."
+    );
+  });
+
+  it("rejects build_swap_calls when aggregated calldata item count is too large", async () => {
+    const largeCalldata = Array.from({ length: 1500 }, () => "1");
+    const callsFn = vi.fn().mockResolvedValue([
+      {
+        contractAddress: "0x1",
+        entrypoint: "swap_exact_tokens",
+        calldata: largeCalldata,
+      },
+      {
+        contractAddress: "0x2",
+        entrypoint: "swap_exact_tokens",
+        calldata: largeCalldata,
+      },
+      {
+        contractAddress: "0x3",
+        entrypoint: "swap_exact_tokens",
+        calldata: largeCalldata,
+      },
+    ]);
+    const swapFn = vi.fn().mockReturnValue({ calls: callsFn });
+    testing.setWalletSingleton({
+      tx: vi.fn().mockReturnValue({
+        swap: swapFn,
+      }),
+    } as unknown as Wallet);
+
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_build_swap_calls",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "1",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain(
+      "Invalid swap calls returned by SDK: calldata item count exceeds 4096."
     );
   });
 

--- a/packages/mcp-server/tests/index.integration.test.ts
+++ b/packages/mcp-server/tests/index.integration.test.ts
@@ -380,6 +380,114 @@ describe("index integration hardening", () => {
     );
   });
 
+  it("returns batched balances for multiple tokens", async () => {
+    testing.setWalletSingleton({
+      balanceOf: vi.fn(async (token: Token) =>
+        token.symbol === "STRK"
+          ? Amount.parse("1.25", token)
+          : Amount.parse("2.5", token)
+      ),
+    } as unknown as Wallet);
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_get_balances",
+        arguments: { tokens: ["STRK", "USDC"] },
+      },
+    });
+    expect(response.isError).not.toBe(true);
+    const payload = JSON.parse(response.content[0]?.text ?? "{}") as {
+      balances?: Array<{ token?: string; balance?: string; raw?: string }>;
+    };
+    expect(payload.balances).toHaveLength(2);
+    expect(payload.balances?.[0]?.token).toBe("STRK");
+    expect(payload.balances?.[0]?.balance).toBe("1.25");
+    expect(payload.balances?.[1]?.token).toBe("USDC");
+    expect(payload.balances?.[1]?.balance).toBe("2.5");
+    expect(
+      payload.balances?.every((entry) => typeof entry.raw === "string")
+    ).toBe(true);
+  });
+
+  it("rejects malformed swap quote responses from SDK", async () => {
+    testing.setWalletSingleton({
+      getQuote: vi.fn().mockResolvedValue({
+        amountInBase: 1n,
+        amountOutBase: "not-bigint",
+      }),
+    } as unknown as Wallet);
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_get_quote",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "1",
+        },
+      },
+    });
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain(
+      "Invalid swap quote returned by SDK"
+    );
+  });
+
+  it("builds unsigned swap calls without execution", async () => {
+    const calls = [
+      {
+        contractAddress: "0x1",
+        entrypoint: "swap_exact_tokens",
+        calldata: [1n, "0x2", 3],
+      },
+    ];
+    const callsFn = vi.fn().mockResolvedValue(calls);
+    const swapFn = vi.fn().mockReturnValue({ calls: callsFn });
+    testing.setWalletSingleton({
+      tx: vi.fn().mockReturnValue({
+        swap: swapFn,
+      }),
+    } as unknown as Wallet);
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_build_swap_calls",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "1",
+          slippageBps: 50,
+          provider: "avnu",
+        },
+      },
+    });
+    expect(response.isError).not.toBe(true);
+    const payload = JSON.parse(response.content[0]?.text ?? "{}") as {
+      calls?: Array<{
+        contractAddress: string;
+        entrypoint: string;
+        calldata: string[];
+      }>;
+    };
+    expect(swapFn).toHaveBeenCalledTimes(1);
+    expect(payload.calls).toHaveLength(1);
+    expect(payload.calls?.[0]?.contractAddress).toBe(fromAddress("0x1"));
+    expect(payload.calls?.[0]?.entrypoint).toBe("swap_exact_tokens");
+    expect(payload.calls?.[0]?.calldata).toEqual(["0x1", "0x2", "3"]);
+  });
+
+  it("keeps swap execution write-gated by default", async () => {
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_swap",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "1",
+        },
+      },
+    });
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain("disabled by default");
+  });
+
   it("fails with clear message when fee estimate overall_fee is malformed", async () => {
     testing.setWalletSingleton({
       estimateFee: vi.fn().mockResolvedValue({

--- a/packages/mcp-server/tests/index.integration.test.ts
+++ b/packages/mcp-server/tests/index.integration.test.ts
@@ -1,4 +1,4 @@
-import { Amount, fromAddress } from "starkzap";
+import { Amount, fromAddress, mainnetTokens } from "starkzap";
 import type { Token, Wallet } from "starkzap";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -9,6 +9,13 @@ const TEST_TOKEN: Token = {
     "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab0720189f9f3f75e66" as Token["address"],
   decimals: 18,
 };
+
+const KNOWN_MAINNET_TOKEN: Token = (() => {
+  const preferred = Object.values(mainnetTokens).find(
+    (token) => token.symbol.toUpperCase() === "STRK"
+  );
+  return preferred ?? TEST_TOKEN;
+})();
 
 type TestingExports = {
   withTimeout<T>(
@@ -431,6 +438,26 @@ describe("index integration hardening", () => {
     );
   });
 
+  it("rejects swap quote when tokenIn/tokenOut resolve to the same token", async () => {
+    const getQuote = vi.fn();
+    testing.setWalletSingleton({
+      getQuote,
+    } as unknown as Wallet);
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_get_quote",
+        arguments: {
+          tokenIn: KNOWN_MAINNET_TOKEN.symbol,
+          tokenOut: KNOWN_MAINNET_TOKEN.address,
+          amountIn: "1",
+        },
+      },
+    });
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain("Operation failed. Reference:");
+    expect(getQuote).not.toHaveBeenCalled();
+  });
+
   it("builds unsigned swap calls without execution", async () => {
     const calls = [
       {
@@ -471,6 +498,30 @@ describe("index integration hardening", () => {
     expect(payload.calls?.[0]?.contractAddress).toBe(fromAddress("0x1"));
     expect(payload.calls?.[0]?.entrypoint).toBe("swap_exact_tokens");
     expect(payload.calls?.[0]?.calldata).toEqual(["0x1", "0x2", "3"]);
+  });
+
+  it("rejects build_swap_calls when tokenIn/tokenOut resolve to the same token", async () => {
+    const callsFn = vi.fn();
+    const swapFn = vi.fn().mockReturnValue({ calls: callsFn });
+    testing.setWalletSingleton({
+      tx: vi.fn().mockReturnValue({
+        swap: swapFn,
+      }),
+    } as unknown as Wallet);
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_build_swap_calls",
+        arguments: {
+          tokenIn: KNOWN_MAINNET_TOKEN.symbol,
+          tokenOut: KNOWN_MAINNET_TOKEN.address,
+          amountIn: "1",
+        },
+      },
+    });
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain("Operation failed. Reference:");
+    expect(swapFn).not.toHaveBeenCalled();
+    expect(callsFn).not.toHaveBeenCalled();
   });
 
   it("keeps swap execution write-gated by default", async () => {

--- a/packages/mcp-server/tests/index.integration.test.ts
+++ b/packages/mcp-server/tests/index.integration.test.ts
@@ -500,6 +500,66 @@ describe("index integration hardening", () => {
     expect(payload.calls?.[0]?.calldata).toEqual(["0x1", "0x2", "3"]);
   });
 
+  it("rejects build_swap_calls when calldata contains unsafe numeric values", async () => {
+    const callsFn = vi.fn().mockResolvedValue([
+      {
+        contractAddress: "0x1",
+        entrypoint: "swap_exact_tokens",
+        calldata: [Number.MAX_SAFE_INTEGER + 1],
+      },
+    ]);
+    const swapFn = vi.fn().mockReturnValue({ calls: callsFn });
+    testing.setWalletSingleton({
+      tx: vi.fn().mockReturnValue({
+        swap: swapFn,
+      }),
+    } as unknown as Wallet);
+
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_build_swap_calls",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "1",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain("Operation failed. Reference:");
+  });
+
+  it("rejects build_swap_calls when calldata contains invalid strings", async () => {
+    const callsFn = vi.fn().mockResolvedValue([
+      {
+        contractAddress: "0x1",
+        entrypoint: "swap_exact_tokens",
+        calldata: ["0xnothex"],
+      },
+    ]);
+    const swapFn = vi.fn().mockReturnValue({ calls: callsFn });
+    testing.setWalletSingleton({
+      tx: vi.fn().mockReturnValue({
+        swap: swapFn,
+      }),
+    } as unknown as Wallet);
+
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_build_swap_calls",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "1",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain("Operation failed. Reference:");
+  });
+
   it("rejects build_swap_calls when tokenIn/tokenOut resolve to the same token", async () => {
     const callsFn = vi.fn();
     const swapFn = vi.fn().mockReturnValue({ calls: callsFn });

--- a/packages/mcp-server/tests/index.integration.test.ts
+++ b/packages/mcp-server/tests/index.integration.test.ts
@@ -144,7 +144,7 @@ describe("index integration hardening", () => {
     expect(connectWallet).toHaveBeenCalledTimes(1);
     expect(connectWallet).toHaveBeenCalledWith(
       expect.objectContaining({
-        accountAddress: "0x2",
+        accountAddress: fromAddress("0x2"),
       })
     );
 
@@ -153,7 +153,7 @@ describe("index integration hardening", () => {
     expect(connectWallet).toHaveBeenCalledTimes(2);
     expect(connectWallet).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        accountAddress: "0x2",
+        accountAddress: fromAddress("0x2"),
       })
     );
   });

--- a/packages/mcp-server/tests/index.integration.test.ts
+++ b/packages/mcp-server/tests/index.integration.test.ts
@@ -83,6 +83,7 @@ beforeAll(async () => {
   process.env.STARKZAP_MCP_TEST_KEY_MARKER =
     "TEST_KEY_DO_NOT_USE_IN_PRODUCTION";
   process.env.STARKNET_PRIVATE_KEY = `0x${"1".padStart(64, "0")}`;
+  process.env.STARKNET_ACCOUNT_ADDRESS = "0x2";
   process.env.STARKNET_STAKING_CONTRACT =
     "0x03745ab04a431fc02871a139be6b93d9260b0ff3e779ad9c8b377183b23109f1";
   process.env.STARKNET_PAYMASTER_URL = "https://sepolia.paymaster.avnu.fi";
@@ -141,10 +142,20 @@ describe("index integration hardening", () => {
       /temporarily throttled after recent failures/
     );
     expect(connectWallet).toHaveBeenCalledTimes(1);
+    expect(connectWallet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountAddress: "0x2",
+      })
+    );
 
     testing.setNowProvider(() => 2_000);
     await expect(testing.getWallet()).resolves.toBeDefined();
     expect(connectWallet).toHaveBeenCalledTimes(2);
+    expect(connectWallet).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        accountAddress: "0x2",
+      })
+    );
   });
 
   it("wires paymaster URL and API key into SDK config", () => {

--- a/packages/mcp-server/tests/index.integration.test.ts
+++ b/packages/mcp-server/tests/index.integration.test.ts
@@ -438,6 +438,30 @@ describe("index integration hardening", () => {
     );
   });
 
+  it("rejects unsafe provider ids in swap quote responses", async () => {
+    testing.setWalletSingleton({
+      getQuote: vi.fn().mockResolvedValue({
+        amountInBase: 1n,
+        amountOutBase: 2n,
+        provider: "bad provider\nid",
+      }),
+    } as unknown as Wallet);
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_get_quote",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "1",
+        },
+      },
+    });
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain(
+      "Invalid swap quote returned by SDK: provider must be a safe provider id."
+    );
+  });
+
   it("rejects swap quote when tokenIn/tokenOut resolve to the same token", async () => {
     const getQuote = vi.fn();
     testing.setWalletSingleton({
@@ -527,7 +551,9 @@ describe("index integration hardening", () => {
     });
 
     expect(response.isError).toBe(true);
-    expect(response.content[0]?.text).toContain("Operation failed. Reference:");
+    expect(response.content[0]?.text).toContain(
+      "Invalid swap_call_0 returned by SDK: calldata_0 must be a non-negative safe integer."
+    );
   });
 
   it("rejects build_swap_calls when calldata contains invalid strings", async () => {
@@ -557,7 +583,9 @@ describe("index integration hardening", () => {
     });
 
     expect(response.isError).toBe(true);
-    expect(response.content[0]?.text).toContain("Operation failed. Reference:");
+    expect(response.content[0]?.text).toContain(
+      "Invalid swap_call_0 returned by SDK: calldata_0 must be a felt-like hex or decimal string."
+    );
   });
 
   it("rejects build_swap_calls when tokenIn/tokenOut resolve to the same token", async () => {
@@ -582,6 +610,60 @@ describe("index integration hardening", () => {
     expect(response.content[0]?.text).toContain("Operation failed. Reference:");
     expect(swapFn).not.toHaveBeenCalled();
     expect(callsFn).not.toHaveBeenCalled();
+  });
+
+  it("rejects build_swap_calls when SDK returns non-array calls", async () => {
+    const callsFn = vi.fn().mockResolvedValue("not-an-array");
+    const swapFn = vi.fn().mockReturnValue({ calls: callsFn });
+    testing.setWalletSingleton({
+      tx: vi.fn().mockReturnValue({
+        swap: swapFn,
+      }),
+    } as unknown as Wallet);
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_build_swap_calls",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "1",
+        },
+      },
+    });
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain(
+      "Invalid swap calls returned by SDK: expected 1-10 calls."
+    );
+  });
+
+  it("rejects build_swap_calls when SDK returns invalid entrypoint names", async () => {
+    const callsFn = vi.fn().mockResolvedValue([
+      {
+        contractAddress: "0x1",
+        entrypoint: "transfer!",
+        calldata: [],
+      },
+    ]);
+    const swapFn = vi.fn().mockReturnValue({ calls: callsFn });
+    testing.setWalletSingleton({
+      tx: vi.fn().mockReturnValue({
+        swap: swapFn,
+      }),
+    } as unknown as Wallet);
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_build_swap_calls",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "1",
+        },
+      },
+    });
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain(
+      "Invalid swap_call_0 returned by SDK: entrypoint must be a valid Cairo identifier."
+    );
   });
 
   it("keeps swap execution write-gated by default", async () => {

--- a/packages/mcp-server/tests/index.integration.test.ts
+++ b/packages/mcp-server/tests/index.integration.test.ts
@@ -129,6 +129,7 @@ describe("index integration hardening", () => {
       .fn()
       .mockRejectedValueOnce(new Error("connection refused"))
       .mockResolvedValueOnce({
+        address: fromAddress("0x2"),
         disconnect: vi.fn().mockResolvedValue(undefined),
       });
 
@@ -152,6 +153,25 @@ describe("index integration hardening", () => {
     await expect(testing.getWallet()).resolves.toBeDefined();
     expect(connectWallet).toHaveBeenCalledTimes(2);
     expect(connectWallet).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        accountAddress: fromAddress("0x2"),
+      })
+    );
+  });
+
+  it("fails wallet init when SDK ignores the configured account override", async () => {
+    const connectWallet = vi.fn().mockResolvedValue({
+      address: fromAddress("0x3"),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+    });
+
+    testing.setSdkSingleton({ connectWallet });
+    testing.setNowProvider(() => 10_000);
+
+    await expect(testing.getWallet()).rejects.toThrow(
+      /Requested account override/
+    );
+    expect(connectWallet).toHaveBeenCalledWith(
       expect.objectContaining({
         accountAddress: fromAddress("0x2"),
       })
@@ -426,6 +446,26 @@ describe("index integration hardening", () => {
     ).toBe(true);
   });
 
+  it("rejects semantically duplicate tokens in batched balances", async () => {
+    const balanceOf = vi.fn();
+    testing.setWalletSingleton({
+      balanceOf,
+    } as unknown as Wallet);
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_get_balances",
+        arguments: {
+          tokens: [KNOWN_MAINNET_TOKEN.symbol, KNOWN_MAINNET_TOKEN.address],
+        },
+      },
+    });
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain(
+      "Duplicate token requested after resolution"
+    );
+    expect(balanceOf).not.toHaveBeenCalled();
+  });
+
   it("rejects malformed swap quote responses from SDK", async () => {
     testing.setWalletSingleton({
       getQuote: vi.fn().mockResolvedValue({
@@ -470,6 +510,30 @@ describe("index integration hardening", () => {
     expect(response.isError).toBe(true);
     expect(response.content[0]?.text).toContain(
       "Invalid swap quote returned by SDK: provider must be a safe provider id."
+    );
+  });
+
+  it("rejects non-positive swap quote amounts from SDK", async () => {
+    testing.setWalletSingleton({
+      getQuote: vi.fn().mockResolvedValue({
+        amountInBase: 1n,
+        amountOutBase: 0n,
+        provider: "avnu",
+      }),
+    } as unknown as Wallet);
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_get_quote",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "1",
+        },
+      },
+    });
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain(
+      "amountOutBase must be a positive bigint"
     );
   });
 

--- a/packages/mcp-server/tests/index.integration.test.ts
+++ b/packages/mcp-server/tests/index.integration.test.ts
@@ -489,7 +489,9 @@ describe("index integration hardening", () => {
       },
     });
     expect(response.isError).toBe(true);
-    expect(response.content[0]?.text).toContain("Operation failed. Reference:");
+    expect(response.content[0]?.text).toContain(
+      "Swap quote: tokenIn and tokenOut resolve to the same token"
+    );
     expect(getQuote).not.toHaveBeenCalled();
   });
 
@@ -632,6 +634,40 @@ describe("index integration hardening", () => {
     );
   });
 
+  it("rejects build_swap_calls when hex calldata exceeds felt252 upper bound", async () => {
+    const tooLargeHex =
+      "0x0800000000000011000000000000000000000000000000000000000000000001";
+    const callsFn = vi.fn().mockResolvedValue([
+      {
+        contractAddress: "0x1",
+        entrypoint: "swap_exact_tokens",
+        calldata: [tooLargeHex],
+      },
+    ]);
+    const swapFn = vi.fn().mockReturnValue({ calls: callsFn });
+    testing.setWalletSingleton({
+      tx: vi.fn().mockReturnValue({
+        swap: swapFn,
+      }),
+    } as unknown as Wallet);
+
+    const response = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_build_swap_calls",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "1",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain(
+      "Invalid swap_call_0 returned by SDK: calldata_0 exceeds felt range."
+    );
+  });
+
   it("rejects build_swap_calls when tokenIn/tokenOut resolve to the same token", async () => {
     const callsFn = vi.fn();
     const swapFn = vi.fn().mockReturnValue({ calls: callsFn });
@@ -651,7 +687,9 @@ describe("index integration hardening", () => {
       },
     });
     expect(response.isError).toBe(true);
-    expect(response.content[0]?.text).toContain("Operation failed. Reference:");
+    expect(response.content[0]?.text).toContain(
+      "Build swap calls: tokenIn and tokenOut resolve to the same token"
+    );
     expect(swapFn).not.toHaveBeenCalled();
     expect(callsFn).not.toHaveBeenCalled();
   });

--- a/packages/mcp-server/tests/index.integration.test.ts
+++ b/packages/mcp-server/tests/index.integration.test.ts
@@ -82,7 +82,7 @@ beforeAll(async () => {
   process.env.STARKZAP_MCP_ENABLE_TEST_HOOKS = "1";
   process.env.STARKZAP_MCP_TEST_KEY_MARKER =
     "TEST_KEY_DO_NOT_USE_IN_PRODUCTION";
-  process.env.STARKNET_PRIVATE_KEY = `0x${"1".padStart(64, "0")}`;
+  process.env.STARKNET_PRIVATE_KEY = "0x1";
   process.env.STARKNET_ACCOUNT_ADDRESS = "0x2";
   process.env.STARKNET_STAKING_CONTRACT =
     "0x03745ab04a431fc02871a139be6b93d9260b0ff3e779ad9c8b377183b23109f1";

--- a/packages/mcp-server/tests/sponsored-preflight.integration.test.ts
+++ b/packages/mcp-server/tests/sponsored-preflight.integration.test.ts
@@ -45,6 +45,12 @@ function mismatchedProvider() {
   };
 }
 
+function deployedProvider() {
+  return {
+    getClassHashAt: vi.fn().mockResolvedValue(EXPECTED_CLASS_HASH),
+  };
+}
+
 function tx(hash: string) {
   return {
     hash,
@@ -128,7 +134,15 @@ describe("sponsored write preflight hardening", () => {
     expect(result.content[0]?.text ?? "").toContain(
       "Sponsored transfer post-check succeeded but wallet account is still not deployed on-chain."
     );
+    expect(result.content[0]?.text ?? "").toContain("Transaction hash:");
     expect(transfer).toHaveBeenCalledOnce();
+    expect(transfer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        feeMode: "sponsored",
+      })
+    );
   });
 
   it("blocks sponsored transfer before submission when account class hash mismatches", async () => {
@@ -185,7 +199,14 @@ describe("sponsored write preflight hardening", () => {
     expect(result.content[0]?.text ?? "").toContain(
       "Sponsored execute post-check succeeded but wallet account is still not deployed on-chain."
     );
+    expect(result.content[0]?.text ?? "").toContain("Transaction hash:");
     expect(execute).toHaveBeenCalledOnce();
+    expect(execute).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        feeMode: "sponsored",
+      })
+    );
   });
 
   it("blocks sponsored execute before submission when account class hash mismatches", async () => {
@@ -249,8 +270,59 @@ describe("sponsored write preflight hardening", () => {
     expect(result.content[0]?.text ?? "").toContain(
       "Sponsored swap post-check succeeded but wallet account is still not deployed on-chain."
     );
+    expect(result.content[0]?.text ?? "").toContain("Transaction hash:");
     expect(getQuote).toHaveBeenCalledOnce();
     expect(swap).toHaveBeenCalledOnce();
+    expect(swap).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        feeMode: "sponsored",
+      })
+    );
+  });
+
+  it("executes non-sponsored swap and reports the pretrade quote source", async () => {
+    const swap = vi.fn().mockResolvedValue(tx("0xabc"));
+    const getQuote = vi.fn().mockResolvedValue({
+      amountInBase: 100000000000000000n,
+      amountOutBase: 100000n,
+      provider: "avnu",
+    });
+    const wallet = {
+      address: WALLET_ADDRESS,
+      getClassHash: () => EXPECTED_CLASS_HASH,
+      getProvider: deployedProvider,
+      getQuote,
+      swap,
+    } as unknown as Wallet;
+
+    testing.setWalletSingleton(wallet);
+
+    const result = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_swap",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "0.1",
+        },
+      },
+    });
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0]?.text ?? "{}") as {
+      hash?: string;
+      amountOutRaw?: string;
+      amountOutSource?: string;
+    };
+    expect(payload.hash).toBe(
+      "0x0000000000000000000000000000000000000000000000000000000000000abc"
+    );
+    expect(payload.amountOutRaw).toBe("100000");
+    expect(payload.amountOutSource).toBe("pretrade_quote");
+    expect(getQuote).toHaveBeenCalledOnce();
+    expect(swap).toHaveBeenCalledOnce();
+    expect(swap).toHaveBeenCalledWith(expect.anything(), {});
   });
 
   it("blocks sponsored swap before submission when account class hash mismatches", async () => {

--- a/packages/mcp-server/tests/sponsored-preflight.integration.test.ts
+++ b/packages/mcp-server/tests/sponsored-preflight.integration.test.ts
@@ -1,0 +1,81 @@
+import type { Wallet } from "starkzap";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+type TestingExports = {
+  handleCallToolRequest(request: {
+    params: { name: string; arguments?: Record<string, unknown> | undefined };
+  }): Promise<{
+    content: Array<{ type: "text"; text: string }>;
+    isError?: boolean;
+  }>;
+  setWalletSingleton(value: Wallet | undefined): void;
+  resetState(): void;
+};
+
+let testing: TestingExports;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = "test";
+  process.env.STARKZAP_MCP_ENABLE_TEST_HOOKS = "1";
+  process.env.STARKZAP_MCP_TEST_KEY_MARKER =
+    "TEST_KEY_DO_NOT_USE_IN_PRODUCTION";
+  process.env.STARKNET_PRIVATE_KEY = `0x${"1".padStart(64, "0")}`;
+  process.argv = [
+    "node",
+    "sponsored-preflight.integration.test.ts",
+    "--network",
+    "sepolia",
+    "--enable-write",
+  ];
+
+  await import("../src/index.js");
+  const hooks = (globalThis as Record<string, unknown>)
+    .__STARKZAP_MCP_TESTING__;
+  if (!hooks) {
+    throw new Error("Expected __STARKZAP_MCP_TESTING__ hooks to be available");
+  }
+  testing = hooks as TestingExports;
+});
+
+beforeEach(() => {
+  testing.resetState();
+});
+
+describe("sponsored write preflight hardening", () => {
+  it("blocks sponsored transfer before submission when account class hash mismatches", async () => {
+    const transfer = vi.fn();
+    const wallet = {
+      address:
+        "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      getClassHash: () =>
+        "0x01d1777db36cdd06dd62cfde77b1b6ae06412af95d57a13dc40ac77b8a702381",
+      getProvider: () => ({
+        getClassHashAt: vi
+          .fn()
+          .mockResolvedValue(
+            "0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f"
+          ),
+      }),
+      transfer,
+    } as unknown as Wallet;
+
+    testing.setWalletSingleton(wallet);
+
+    const result = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_transfer",
+        arguments: {
+          token: "STRK",
+          transfers: [{ to: "0x1", amount: "0.1" }],
+          sponsored: true,
+        },
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text ?? "").toContain(
+      "Sponsored transfer preflight detected account class hash mismatch"
+    );
+    expect(transfer).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-server/tests/sponsored-preflight.integration.test.ts
+++ b/packages/mcp-server/tests/sponsored-preflight.integration.test.ts
@@ -26,6 +26,7 @@ beforeAll(async () => {
     "--network",
     "sepolia",
     "--enable-write",
+    "--enable-execute",
   ];
 
   await import("../src/index.js");

--- a/packages/mcp-server/tests/sponsored-preflight.integration.test.ts
+++ b/packages/mcp-server/tests/sponsored-preflight.integration.test.ts
@@ -1,5 +1,13 @@
 import type { Wallet } from "starkzap";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 type TestingExports = {
   handleCallToolRequest(request: {
@@ -13,8 +21,45 @@ type TestingExports = {
 };
 
 let testing: TestingExports;
+const originalArgv = [...process.argv];
+const originalEnv = { ...process.env };
+const originalTestingHooks = (globalThis as Record<string, unknown>)
+  .__STARKZAP_MCP_TESTING__;
+
+const WALLET_ADDRESS =
+  "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const EXPECTED_CLASS_HASH =
+  "0x01d1777db36cdd06dd62cfde77b1b6ae06412af95d57a13dc40ac77b8a702381";
+const MISMATCHED_CLASS_HASH =
+  "0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f";
+
+function undeployedProvider() {
+  return {
+    getClassHashAt: vi.fn().mockRejectedValue(new Error("Contract not found")),
+  };
+}
+
+function mismatchedProvider() {
+  return {
+    getClassHashAt: vi.fn().mockResolvedValue(MISMATCHED_CLASS_HASH),
+  };
+}
+
+function tx(hash: string) {
+  return {
+    hash,
+    wait: vi.fn().mockResolvedValue(undefined),
+    explorerUrl: `https://example.com/tx/${hash}`,
+  };
+}
 
 beforeAll(async () => {
+  vi.resetModules();
+  delete (globalThis as Record<string, unknown>).__STARKZAP_MCP_TESTING__;
+  delete process.env.STARKNET_ACCOUNT_ADDRESS;
+  delete process.env.STARKNET_STAKING_CONTRACT;
+  delete process.env.STARKNET_PAYMASTER_URL;
+  delete process.env.AVNU_PAYMASTER_API_KEY;
   process.env.NODE_ENV = "test";
   process.env.STARKZAP_MCP_ENABLE_TEST_HOOKS = "1";
   process.env.STARKZAP_MCP_TEST_KEY_MARKER =
@@ -42,21 +87,56 @@ beforeEach(() => {
   testing.resetState();
 });
 
+afterAll(() => {
+  process.argv = originalArgv;
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) {
+      delete process.env[key];
+    }
+  }
+  for (const [key, value] of Object.entries(originalEnv)) {
+    process.env[key] = value;
+  }
+  (globalThis as Record<string, unknown>).__STARKZAP_MCP_TESTING__ =
+    originalTestingHooks;
+});
+
 describe("sponsored write preflight hardening", () => {
+  it("allows sponsored transfer preflight to continue when the account is undeployed", async () => {
+    const transfer = vi.fn().mockResolvedValue(tx("0x123"));
+    const wallet = {
+      address: WALLET_ADDRESS,
+      getClassHash: () => EXPECTED_CLASS_HASH,
+      getProvider: undeployedProvider,
+      transfer,
+    } as unknown as Wallet;
+
+    testing.setWalletSingleton(wallet);
+
+    const result = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_transfer",
+        arguments: {
+          token: "STRK",
+          transfers: [{ to: "0x1", amount: "0.1" }],
+          sponsored: true,
+        },
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text ?? "").toContain(
+      "Sponsored transfer post-check succeeded but wallet account is still not deployed on-chain."
+    );
+    expect(transfer).toHaveBeenCalledOnce();
+  });
+
   it("blocks sponsored transfer before submission when account class hash mismatches", async () => {
     const transfer = vi.fn();
     const wallet = {
-      address:
-        "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-      getClassHash: () =>
-        "0x01d1777db36cdd06dd62cfde77b1b6ae06412af95d57a13dc40ac77b8a702381",
-      getProvider: () => ({
-        getClassHashAt: vi
-          .fn()
-          .mockResolvedValue(
-            "0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f"
-          ),
-      }),
+      address: WALLET_ADDRESS,
+      getClassHash: () => EXPECTED_CLASS_HASH,
+      getProvider: mismatchedProvider,
       transfer,
     } as unknown as Wallet;
 
@@ -78,5 +158,135 @@ describe("sponsored write preflight hardening", () => {
       "Sponsored transfer preflight detected account class hash mismatch"
     );
     expect(transfer).not.toHaveBeenCalled();
+  });
+
+  it("allows sponsored execute preflight to continue when the account is undeployed", async () => {
+    const execute = vi.fn().mockResolvedValue(tx("0x456"));
+    const wallet = {
+      address: WALLET_ADDRESS,
+      getClassHash: () => EXPECTED_CLASS_HASH,
+      getProvider: undeployedProvider,
+      execute,
+    } as unknown as Wallet;
+
+    testing.setWalletSingleton(wallet);
+
+    const result = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_execute",
+        arguments: {
+          calls: [{ contractAddress: "0x1", entrypoint: "transfer" }],
+          sponsored: true,
+        },
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text ?? "").toContain(
+      "Sponsored execute post-check succeeded but wallet account is still not deployed on-chain."
+    );
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it("blocks sponsored execute before submission when account class hash mismatches", async () => {
+    const execute = vi.fn();
+    const wallet = {
+      address: WALLET_ADDRESS,
+      getClassHash: () => EXPECTED_CLASS_HASH,
+      getProvider: mismatchedProvider,
+      execute,
+    } as unknown as Wallet;
+
+    testing.setWalletSingleton(wallet);
+
+    const result = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_execute",
+        arguments: {
+          calls: [{ contractAddress: "0x1", entrypoint: "transfer" }],
+          sponsored: true,
+        },
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text ?? "").toContain(
+      "Sponsored execute preflight detected account class hash mismatch"
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("allows sponsored swap preflight to continue when the account is undeployed", async () => {
+    const swap = vi.fn().mockResolvedValue(tx("0x789"));
+    const getQuote = vi.fn().mockResolvedValue({
+      amountInBase: 100000000000000000n,
+      amountOutBase: 100000n,
+      provider: "avnu",
+    });
+    const wallet = {
+      address: WALLET_ADDRESS,
+      getClassHash: () => EXPECTED_CLASS_HASH,
+      getProvider: undeployedProvider,
+      getQuote,
+      swap,
+    } as unknown as Wallet;
+
+    testing.setWalletSingleton(wallet);
+
+    const result = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_swap",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "0.1",
+          sponsored: true,
+        },
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text ?? "").toContain(
+      "Sponsored swap post-check succeeded but wallet account is still not deployed on-chain."
+    );
+    expect(getQuote).toHaveBeenCalledOnce();
+    expect(swap).toHaveBeenCalledOnce();
+  });
+
+  it("blocks sponsored swap before submission when account class hash mismatches", async () => {
+    const swap = vi.fn();
+    const getQuote = vi.fn().mockResolvedValue({
+      amountInBase: 100000000000000000n,
+      amountOutBase: 100000n,
+      provider: "avnu",
+    });
+    const wallet = {
+      address: WALLET_ADDRESS,
+      getClassHash: () => EXPECTED_CLASS_HASH,
+      getProvider: mismatchedProvider,
+      getQuote,
+      swap,
+    } as unknown as Wallet;
+
+    testing.setWalletSingleton(wallet);
+
+    const result = await testing.handleCallToolRequest({
+      params: {
+        name: "starkzap_swap",
+        arguments: {
+          tokenIn: "STRK",
+          tokenOut: "USDC",
+          amountIn: "0.1",
+          sponsored: true,
+        },
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text ?? "").toContain(
+      "Sponsored swap preflight detected account class hash mismatch"
+    );
+    expect(getQuote).toHaveBeenCalledOnce();
+    expect(swap).not.toHaveBeenCalled();
   });
 });

--- a/packages/mcp-server/tests/sponsored-preflight.integration.test.ts
+++ b/packages/mcp-server/tests/sponsored-preflight.integration.test.ts
@@ -19,7 +19,7 @@ beforeAll(async () => {
   process.env.STARKZAP_MCP_ENABLE_TEST_HOOKS = "1";
   process.env.STARKZAP_MCP_TEST_KEY_MARKER =
     "TEST_KEY_DO_NOT_USE_IN_PRODUCTION";
-  process.env.STARKNET_PRIVATE_KEY = `0x${"1".padStart(64, "0")}`;
+  process.env.STARKNET_PRIVATE_KEY = "0x1";
   process.argv = [
     "node",
     "sponsored-preflight.integration.test.ts",

--- a/packages/mcp-server/tsup.config.ts
+++ b/packages/mcp-server/tsup.config.ts
@@ -4,8 +4,9 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm"],
   dts: true,
-  // Bundle StarkZap SDK to keep runtime resolution deterministic for npx usage.
-  noExternal: ["starkzap"],
+  // Keep runtime dependencies external. Bundling StarkZap pulls websocket
+  // internals into the ESM artifact and breaks Node startup on real MCP runs.
+  platform: "node",
   target: "es2020",
   clean: true,
 });

--- a/packages/mcp-server/tsup.config.ts
+++ b/packages/mcp-server/tsup.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
   dts: true,
   // Keep runtime dependencies external. Bundling StarkZap pulls websocket
   // internals into the ESM artifact and breaks Node startup on real MCP runs.
+  noExternal: ["starkzap"],
   platform: "node",
   target: "es2020",
+  skipNodeModulesBundle: true,
   clean: true,
 });


### PR DESCRIPTION
## Summary

Expands StarkZap MCP execution parity with swap and batch balance tools, plus security hardening from prior MCP review feedback patterns.

### Added MCP tools
- `starkzap_get_balances`
- `starkzap_get_quote`
- `starkzap_swap`
- `starkzap_build_swap_calls`

### Hardening included in this PR
- Enforce strict schemas for the new swap/get-balances inputs (reject unknown keys).
- Add token/provider input bounds and provider format validation.
- Add same-token swap protections:
  - schema-level guard for obvious same-token inputs
  - runtime guard after token resolution (covers symbol/address equivalence)
- Keep schema parity checks compatible with refined schemas (`ZodEffects` unwrap).

## Why

This is the first scoped step for issue #80 (SDK -> MCP -> CLI parity), while keeping scope reviewable and production-safe.

## Validation

Ran in `packages/mcp-server`:
- `npm run typecheck`
- `npm run test`

Result: `84/84` tests passing.

## Files

- `packages/mcp-server/src/core.ts`
- `packages/mcp-server/src/index.ts`
- `packages/mcp-server/tests/core.test.ts`
- `packages/mcp-server/tests/index.integration.test.ts`
- `packages/mcp-server/README.md`

Refs #80
