### PR TITLE
Simplify bridge module

### DIFF
--- a/src/bridge/ethereum/EthereumBridge.ts
+++ b/src/bridge/ethereum/EthereumBridge.ts
@@ -102,11 +102,10 @@ export abstract class EthereumBridge implements BridgeInterface<EthereumAddress>
 
   protected async getEthereumGasPrice(): Promise<bigint> {
     const gasData = await this.config.provider.getFeeData();
-    const gasPrice = gasData.gasPrice ?? 0n;
     const maxFeePerGas = gasData.maxFeePerGas;
-    return maxFeePerGas && gasData.maxPriorityFeePerGas
+    return maxFeePerGas != null && gasData.maxPriorityFeePerGas != null
       ? maxFeePerGas
-      : gasPrice;
+      : (gasData.gasPrice ?? 0n);
   }
 
   protected async approveSpendingOf(amount: Amount): Promise<void> {

--- a/tests/provider-assert.test.ts
+++ b/tests/provider-assert.test.ts
@@ -4,9 +4,7 @@ import { assertPreparedCalls } from "@/providers/assert";
 describe("assertPreparedCalls", () => {
   it("does not throw when calls array is non-empty", () => {
     const calls = [{ contractAddress: "0x1", entrypoint: "transfer" }];
-    expect(() =>
-      assertPreparedCalls(calls, "DCA", "avnu")
-    ).not.toThrow();
+    expect(() => assertPreparedCalls(calls, "DCA", "avnu")).not.toThrow();
   });
 
   it("throws when calls array is empty", () => {

--- a/tests/url.test.ts
+++ b/tests/url.test.ts
@@ -43,9 +43,9 @@ describe("assertSafeHttpUrl", () => {
   });
 
   it("throws on javascript protocol", () => {
-    expect(() =>
-      assertSafeHttpUrl("javascript:alert(1)", "explorer")
-    ).toThrow("explorer must use http:// or https://");
+    expect(() => assertSafeHttpUrl("javascript:alert(1)", "explorer")).toThrow(
+      "explorer must use http:// or https://"
+    );
   });
 
   it("throws on data URI", () => {


### PR DESCRIPTION
## Summary
- Move `getEthereumGasPrice()` from abstract to a default implementation in `EthereumBridge` base class, eliminating identical duplicates in `CanonicalEthereumBridge` and `OftBridge`
- `CCTPBridge` keeps its `override` with simpler fallback logic
- Inline `CCTPFees.getFees()` (which just delegated to `fetchFees()`) and simplify `getMinimumFeeBps` with optional chaining
- Simplify `EtherToken.amount()` to use inline constants instead of async self-calls
- Simplify `ERC20EthereumToken.getContract()` from if/else to ternary

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (505 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)