### PR TITLE
fix: trim and validate network string input

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,7 +1,7 @@
 import { RpcProvider, type Call, type PaymasterTimeBounds } from "starknet";
 import { ChainId, getChainId, type SDKConfig } from "@/types/config";
 import type { ConnectWalletOptions, FeeMode } from "@/types/wallet";
-import { networks, type NetworkPreset } from "@/network";
+import { networks, type NetworkPreset, type NetworkName } from "@/network";
 import { Wallet } from "@/wallet";
 import type { WalletInterface } from "@/wallet/interface";
 import type { Address, Token, Pool } from "@/types";
@@ -93,10 +93,17 @@ export class StarkZap {
     // Get network preset if specified
     let networkPreset: NetworkPreset | undefined;
     if (config.network) {
-      networkPreset =
-        typeof config.network === "string"
-          ? networks[config.network]
-          : config.network;
+      if (typeof config.network === "string") {
+        const trimmed = config.network.trim() as NetworkName;
+        networkPreset = networks[trimmed];
+        if (!networkPreset) {
+          throw new Error(
+            `Invalid network "${config.network.replace(/\s/g, "\\n")}". Valid options: ${Object.keys(networks).join(", ")}`
+          );
+        }
+      } else {
+        networkPreset = config.network;
+      }
     }
 
     // Resolve rpcUrl (explicit > network preset)


### PR DESCRIPTION
## Problem

Network strings with trailing whitespace (e.g. `"sepolia\n"` from environment variables) cause a misleading error:

```
StarkZap requires either 'network' or 'rpcUrl' to be specified
```

The network **was** specified — it just has a trailing newline. `networks["sepolia\n"]` returns `undefined`, and the error then claims network wasn't provided at all.

This is common when env vars are copy-pasted from dashboards (Vercel, Railway) that sometimes include trailing whitespace.

## Fix

1. `.trim()` the network string before lookup
2. If the trimmed string doesn't match a valid network, throw a descriptive error listing valid options:
   ```
   Invalid network "sepolia\n". Valid options: mainnet, sepolia, devnet
   ```

## Context

Found while building [Zapp](https://github.com/owizdom/zap) (28 SDK modules used). Lost hours debugging this before spotting raw `\n` bytes in a Vercel env var.

Closes #89