### PR TITLE
feat: add gasToken option to execute and deploy

### DIFF
--- a/examples/flappy-bird/starknet.ts
+++ b/examples/flappy-bird/starknet.ts
@@ -70,7 +70,7 @@ async function executeGameCall(
   calldata: Calldata = []
 ): Promise<void> {
   if (!wallet) return;
-  const feeMode = useUserPaysForSession ? "user_pays" : "sponsored";
+  const feeMode = useUserPaysForSession ? ("user_pays" as const) : ({ type: "paymaster" } as const);
   try {
     await wallet.execute(
       [

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1413,8 +1413,8 @@ async function handleTool(
         maxBatchAmount
       );
 
-      const feeMode: "sponsored" | undefined = parsed.sponsored
-        ? "sponsored"
+      const feeMode = parsed.sponsored
+        ? ({ type: "paymaster" } as const)
         : undefined;
       const tx = await withTimeout("Token transfer submission", () =>
         wallet.transfer(token, transfers, {
@@ -1422,7 +1422,7 @@ async function handleTool(
         })
       );
       const txResult = await waitForTrackedTransaction(tx);
-      if (feeMode === "sponsored") {
+      if (feeMode) {
         await assertWalletAccountClassHash(
           wallet,
           "Sponsored transfer post-check"
@@ -1451,8 +1451,8 @@ async function handleTool(
         entrypoint: call.entrypoint,
         calldata: call.calldata ?? [],
       }));
-      const feeMode: "sponsored" | undefined = parsed.sponsored
-        ? "sponsored"
+      const feeMode = parsed.sponsored
+        ? ({ type: "paymaster" } as const)
         : undefined;
       const tx = await withTimeout("Contract execution submission", () =>
         wallet.execute(calls, {
@@ -1460,7 +1460,7 @@ async function handleTool(
         })
       );
       const txResult = await waitForTrackedTransaction(tx);
-      if (feeMode === "sponsored") {
+      if (feeMode) {
         await assertWalletAccountClassHash(
           wallet,
           "Sponsored execute post-check"
@@ -1501,8 +1501,8 @@ async function handleTool(
           address: wallet.address,
         });
       }
-      const feeMode: "sponsored" | undefined = parsed.sponsored
-        ? "sponsored"
+      const feeMode = parsed.sponsored
+        ? ({ type: "paymaster" } as const)
         : undefined;
       const tx = await withTimeout("Account deployment submission", () =>
         wallet.deploy({

--- a/packages/native/src/wallet/cartridge.ts
+++ b/packages/native/src/wallet/cartridge.ts
@@ -74,7 +74,18 @@ function unsupportedUserPaysMessage(): string {
   return 'Cartridge wallet currently supports sponsored session execution only. Use feeMode: { type: "paymaster" }.';
 }
 
-export type SupportedNativeCartridgeFeeMode = Exclude<FeeMode, "user_pays">;
+function unsupportedGasTokenMessage(): string {
+  return 'Cartridge wallet does not support gasToken. Use feeMode: { type: "paymaster" } without gasToken.';
+}
+
+/**
+ * Fee modes supported by native Cartridge sessions.
+ * Only sponsored execution is supported — `gasToken` is not available.
+ */
+export type SupportedNativeCartridgeFeeMode =
+  | "sponsored"
+  | { type: "paymaster" };
+
 type UniversalDetailsWithTimeBounds = UniversalDetails & {
   timeBounds?: PaymasterTimeBounds;
 };
@@ -82,14 +93,18 @@ type UniversalDetailsWithTimeBounds = UniversalDetails & {
 export function validateSupportedCartridgeFeeMode(
   feeMode?: FeeMode
 ): SupportedNativeCartridgeFeeMode | undefined {
-  if (
-    feeMode === undefined ||
-    feeMode === "sponsored" ||
-    (typeof feeMode === "object" &&
-      feeMode !== null &&
-      feeMode.type === "paymaster")
-  ) {
+  if (feeMode === undefined || feeMode === "sponsored") {
     return feeMode;
+  }
+  if (
+    typeof feeMode === "object" &&
+    feeMode !== null &&
+    feeMode.type === "paymaster"
+  ) {
+    if (feeMode.gasToken) {
+      throw new Error(unsupportedGasTokenMessage());
+    }
+    return { type: "paymaster" };
   }
 
   throw new Error(unsupportedUserPaysMessage());

--- a/packages/native/src/wallet/cartridge.ts
+++ b/packages/native/src/wallet/cartridge.ts
@@ -71,10 +71,10 @@ function unsupportedSessionFeature(feature: string): Error {
 }
 
 function unsupportedUserPaysMessage(): string {
-  return 'Cartridge wallet currently supports sponsored session execution only. Use feeMode: "sponsored".';
+  return 'Cartridge wallet currently supports sponsored session execution only. Use feeMode: { type: "paymaster" }.';
 }
 
-export type SupportedNativeCartridgeFeeMode = Extract<FeeMode, "sponsored">;
+export type SupportedNativeCartridgeFeeMode = Exclude<FeeMode, "user_pays">;
 type UniversalDetailsWithTimeBounds = UniversalDetails & {
   timeBounds?: PaymasterTimeBounds;
 };
@@ -82,7 +82,13 @@ type UniversalDetailsWithTimeBounds = UniversalDetails & {
 export function validateSupportedCartridgeFeeMode(
   feeMode?: FeeMode
 ): SupportedNativeCartridgeFeeMode | undefined {
-  if (feeMode === undefined || feeMode === "sponsored") {
+  if (
+    feeMode === undefined ||
+    feeMode === "sponsored" ||
+    (typeof feeMode === "object" &&
+      feeMode !== null &&
+      feeMode.type === "paymaster")
+  ) {
     return feeMode;
   }
 
@@ -273,7 +279,7 @@ export class NativeCartridgeWallet extends BaseWallet {
     this.chainId = options.chainId;
     this.classHash = options.classHash;
     this.explorerConfig = options.explorer;
-    this.defaultFeeMode = options.feeMode ?? "sponsored";
+    this.defaultFeeMode = options.feeMode ?? { type: "paymaster" };
     this.defaultTimeBounds = options.timeBounds;
     this.account = new NativeCartridgeAccount({
       session: options.session,
@@ -285,8 +291,9 @@ export class NativeCartridgeWallet extends BaseWallet {
   static async create(
     options: NativeCartridgeWalletOptions
   ): Promise<NativeCartridgeWallet> {
-    const feeMode =
-      validateSupportedCartridgeFeeMode(options.feeMode) ?? "sponsored";
+    const feeMode = validateSupportedCartridgeFeeMode(options.feeMode) ?? {
+      type: "paymaster",
+    };
     let classHash: string | undefined;
     try {
       classHash = await options.provider.getClassHashAt(
@@ -301,7 +308,7 @@ export class NativeCartridgeWallet extends BaseWallet {
     return new NativeCartridgeWallet({
       ...options,
       ...(classHash !== undefined && { classHash }),
-      ...(feeMode && { feeMode }),
+      feeMode,
     });
   }
 
@@ -358,7 +365,7 @@ export class NativeCartridgeWallet extends BaseWallet {
 
   async execute(calls: Call[], options: ExecuteOptions = {}): Promise<Tx> {
     const feeMode = options.feeMode ?? this.defaultFeeMode;
-    if (feeMode !== "sponsored") {
+    if (feeMode === "user_pays") {
       throw new Error(unsupportedUserPaysMessage());
     }
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
@@ -384,7 +391,7 @@ export class NativeCartridgeWallet extends BaseWallet {
 
   async preflight(options: PreflightOptions): Promise<PreflightResult> {
     const feeMode = options.feeMode ?? this.defaultFeeMode;
-    if (feeMode !== "sponsored") {
+    if (feeMode === "user_pays") {
       return { ok: false, reason: unsupportedUserPaysMessage() };
     }
     const simulate = this.session.account.simulateTransaction;

--- a/packages/native/tests/native-cartridge-wallet.test.ts
+++ b/packages/native/tests/native-cartridge-wallet.test.ts
@@ -49,11 +49,11 @@ describe("NativeCartridgeWallet", () => {
     });
 
     const tx = await wallet.execute([{ contractAddress: "0x1" } as Call], {
-      feeMode: "sponsored",
+      feeMode: { type: "paymaster" },
     });
 
     expect(tx.hash).toBe("0xfeed");
-    expect(wallet.getFeeMode()).toBe("sponsored");
+    expect(wallet.getFeeMode()).toEqual({ type: "paymaster" });
     expect(session.account.execute).toHaveBeenCalledTimes(1);
     expect(wallet.getAccount()).toBeInstanceOf(Account);
   });
@@ -72,7 +72,7 @@ describe("NativeCartridgeWallet", () => {
 
     const err = await wallet
       .execute([{ contractAddress: "0x1" } as Call], {
-        feeMode: "sponsored",
+        feeMode: { type: "paymaster" },
       })
       .then(
         () => {
@@ -124,7 +124,7 @@ describe("NativeCartridgeWallet", () => {
   });
 
   it("rejects unsupported default fee mode during creation", async () => {
-    const unsupportedFeeMode = "user_pays" as unknown as "sponsored";
+    const unsupportedFeeMode = "user_pays" as const;
 
     await expect(
       NativeCartridgeWallet.create({
@@ -185,7 +185,7 @@ describe("NativeCartridgeWallet", () => {
 
     await expect(
       wallet.execute([{ contractAddress: "0x1" } as Call], {
-        feeMode: "sponsored",
+        feeMode: { type: "paymaster" },
       })
     ).resolves.toMatchObject({ hash: "0xfeed" });
 
@@ -228,7 +228,7 @@ describe("NativeCartridgeWallet", () => {
     await expect(
       wallet.preflight({
         calls: [{ contractAddress: "0x1" } as Call],
-        feeMode: "sponsored",
+        feeMode: { type: "paymaster" },
       })
     ).resolves.toEqual({
       ok: true,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -229,7 +229,7 @@ export class StarkZap {
    * // With sponsored transactions
    * const wallet = await sdk.connectWallet({
    *   account: { signer: new StarkSigner(privateKey) },
-   *   feeMode: "sponsored",
+   *   feeMode: { type: "paymaster" },
    * });
    * ```
    */

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -223,6 +223,13 @@ export interface PreflightOptions {
    * because the paymaster path can deploy + execute atomically.
    */
   feeMode?: FeeMode;
+  /**
+   * ERC-20 token contract address used to pay gas fees via the paymaster.
+   *
+   * When set and the account is undeployed, preflight returns `{ ok: true }`
+   * because the paymaster path handles deployment atomically.
+   */
+  gasToken?: Address;
 }
 
 /** Preflight succeeded — operation can proceed */

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -74,7 +74,12 @@ export interface AccountConfig {
 export type FeeMode =
   | "user_pays"
   | { type: "paymaster"; gasToken?: Address }
-  | "sponsored";
+  | DeprecatedSponsoredFeeMode;
+
+/**
+ * @deprecated Use `{ type: "paymaster" }` instead.
+ */
+type DeprecatedSponsoredFeeMode = "sponsored";
 
 // ─── Provider Options ────────────────────────────────────────────────────────
 

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -65,10 +65,16 @@ export interface AccountConfig {
 
 /**
  * How transaction fees are paid.
- * - `"sponsored"`: Paymaster covers gas
- * - `"user_pays"`: User's account pays gas in ETH/STRK
+ *
+ * - `"user_pays"` — User's account pays gas in ETH/STRK
+ * - `{ type: "paymaster" }` — Paymaster covers gas (sponsored)
+ * - `{ type: "paymaster", gasToken: "0x..." }` — Pay gas via ERC-20 through paymaster
+ * - `"sponsored"` — *(deprecated)* Alias for `{ type: "paymaster" }`
  */
-export type FeeMode = "sponsored" | "user_pays";
+export type FeeMode =
+  | "user_pays"
+  | { type: "paymaster"; gasToken?: Address }
+  | "sponsored";
 
 // ─── Provider Options ────────────────────────────────────────────────────────
 
@@ -109,7 +115,7 @@ export interface ProviderOptions {
  * // Sponsored via AVNU paymaster
  * await sdk.connectWallet({
  *   account: { signer: new StarkSigner(privateKey) },
- *   feeMode: "sponsored",
+ *   feeMode: { type: "paymaster" },
  * });
  * ```
  */
@@ -154,7 +160,7 @@ export interface ProgressEvent {
  * ```ts
  * await wallet.ensureReady({
  *   deploy: "if_needed",
- *   feeMode: "sponsored",
+ *   feeMode: { type: "paymaster" },
  *   onProgress: (e) => console.log(e.step)
  * });
  * ```
@@ -164,11 +170,6 @@ export interface EnsureReadyOptions {
   deploy?: DeployMode;
   /** How to pay for deployment if needed (default: wallet's default) */
   feeMode?: FeeMode;
-  /**
-   * ERC-20 token contract address used to pay deployment gas fees.
-   * @see {@link TransactionFeeOptions.gasToken}
-   */
-  gasToken?: Address;
   /** Callback for progress updates */
   onProgress?: (event: ProgressEvent) => void;
 }
@@ -181,20 +182,6 @@ interface TransactionFeeOptions {
   feeMode?: FeeMode;
   /** Optional time bounds for paymaster transactions */
   timeBounds?: PaymasterTimeBounds;
-  /**
-   * ERC-20 token contract address used to pay gas fees via the paymaster.
-   *
-   * When set, the transaction uses the paymaster with
-   * `{ mode: 'default', gasToken }` instead of full sponsorship.
-   * The user pays gas in the specified token (e.g. the USDC or STRK contract address).
-   *
-   * Requires a paymaster to be configured in the SDK.
-   *
-   * @remarks
-   * - Omit `feeMode` when using `gasToken` (recommended happy path).
-   * - Combining `feeMode: "user_pays"` with `gasToken` throws an error.
-   */
-  gasToken?: Address;
 }
 
 // ─── Deploy ──────────────────────────────────────────────────────────────────
@@ -219,17 +206,14 @@ export interface PreflightOptions {
   /**
    * Fee mode used for preflight assumptions.
    *
-   * When `"sponsored"` and the account is undeployed, preflight returns `{ ok: true }`
+   * When using a paymaster mode (`{ type: "paymaster" }` — with or without
+   * `gasToken`) and the account is undeployed, preflight returns `{ ok: true }`
    * because the paymaster path can deploy + execute atomically.
+   *
+   * The `gasToken` field only affects which token is used for fee payment;
+   * it does not change the preflight deployment decision.
    */
   feeMode?: FeeMode;
-  /**
-   * ERC-20 token contract address used to pay gas fees via the paymaster.
-   *
-   * When set and the account is undeployed, preflight returns `{ ok: true }`
-   * because the paymaster path handles deployment atomically.
-   */
-  gasToken?: Address;
 }
 
 /** Preflight succeeded — operation can proceed */

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -164,49 +164,48 @@ export interface EnsureReadyOptions {
   deploy?: DeployMode;
   /** How to pay for deployment if needed (default: wallet's default) */
   feeMode?: FeeMode;
+  /**
+   * ERC-20 token contract address used to pay deployment gas fees.
+   * @see {@link TransactionFeeOptions.gasToken}
+   */
+  gasToken?: Address;
   /** Callback for progress updates */
   onProgress?: (event: ProgressEvent) => void;
+}
+
+// ─── Transaction Fee Options ─────────────────────────────────────────────────
+
+/** Common fee options shared by deploy and execute operations. */
+interface TransactionFeeOptions {
+  /** How fees are paid (default: "user_pays") */
+  feeMode?: FeeMode;
+  /** Optional time bounds for paymaster transactions */
+  timeBounds?: PaymasterTimeBounds;
+  /**
+   * ERC-20 token contract address used to pay gas fees via the paymaster.
+   *
+   * When set, the transaction uses the paymaster with
+   * `{ mode: 'default', gasToken }` instead of full sponsorship.
+   * The user pays gas in the specified token (e.g. the USDC or STRK contract address).
+   *
+   * Requires a paymaster to be configured in the SDK.
+   *
+   * @remarks
+   * - Omit `feeMode` when using `gasToken` (recommended happy path).
+   * - Combining `feeMode: "user_pays"` with `gasToken` throws an error.
+   */
+  gasToken?: Address;
 }
 
 // ─── Deploy ──────────────────────────────────────────────────────────────────
 
 /** Options for `wallet.deploy()` */
-export interface DeployOptions {
-  /** How fees are paid (default: "user_pays") */
-  feeMode?: FeeMode;
-  /** Optional time bounds for paymaster-sponsored deployment */
-  timeBounds?: PaymasterTimeBounds;
-  /**
-   * ERC-20 token address used to pay gas fees via the paymaster.
-   *
-   * When set, the transaction uses the paymaster with
-   * `{ mode: 'default', gasToken }` instead of full sponsorship.
-   * The user pays gas in the specified token (e.g. USDC, STRK).
-   *
-   * Requires a paymaster to be configured in the SDK.
-   */
-  gasToken?: Address;
-}
+export type DeployOptions = TransactionFeeOptions;
 
 // ─── Execute ─────────────────────────────────────────────────────────────────
 
 /** Options for `wallet.execute()` */
-export interface ExecuteOptions {
-  /** How fees are paid */
-  feeMode?: FeeMode;
-  /** Optional time bounds for paymaster transactions */
-  timeBounds?: PaymasterTimeBounds;
-  /**
-   * ERC-20 token address used to pay gas fees via the paymaster.
-   *
-   * When set, the transaction uses the paymaster with
-   * `{ mode: 'default', gasToken }` instead of full sponsorship.
-   * The user pays gas in the specified token (e.g. USDC, STRK).
-   *
-   * Requires a paymaster to be configured in the SDK.
-   */
-  gasToken?: Address;
-}
+export type ExecuteOptions = TransactionFeeOptions;
 
 // ─── Preflight ───────────────────────────────────────────────────────────────
 

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -176,6 +176,16 @@ export interface DeployOptions {
   feeMode?: FeeMode;
   /** Optional time bounds for paymaster-sponsored deployment */
   timeBounds?: PaymasterTimeBounds;
+  /**
+   * ERC-20 token address used to pay gas fees via the paymaster.
+   *
+   * When set, the transaction uses the paymaster with
+   * `{ mode: 'default', gasToken }` instead of full sponsorship.
+   * The user pays gas in the specified token (e.g. USDC, STRK).
+   *
+   * Requires a paymaster to be configured in the SDK.
+   */
+  gasToken?: Address;
 }
 
 // ─── Execute ─────────────────────────────────────────────────────────────────
@@ -186,6 +196,16 @@ export interface ExecuteOptions {
   feeMode?: FeeMode;
   /** Optional time bounds for paymaster transactions */
   timeBounds?: PaymasterTimeBounds;
+  /**
+   * ERC-20 token address used to pay gas fees via the paymaster.
+   *
+   * When set, the transaction uses the paymaster with
+   * `{ mode: 'default', gasToken }` instead of full sponsorship.
+   * The user pays gas in the specified token (e.g. USDC, STRK).
+   *
+   * Requires a paymaster to be configured in the SDK.
+   */
+  gasToken?: Address;
 }
 
 // ─── Preflight ───────────────────────────────────────────────────────────────

--- a/src/wallet/cartridge.ts
+++ b/src/wallet/cartridge.ts
@@ -22,9 +22,9 @@ import {
   type StakingConfig,
 } from "@/types";
 import {
-  assertNoGasTokenConflict,
   checkDeployed,
   ensureWalletReady,
+  normalizeFeeMode,
   paymasterDetails,
   preflightTransaction,
 } from "@/wallet/utils";
@@ -286,11 +286,7 @@ export class CartridgeWallet extends BaseWallet {
   }
 
   async deploy(options: DeployOptions = {}): Promise<Tx> {
-    if (
-      options.feeMode !== undefined ||
-      options.timeBounds !== undefined ||
-      options.gasToken !== undefined
-    ) {
+    if (options.feeMode !== undefined || options.timeBounds !== undefined) {
       throw new Error(
         "CartridgeWallet.deploy() does not support DeployOptions overrides; deployment mode is controlled by Cartridge Controller."
       );
@@ -312,22 +308,18 @@ export class CartridgeWallet extends BaseWallet {
   }
 
   async execute(calls: Call[], options: ExecuteOptions = {}): Promise<Tx> {
-    const requestedFeeMode = options.feeMode;
-    const feeMode = requestedFeeMode ?? this.defaultFeeMode;
+    const feeMode = normalizeFeeMode(options.feeMode ?? this.defaultFeeMode);
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
-    const gasToken = options.gasToken;
-
-    assertNoGasTokenConflict(requestedFeeMode, gasToken);
 
     let transaction_hash: string;
 
-    if (feeMode === "sponsored" || gasToken) {
+    if (feeMode !== "user_pays") {
       // Allow provider/controller implementations to handle undeployed accounts
       // atomically via paymaster flow when supported.
       transaction_hash = (
         await this.walletAccount.executePaymasterTransaction(
           calls,
-          paymasterDetails({ timeBounds, gasToken })
+          paymasterDetails({ feeMode, timeBounds })
         )
       ).transaction_hash;
     } else {

--- a/src/wallet/cartridge.ts
+++ b/src/wallet/cartridge.ts
@@ -309,16 +309,17 @@ export class CartridgeWallet extends BaseWallet {
   async execute(calls: Call[], options: ExecuteOptions = {}): Promise<Tx> {
     const feeMode = options.feeMode ?? this.defaultFeeMode;
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
+    const gasToken = options.gasToken;
 
     let transaction_hash: string;
 
-    if (feeMode === "sponsored") {
+    if (feeMode === "sponsored" || gasToken) {
       // Allow provider/controller implementations to handle undeployed accounts
       // atomically via paymaster flow when supported.
       transaction_hash = (
         await this.walletAccount.executePaymasterTransaction(
           calls,
-          sponsoredDetails(timeBounds)
+          sponsoredDetails(timeBounds, undefined, gasToken)
         )
       ).transaction_hash;
     } else {

--- a/src/wallet/cartridge.ts
+++ b/src/wallet/cartridge.ts
@@ -285,7 +285,11 @@ export class CartridgeWallet extends BaseWallet {
   }
 
   async deploy(options: DeployOptions = {}): Promise<Tx> {
-    if (options.feeMode !== undefined || options.timeBounds !== undefined) {
+    if (
+      options.feeMode !== undefined ||
+      options.timeBounds !== undefined ||
+      options.gasToken !== undefined
+    ) {
       throw new Error(
         "CartridgeWallet.deploy() does not support DeployOptions overrides; deployment mode is controlled by Cartridge Controller."
       );

--- a/src/wallet/cartridge.ts
+++ b/src/wallet/cartridge.ts
@@ -22,10 +22,11 @@ import {
   type StakingConfig,
 } from "@/types";
 import {
+  assertNoGasTokenConflict,
   checkDeployed,
   ensureWalletReady,
+  paymasterDetails,
   preflightTransaction,
-  sponsoredDetails,
 } from "@/wallet/utils";
 import { BaseWallet } from "@/wallet/base";
 import { assertSafeHttpUrl } from "@/utils";
@@ -311,9 +312,12 @@ export class CartridgeWallet extends BaseWallet {
   }
 
   async execute(calls: Call[], options: ExecuteOptions = {}): Promise<Tx> {
-    const feeMode = options.feeMode ?? this.defaultFeeMode;
+    const requestedFeeMode = options.feeMode;
+    const feeMode = requestedFeeMode ?? this.defaultFeeMode;
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
     const gasToken = options.gasToken;
+
+    assertNoGasTokenConflict(requestedFeeMode, gasToken);
 
     let transaction_hash: string;
 
@@ -323,7 +327,7 @@ export class CartridgeWallet extends BaseWallet {
       transaction_hash = (
         await this.walletAccount.executePaymasterTransaction(
           calls,
-          sponsoredDetails(timeBounds, undefined, gasToken)
+          paymasterDetails({ timeBounds, gasToken })
         )
       ).transaction_hash;
     } else {

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -29,10 +29,11 @@ import type {
   StakingConfig,
 } from "@/types";
 import {
+  assertNoGasTokenConflict,
   checkDeployed,
   ensureWalletReady,
+  paymasterDetails,
   preflightTransaction,
-  sponsoredDetails,
 } from "@/wallet/utils";
 import type { WalletInterface } from "@/wallet/interface";
 import { BaseWallet } from "@/wallet/base";
@@ -290,9 +291,7 @@ export class Wallet extends BaseWallet {
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
     const gasToken = options.gasToken;
 
-    if (requestedFeeMode === "user_pays" && gasToken) {
-      Wallet.throwGasTokenConflict();
-    }
+    assertNoGasTokenConflict(requestedFeeMode, gasToken);
 
     if (feeMode === "sponsored" || gasToken) {
       return this.deployPaymasterWith([], timeBounds, gasToken);
@@ -374,11 +373,11 @@ export class Wallet extends BaseWallet {
     const deploymentData = await this.accountProvider.getDeploymentData();
     const { transaction_hash } = await this.account.executePaymasterTransaction(
       calls,
-      sponsoredDetails(
-        timeBounds ?? this.defaultTimeBounds,
+      paymasterDetails({
+        timeBounds: timeBounds ?? this.defaultTimeBounds,
         deploymentData,
-        gasToken
-      )
+        gasToken,
+      })
     );
     return new Tx(
       transaction_hash,
@@ -480,11 +479,11 @@ export class Wallet extends BaseWallet {
       : await ozProvider.getDeploymentData();
     const { transaction_hash } = await ozAccount.executePaymasterTransaction(
       allCalls,
-      sponsoredDetails(
-        timeBounds ?? this.defaultTimeBounds,
-        ozDeploymentData,
-        gasToken
-      )
+      paymasterDetails({
+        timeBounds: timeBounds ?? this.defaultTimeBounds,
+        deploymentData: ozDeploymentData,
+        gasToken,
+      })
     );
 
     return new Tx(
@@ -501,9 +500,7 @@ export class Wallet extends BaseWallet {
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
     const gasToken = options.gasToken;
 
-    if (requestedFeeMode === "user_pays" && gasToken) {
-      Wallet.throwGasTokenConflict();
-    }
+    assertNoGasTokenConflict(requestedFeeMode, gasToken);
 
     const transactionHash =
       feeMode === "sponsored" || gasToken
@@ -536,7 +533,7 @@ export class Wallet extends BaseWallet {
     return this.account
       .executePaymasterTransaction(
         calls,
-        sponsoredDetails(timeBounds, undefined, gasToken)
+        paymasterDetails({ timeBounds, gasToken })
       )
       .then((r) => r.transaction_hash);
   }
@@ -567,13 +564,6 @@ export class Wallet extends BaseWallet {
 
   async signMessage(typedData: TypedData): Promise<Signature> {
     return this.account.signMessage(typedData);
-  }
-
-  private static throwGasTokenConflict(): never {
-    throw new Error(
-      "Cannot combine feeMode 'user_pays' with gasToken. " +
-        "Use feeMode 'sponsored' or omit feeMode when paying with an ERC-20 token."
-    );
   }
 
   async preflight(options: PreflightOptions): Promise<PreflightResult> {

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -287,9 +287,10 @@ export class Wallet extends BaseWallet {
     this.clearDeploymentCache();
     const feeMode = options.feeMode ?? this.defaultFeeMode;
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
+    const gasToken = options.gasToken;
 
-    if (feeMode === "sponsored") {
-      return this.deployPaymasterWith([], timeBounds);
+    if (feeMode === "sponsored" || gasToken) {
+      return this.deployPaymasterWith([], timeBounds, gasToken);
     }
 
     const classHash = this.accountProvider.getClassHash();

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -285,11 +285,12 @@ export class Wallet extends BaseWallet {
 
   async deploy(options: DeployOptions = {}): Promise<Tx> {
     this.clearDeploymentCache();
-    const feeMode = options.feeMode ?? this.defaultFeeMode;
+    const requestedFeeMode = options.feeMode;
+    const feeMode = requestedFeeMode ?? this.defaultFeeMode;
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
     const gasToken = options.gasToken;
 
-    if (feeMode === "user_pays" && gasToken) {
+    if (requestedFeeMode === "user_pays" && gasToken) {
       throw new Error(
         "Cannot combine feeMode 'user_pays' with gasToken. " +
           "Use feeMode 'sponsored' or omit feeMode when paying with an ERC-20 token."
@@ -498,11 +499,12 @@ export class Wallet extends BaseWallet {
   }
 
   async execute(calls: Call[], options: ExecuteOptions = {}): Promise<Tx> {
-    const feeMode = options.feeMode ?? this.defaultFeeMode;
+    const requestedFeeMode = options.feeMode;
+    const feeMode = requestedFeeMode ?? this.defaultFeeMode;
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
     const gasToken = options.gasToken;
 
-    if (feeMode === "user_pays" && gasToken) {
+    if (requestedFeeMode === "user_pays" && gasToken) {
       throw new Error(
         "Cannot combine feeMode 'user_pays' with gasToken. " +
           "Use feeMode 'sponsored' or omit feeMode when paying with an ERC-20 token."

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -291,10 +291,7 @@ export class Wallet extends BaseWallet {
     const gasToken = options.gasToken;
 
     if (requestedFeeMode === "user_pays" && gasToken) {
-      throw new Error(
-        "Cannot combine feeMode 'user_pays' with gasToken. " +
-          "Use feeMode 'sponsored' or omit feeMode when paying with an ERC-20 token."
-      );
+      Wallet.throwGasTokenConflict();
     }
 
     if (feeMode === "sponsored" || gasToken) {
@@ -505,10 +502,7 @@ export class Wallet extends BaseWallet {
     const gasToken = options.gasToken;
 
     if (requestedFeeMode === "user_pays" && gasToken) {
-      throw new Error(
-        "Cannot combine feeMode 'user_pays' with gasToken. " +
-          "Use feeMode 'sponsored' or omit feeMode when paying with an ERC-20 token."
-      );
+      Wallet.throwGasTokenConflict();
     }
 
     const transactionHash =
@@ -573,6 +567,13 @@ export class Wallet extends BaseWallet {
 
   async signMessage(typedData: TypedData): Promise<Signature> {
     return this.account.signMessage(typedData);
+  }
+
+  private static throwGasTokenConflict(): never {
+    throw new Error(
+      "Cannot combine feeMode 'user_pays' with gasToken. " +
+        "Use feeMode 'sponsored' or omit feeMode when paying with an ERC-20 token."
+    );
   }
 
   async preflight(options: PreflightOptions): Promise<PreflightResult> {

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -353,21 +353,26 @@ export class Wallet extends BaseWallet {
 
   private async deployPaymasterWith(
     calls: Call[],
-    timeBounds?: PaymasterTimeBounds
+    timeBounds?: PaymasterTimeBounds,
+    gasToken?: string
   ): Promise<Tx> {
     this.clearDeploymentCache();
     const classHash = this.accountProvider.getClassHash();
 
     // Special handling for Braavos - deploy via factory
     if (classHash === BraavosPreset.classHash) {
-      return this.deployBraavosViaFactory(calls, timeBounds);
+      return this.deployBraavosViaFactory(calls, timeBounds, gasToken);
     }
 
     // Standard deployment flow
     const deploymentData = await this.accountProvider.getDeploymentData();
     const { transaction_hash } = await this.account.executePaymasterTransaction(
       calls,
-      sponsoredDetails(timeBounds ?? this.defaultTimeBounds, deploymentData)
+      sponsoredDetails(
+        timeBounds ?? this.defaultTimeBounds,
+        deploymentData,
+        gasToken
+      )
     );
     return new Tx(
       transaction_hash,
@@ -387,7 +392,8 @@ export class Wallet extends BaseWallet {
    */
   private async deployBraavosViaFactory(
     calls: Call[],
-    timeBounds?: PaymasterTimeBounds
+    timeBounds?: PaymasterTimeBounds,
+    gasToken?: string
   ): Promise<Tx> {
     const publicKey = await this.accountProvider.getPublicKey();
     const signer = this.accountProvider.getSigner();
@@ -468,7 +474,11 @@ export class Wallet extends BaseWallet {
       : await ozProvider.getDeploymentData();
     const { transaction_hash } = await ozAccount.executePaymasterTransaction(
       allCalls,
-      sponsoredDetails(timeBounds ?? this.defaultTimeBounds, ozDeploymentData)
+      sponsoredDetails(
+        timeBounds ?? this.defaultTimeBounds,
+        ozDeploymentData,
+        gasToken
+      )
     );
 
     return new Tx(
@@ -482,10 +492,11 @@ export class Wallet extends BaseWallet {
   async execute(calls: Call[], options: ExecuteOptions = {}): Promise<Tx> {
     const feeMode = options.feeMode ?? this.defaultFeeMode;
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
+    const gasToken = options.gasToken;
 
     const transactionHash =
-      feeMode === "sponsored"
-        ? await this.executeSponsored(calls, timeBounds)
+      feeMode === "sponsored" || gasToken
+        ? await this.executeSponsored(calls, timeBounds, gasToken)
         : await this.executeUserPays(calls);
 
     return new Tx(
@@ -508,31 +519,37 @@ export class Wallet extends BaseWallet {
 
   private executePaymaster(
     calls: Call[],
-    timeBounds: PaymasterTimeBounds | undefined
+    timeBounds: PaymasterTimeBounds | undefined,
+    gasToken?: string
   ): Promise<string> {
     return this.account
-      .executePaymasterTransaction(calls, sponsoredDetails(timeBounds))
+      .executePaymasterTransaction(
+        calls,
+        sponsoredDetails(timeBounds, undefined, gasToken)
+      )
       .then((r) => r.transaction_hash);
   }
 
   private async executeSponsored(
     calls: Call[],
-    timeBounds: PaymasterTimeBounds | undefined
+    timeBounds: PaymasterTimeBounds | undefined,
+    gasToken?: string
   ): Promise<string> {
     if (await this.isDeployed()) {
-      return this.executePaymaster(calls, timeBounds);
+      return this.executePaymaster(calls, timeBounds, gasToken);
     }
 
     return this.withSponsoredDeployLock(async () => {
       if (await this.isDeployed()) {
-        return this.executePaymaster(calls, timeBounds);
+        return this.executePaymaster(calls, timeBounds, gasToken);
       }
 
       try {
-        return (await this.deployPaymasterWith(calls, timeBounds)).hash;
+        return (await this.deployPaymasterWith(calls, timeBounds, gasToken))
+          .hash;
       } catch (error) {
         if (!isAlreadyDeployedError(error)) throw error;
-        return this.executePaymaster(calls, timeBounds);
+        return this.executePaymaster(calls, timeBounds, gasToken);
       }
     });
   }

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -289,6 +289,13 @@ export class Wallet extends BaseWallet {
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
     const gasToken = options.gasToken;
 
+    if (feeMode === "user_pays" && gasToken) {
+      throw new Error(
+        "Cannot combine feeMode 'user_pays' with gasToken. " +
+          "Use feeMode 'sponsored' or omit feeMode when paying with an ERC-20 token."
+      );
+    }
+
     if (feeMode === "sponsored" || gasToken) {
       return this.deployPaymasterWith([], timeBounds, gasToken);
     }
@@ -355,7 +362,7 @@ export class Wallet extends BaseWallet {
   private async deployPaymasterWith(
     calls: Call[],
     timeBounds?: PaymasterTimeBounds,
-    gasToken?: string
+    gasToken?: Address
   ): Promise<Tx> {
     this.clearDeploymentCache();
     const classHash = this.accountProvider.getClassHash();
@@ -394,7 +401,7 @@ export class Wallet extends BaseWallet {
   private async deployBraavosViaFactory(
     calls: Call[],
     timeBounds?: PaymasterTimeBounds,
-    gasToken?: string
+    gasToken?: Address
   ): Promise<Tx> {
     const publicKey = await this.accountProvider.getPublicKey();
     const signer = this.accountProvider.getSigner();
@@ -495,6 +502,13 @@ export class Wallet extends BaseWallet {
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
     const gasToken = options.gasToken;
 
+    if (feeMode === "user_pays" && gasToken) {
+      throw new Error(
+        "Cannot combine feeMode 'user_pays' with gasToken. " +
+          "Use feeMode 'sponsored' or omit feeMode when paying with an ERC-20 token."
+      );
+    }
+
     const transactionHash =
       feeMode === "sponsored" || gasToken
         ? await this.executeSponsored(calls, timeBounds, gasToken)
@@ -521,7 +535,7 @@ export class Wallet extends BaseWallet {
   private executePaymaster(
     calls: Call[],
     timeBounds: PaymasterTimeBounds | undefined,
-    gasToken?: string
+    gasToken?: Address
   ): Promise<string> {
     return this.account
       .executePaymasterTransaction(
@@ -534,7 +548,7 @@ export class Wallet extends BaseWallet {
   private async executeSponsored(
     calls: Call[],
     timeBounds: PaymasterTimeBounds | undefined,
-    gasToken?: string
+    gasToken?: Address
   ): Promise<string> {
     if (await this.isDeployed()) {
       return this.executePaymaster(calls, timeBounds, gasToken);

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -29,9 +29,9 @@ import type {
   StakingConfig,
 } from "@/types";
 import {
-  assertNoGasTokenConflict,
   checkDeployed,
   ensureWalletReady,
+  normalizeFeeMode,
   paymasterDetails,
   preflightTransaction,
 } from "@/wallet/utils";
@@ -286,15 +286,11 @@ export class Wallet extends BaseWallet {
 
   async deploy(options: DeployOptions = {}): Promise<Tx> {
     this.clearDeploymentCache();
-    const requestedFeeMode = options.feeMode;
-    const feeMode = requestedFeeMode ?? this.defaultFeeMode;
+    const feeMode = normalizeFeeMode(options.feeMode ?? this.defaultFeeMode);
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
-    const gasToken = options.gasToken;
 
-    assertNoGasTokenConflict(requestedFeeMode, gasToken);
-
-    if (feeMode === "sponsored" || gasToken) {
-      return this.deployPaymasterWith([], timeBounds, gasToken);
+    if (feeMode !== "user_pays") {
+      return this.deployPaymasterWith([], timeBounds, feeMode.gasToken);
     }
 
     const classHash = this.accountProvider.getClassHash();
@@ -374,9 +370,9 @@ export class Wallet extends BaseWallet {
     const { transaction_hash } = await this.account.executePaymasterTransaction(
       calls,
       paymasterDetails({
+        feeMode: { type: "paymaster", ...(gasToken && { gasToken }) },
         timeBounds: timeBounds ?? this.defaultTimeBounds,
         deploymentData,
-        gasToken,
       })
     );
     return new Tx(
@@ -480,9 +476,9 @@ export class Wallet extends BaseWallet {
     const { transaction_hash } = await ozAccount.executePaymasterTransaction(
       allCalls,
       paymasterDetails({
+        feeMode: { type: "paymaster", ...(gasToken && { gasToken }) },
         timeBounds: timeBounds ?? this.defaultTimeBounds,
         deploymentData: ozDeploymentData,
-        gasToken,
       })
     );
 
@@ -495,16 +491,12 @@ export class Wallet extends BaseWallet {
   }
 
   async execute(calls: Call[], options: ExecuteOptions = {}): Promise<Tx> {
-    const requestedFeeMode = options.feeMode;
-    const feeMode = requestedFeeMode ?? this.defaultFeeMode;
+    const feeMode = normalizeFeeMode(options.feeMode ?? this.defaultFeeMode);
     const timeBounds = options.timeBounds ?? this.defaultTimeBounds;
-    const gasToken = options.gasToken;
-
-    assertNoGasTokenConflict(requestedFeeMode, gasToken);
 
     const transactionHash =
-      feeMode === "sponsored" || gasToken
-        ? await this.executeSponsored(calls, timeBounds, gasToken)
+      feeMode !== "user_pays"
+        ? await this.executeSponsored(calls, timeBounds, feeMode.gasToken)
         : await this.executeUserPays(calls);
 
     return new Tx(
@@ -533,7 +525,10 @@ export class Wallet extends BaseWallet {
     return this.account
       .executePaymasterTransaction(
         calls,
-        paymasterDetails({ timeBounds, gasToken })
+        paymasterDetails({
+          feeMode: { type: "paymaster", ...(gasToken && { gasToken }) },
+          timeBounds,
+        })
       )
       .then((r) => r.transaction_hash);
   }

--- a/src/wallet/interface.ts
+++ b/src/wallet/interface.ts
@@ -69,7 +69,7 @@ export interface WalletInterface extends BridgeOperatorInterface {
    * Deploy the account contract.
    * Returns a Tx object to track the deployment.
    *
-   * @param options.feeMode - How to pay for deployment ("user_pays" or "sponsored")
+   * @param options.feeMode - How to pay for deployment ("user_pays" or { type: "paymaster" })
    */
   deploy(options?: DeployOptions): Promise<Tx>;
 

--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -12,6 +12,7 @@ import type { Address } from "@/types";
 import type {
   DeployOptions,
   EnsureReadyOptions,
+  FeeMode,
   PreflightOptions,
   PreflightResult,
 } from "@/types";
@@ -68,7 +69,7 @@ export async function ensureWalletReady(
   },
   options: EnsureReadyOptions = {}
 ): Promise<void> {
-  const { deploy = "if_needed", feeMode, onProgress } = options;
+  const { deploy = "if_needed", feeMode, gasToken, onProgress } = options;
 
   try {
     onProgress?.({ step: "CONNECTED" });
@@ -86,7 +87,13 @@ export async function ensureWalletReady(
     }
 
     onProgress?.({ step: "DEPLOYING" });
-    const tx = await wallet.deploy(feeMode ? { feeMode } : undefined);
+    const deployOpts: DeployOptions = {
+      ...(feeMode && { feeMode }),
+      ...(gasToken && { gasToken }),
+    };
+    const tx = await wallet.deploy(
+      Object.keys(deployOpts).length > 0 ? deployOpts : undefined
+    );
     await tx.wait({
       successStates: [
         TransactionFinalityStatus.ACCEPTED_ON_L2,
@@ -144,20 +151,39 @@ export async function preflightTransaction(
   }
 }
 
-/** Paymaster details for sponsored or gasToken transactions */
-export function sponsoredDetails(
-  timeBounds?: PaymasterTimeBounds,
-  deploymentData?: PAYMASTER_API.ACCOUNT_DEPLOYMENT_DATA,
-  gasToken?: Address
+/**
+ * Throw if caller explicitly sets feeMode:"user_pays" alongside gasToken.
+ *
+ * Shared by Wallet and CartridgeWallet to keep validation in sync.
+ */
+export function assertNoGasTokenConflict(
+  requestedFeeMode: FeeMode | undefined,
+  gasToken: Address | undefined
+): void {
+  if (requestedFeeMode === "user_pays" && gasToken) {
+    throw new Error(
+      "Cannot combine feeMode 'user_pays' with gasToken. " +
+        "Use feeMode 'sponsored' or omit feeMode when paying with an ERC-20 token."
+    );
+  }
+}
+
+/** Build PaymasterDetails for sponsored or gasToken transactions. */
+export function paymasterDetails(
+  options: {
+    timeBounds?: PaymasterTimeBounds | undefined;
+    deploymentData?: PAYMASTER_API.ACCOUNT_DEPLOYMENT_DATA | undefined;
+    gasToken?: Address | undefined;
+  } = {}
 ) {
-  const feeMode = gasToken
-    ? { mode: "default" as const, gasToken }
+  const feeMode = options.gasToken
+    ? { mode: "default" as const, gasToken: options.gasToken }
     : { mode: "sponsored" as const };
 
   return {
     feeMode,
-    ...(timeBounds && { timeBounds }),
-    ...(deploymentData && { deploymentData }),
+    ...(options.timeBounds && { timeBounds: options.timeBounds }),
+    ...(options.deploymentData && { deploymentData: options.deploymentData }),
   };
 }
 

--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -144,13 +144,18 @@ export async function preflightTransaction(
   }
 }
 
-/** Paymaster details for sponsored transactions */
+/** Paymaster details for sponsored or gasToken transactions */
 export function sponsoredDetails(
   timeBounds?: PaymasterTimeBounds,
-  deploymentData?: PAYMASTER_API.ACCOUNT_DEPLOYMENT_DATA
+  deploymentData?: PAYMASTER_API.ACCOUNT_DEPLOYMENT_DATA,
+  gasToken?: string
 ) {
+  const feeMode = gasToken
+    ? { mode: "default" as const, gasToken }
+    : { mode: "sponsored" as const };
+
   return {
-    feeMode: { mode: "sponsored" as const },
+    feeMode,
     ...(timeBounds && { timeBounds }),
     ...(deploymentData && { deploymentData }),
   };

--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -122,12 +122,12 @@ export async function preflightTransaction(
   },
   options: PreflightOptions
 ): Promise<PreflightResult> {
-  const { calls, feeMode } = options;
+  const { calls, feeMode, gasToken } = options;
 
   try {
     const deployed = await wallet.isDeployed();
     if (!deployed) {
-      if (feeMode === "sponsored") {
+      if (feeMode === "sponsored" || gasToken) {
         return { ok: true };
       }
       return { ok: false, reason: "Account not deployed" };

--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -148,7 +148,7 @@ export async function preflightTransaction(
 export function sponsoredDetails(
   timeBounds?: PaymasterTimeBounds,
   deploymentData?: PAYMASTER_API.ACCOUNT_DEPLOYMENT_DATA,
-  gasToken?: string
+  gasToken?: Address
 ) {
   const feeMode = gasToken
     ? { mode: "default" as const, gasToken }

--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -17,6 +17,32 @@ import type {
   PreflightResult,
 } from "@/types";
 
+/** Canonical (non-deprecated) fee mode variants. */
+export type NormalizedFeeMode =
+  | "user_pays"
+  | { type: "paymaster"; gasToken?: Address };
+
+/**
+ * Normalize FeeMode by converting the deprecated `"sponsored"` alias
+ * to its canonical `{ type: "paymaster" }` form.
+ */
+export function normalizeFeeMode(feeMode: FeeMode): NormalizedFeeMode {
+  if (feeMode === "sponsored") return { type: "paymaster" };
+  return feeMode;
+}
+
+/** Type guard: does this fee mode use the paymaster path? */
+export function isPaymasterMode(
+  feeMode: FeeMode | undefined
+): feeMode is { type: "paymaster"; gasToken?: Address } | "sponsored" {
+  return (
+    feeMode === "sponsored" ||
+    (typeof feeMode === "object" &&
+      feeMode !== null &&
+      feeMode.type === "paymaster")
+  );
+}
+
 /**
  * Shared wallet utilities.
  * Used by wallet implementations to avoid code duplication.
@@ -69,7 +95,7 @@ export async function ensureWalletReady(
   },
   options: EnsureReadyOptions = {}
 ): Promise<void> {
-  const { deploy = "if_needed", feeMode, gasToken, onProgress } = options;
+  const { deploy = "if_needed", feeMode, onProgress } = options;
 
   try {
     onProgress?.({ step: "CONNECTED" });
@@ -89,7 +115,6 @@ export async function ensureWalletReady(
     onProgress?.({ step: "DEPLOYING" });
     const deployOpts: DeployOptions = {
       ...(feeMode && { feeMode }),
-      ...(gasToken && { gasToken }),
     };
     const tx = await wallet.deploy(
       Object.keys(deployOpts).length > 0 ? deployOpts : undefined
@@ -122,12 +147,12 @@ export async function preflightTransaction(
   },
   options: PreflightOptions
 ): Promise<PreflightResult> {
-  const { calls, feeMode, gasToken } = options;
+  const { calls, feeMode } = options;
 
   try {
     const deployed = await wallet.isDeployed();
     if (!deployed) {
-      if (feeMode === "sponsored" || gasToken) {
+      if (isPaymasterMode(feeMode)) {
         return { ok: true };
       }
       return { ok: false, reason: "Account not deployed" };
@@ -151,37 +176,18 @@ export async function preflightTransaction(
   }
 }
 
-/**
- * Throw if caller explicitly sets feeMode:"user_pays" alongside gasToken.
- *
- * Shared by Wallet and CartridgeWallet to keep validation in sync.
- */
-export function assertNoGasTokenConflict(
-  requestedFeeMode: FeeMode | undefined,
-  gasToken: Address | undefined
-): void {
-  if (requestedFeeMode === "user_pays" && gasToken) {
-    throw new Error(
-      "Cannot combine feeMode 'user_pays' with gasToken. " +
-        "Use feeMode 'sponsored' or omit feeMode when paying with an ERC-20 token."
-    );
-  }
-}
-
 /** Build PaymasterDetails for sponsored or gasToken transactions. */
-export function paymasterDetails(
-  options: {
-    timeBounds?: PaymasterTimeBounds | undefined;
-    deploymentData?: PAYMASTER_API.ACCOUNT_DEPLOYMENT_DATA | undefined;
-    gasToken?: Address | undefined;
-  } = {}
-) {
-  const feeMode = options.gasToken
-    ? { mode: "default" as const, gasToken: options.gasToken }
+export function paymasterDetails(options: {
+  feeMode: { type: "paymaster"; gasToken?: Address };
+  timeBounds?: PaymasterTimeBounds | undefined;
+  deploymentData?: PAYMASTER_API.ACCOUNT_DEPLOYMENT_DATA | undefined;
+}) {
+  const paymasterFeeMode = options.feeMode.gasToken
+    ? { mode: "default" as const, gasToken: options.feeMode.gasToken }
     : { mode: "sponsored" as const };
 
   return {
-    feeMode,
+    feeMode: paymasterFeeMode,
     ...(options.timeBounds && { timeBounds: options.timeBounds }),
     ...(options.deploymentData && { deploymentData: options.deploymentData }),
   };

--- a/tests/cartridge.test.ts
+++ b/tests/cartridge.test.ts
@@ -152,7 +152,7 @@ describe("CartridgeWallet", () => {
 
     it("should accept feeMode and timeBounds options", async () => {
       const wallet = await CartridgeWallet.create({
-        feeMode: "sponsored",
+        feeMode: { type: "paymaster" },
         timeBounds: { executeBefore: 12345 },
       });
 
@@ -188,15 +188,8 @@ describe("CartridgeWallet", () => {
 
     it("should reject unsupported deploy options", async () => {
       const wallet = await CartridgeWallet.create();
-      await expect(wallet.deploy({ feeMode: "sponsored" })).rejects.toThrow(
-        "does not support DeployOptions overrides"
-      );
-    });
-
-    it("should reject gasToken in deploy options", async () => {
-      const wallet = await CartridgeWallet.create();
       await expect(
-        wallet.deploy({ gasToken: fromAddress("0x053c91253bc9") })
+        wallet.deploy({ feeMode: { type: "paymaster" } })
       ).rejects.toThrow("does not support DeployOptions overrides");
     });
   });
@@ -219,7 +212,7 @@ describe("CartridgeWallet", () => {
 
     it("should use paymaster for sponsored mode", async () => {
       const wallet = await CartridgeWallet.create({
-        feeMode: "sponsored",
+        feeMode: { type: "paymaster" },
       });
       const calls = [
         {
@@ -236,7 +229,7 @@ describe("CartridgeWallet", () => {
 
     it("should not pre-deploy before sponsored execution", async () => {
       const wallet = await CartridgeWallet.create({
-        feeMode: "sponsored",
+        feeMode: { type: "paymaster" },
       });
       const calls = [
         {
@@ -305,7 +298,7 @@ describe("CartridgeWallet", () => {
       expect(account.execute).not.toHaveBeenCalled();
     });
 
-    it("should route to paymaster when gasToken is set", async () => {
+    it("should route to paymaster when gasToken is set via feeMode", async () => {
       const wallet = await CartridgeWallet.create();
       const calls = [
         {
@@ -316,7 +309,10 @@ describe("CartridgeWallet", () => {
       ];
 
       const tx = await wallet.execute(calls, {
-        gasToken: fromAddress("0x053c91253bc9"),
+        feeMode: {
+          type: "paymaster",
+          gasToken: fromAddress("0x053c91253bc9"),
+        },
       });
 
       const account = wallet.getAccount() as unknown as {
@@ -333,24 +329,6 @@ describe("CartridgeWallet", () => {
           }),
         })
       );
-    });
-
-    it("should throw when gasToken combined with feeMode 'user_pays'", async () => {
-      const wallet = await CartridgeWallet.create();
-      const calls = [
-        {
-          contractAddress: "0x123",
-          entrypoint: "transfer",
-          calldata: ["0x456", "100"],
-        },
-      ];
-
-      await expect(
-        wallet.execute(calls, {
-          feeMode: "user_pays",
-          gasToken: fromAddress("0x053c91253bc9"),
-        })
-      ).rejects.toThrow("Cannot combine feeMode 'user_pays' with gasToken");
     });
   });
 

--- a/tests/cartridge.test.ts
+++ b/tests/cartridge.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { CartridgeWallet } from "@/wallet/cartridge";
-import { ChainId } from "@/types";
+import { ChainId, fromAddress } from "@/types";
 
 const { MockController, mockToSessionPolicies } = vi.hoisted(() => {
   class ControllerMock {
@@ -192,6 +192,13 @@ describe("CartridgeWallet", () => {
         "does not support DeployOptions overrides"
       );
     });
+
+    it("should reject gasToken in deploy options", async () => {
+      const wallet = await CartridgeWallet.create();
+      await expect(
+        wallet.deploy({ gasToken: fromAddress("0x053c91253bc9") })
+      ).rejects.toThrow("does not support DeployOptions overrides");
+    });
   });
 
   describe("execute", () => {
@@ -296,6 +303,54 @@ describe("CartridgeWallet", () => {
 
       expect(controller.keychain.deploy).not.toHaveBeenCalled();
       expect(account.execute).not.toHaveBeenCalled();
+    });
+
+    it("should route to paymaster when gasToken is set", async () => {
+      const wallet = await CartridgeWallet.create();
+      const calls = [
+        {
+          contractAddress: "0x123",
+          entrypoint: "transfer",
+          calldata: ["0x456", "100"],
+        },
+      ];
+
+      const tx = await wallet.execute(calls, {
+        gasToken: fromAddress("0x053c91253bc9"),
+      });
+
+      const account = wallet.getAccount() as unknown as {
+        executePaymasterTransaction: ReturnType<typeof vi.fn>;
+      };
+
+      expect(tx.hash).toBe("0xsponsored");
+      expect(account.executePaymasterTransaction).toHaveBeenCalledTimes(1);
+      expect(account.executePaymasterTransaction).toHaveBeenCalledWith(
+        calls,
+        expect.objectContaining({
+          feeMode: expect.objectContaining({
+            mode: "default",
+          }),
+        })
+      );
+    });
+
+    it("should throw when gasToken combined with feeMode 'user_pays'", async () => {
+      const wallet = await CartridgeWallet.create();
+      const calls = [
+        {
+          contractAddress: "0x123",
+          entrypoint: "transfer",
+          calldata: ["0x456", "100"],
+        },
+      ];
+
+      await expect(
+        wallet.execute(calls, {
+          feeMode: "user_pays",
+          gasToken: fromAddress("0x053c91253bc9"),
+        })
+      ).rejects.toThrow("Cannot combine feeMode 'user_pays' with gasToken");
     });
   });
 

--- a/tests/dca-wallet.test.ts
+++ b/tests/dca-wallet.test.ts
@@ -159,7 +159,7 @@ describe("BaseWallet DCA abstraction", () => {
   it("executes provider create calls with options", async () => {
     const provider = createDcaProvider();
     const wallet = new TestWallet(provider);
-    const options: ExecuteOptions = { feeMode: "sponsored" };
+    const options: ExecuteOptions = { feeMode: { type: "paymaster" } };
 
     const tx = await wallet.dca().create(
       {

--- a/tests/lending-wallet.test.ts
+++ b/tests/lending-wallet.test.ts
@@ -52,7 +52,7 @@ class TestWallet extends BaseWallet {
 
   async preflight(options: {
     calls: Call[];
-    feeMode?: "sponsored" | "user_pays";
+    feeMode?: "user_pays" | { type: "paymaster"; gasToken?: string };
   }) {
     return this.preflightSpy(options);
   }
@@ -142,7 +142,7 @@ describe("BaseWallet lending abstraction", () => {
     const provider = createProvider();
     const wallet = new TestWallet(provider);
     const amount = Amount.parse("100", debtToken);
-    const options: ExecuteOptions = { feeMode: "sponsored" };
+    const options: ExecuteOptions = { feeMode: { type: "paymaster" } };
 
     const tx = await wallet.lending().deposit(
       {
@@ -203,7 +203,7 @@ describe("BaseWallet lending abstraction", () => {
         collateralToken,
         debtToken,
       },
-      feeMode: "sponsored",
+      feeMode: { type: "paymaster" },
     });
 
     expect(result.current.debtValue).toBe(100n);
@@ -215,7 +215,7 @@ describe("BaseWallet lending abstraction", () => {
     });
     expect(wallet.preflightSpy).toHaveBeenCalledWith({
       calls: [lendingCall],
-      feeMode: "sponsored",
+      feeMode: { type: "paymaster" },
     });
   });
 

--- a/tests/paymaster-live.test.ts
+++ b/tests/paymaster-live.test.ts
@@ -46,7 +46,7 @@ maybeDescribe("Live Paymaster Smoke (opt-in)", () => {
         accountClass: OpenZeppelinPreset,
       },
       ...(testnetFunder.address && { accountAddress: testnetFunder.address }),
-      feeMode: "sponsored",
+      feeMode: { type: "paymaster" },
     });
 
     expect(sponsoredWallet.address).toBe(userPaysWallet.address);
@@ -67,7 +67,7 @@ maybeDescribe("Live Paymaster Smoke (opt-in)", () => {
     await userPaysTx.wait();
 
     const sponsoredTx = await sponsoredWallet.execute([approveZeroCall], {
-      feeMode: "sponsored",
+      feeMode: { type: "paymaster" },
     });
     await sponsoredTx.wait();
 

--- a/tests/sponsorship.test.ts
+++ b/tests/sponsorship.test.ts
@@ -33,7 +33,7 @@ describe("Sponsorship (AVNU Paymaster)", () => {
           signer: new StarkSigner(privateKey),
           accountClass: OpenZeppelinPreset,
         },
-        feeMode: "sponsored",
+        feeMode: { type: "paymaster" },
       });
 
       expect(wallet).toBeDefined();
@@ -86,7 +86,7 @@ describe("Sponsorship (AVNU Paymaster)", () => {
               calldata: [],
             },
           ],
-          { feeMode: "sponsored" }
+          { feeMode: { type: "paymaster" } }
         );
       } catch (error) {
         // Expected to fail (devnet doesn't have AVNU paymaster)
@@ -105,7 +105,7 @@ describe("Sponsorship (AVNU Paymaster)", () => {
           signer: new StarkSigner(privateKey),
           accountClass: OpenZeppelinPreset,
         },
-        feeMode: "sponsored",
+        feeMode: { type: "paymaster" },
         timeBounds: {
           executeAfter: Math.floor(Date.now() / 1000),
           executeBefore: Math.floor(Date.now() / 1000) + 3600,

--- a/tests/staking-auto-stake.test.ts
+++ b/tests/staking-auto-stake.test.ts
@@ -122,7 +122,7 @@ describe("staking auto stake", () => {
       staking: vi.fn().mockResolvedValue(staking),
     } as unknown as BaseWallet;
 
-    const options = { feeMode: "sponsored" as const };
+    const options = { feeMode: { type: "paymaster" } as const };
     const result = await BaseWallet.prototype.stake.call(
       walletLike,
       poolAddress,

--- a/tests/swap-wallet.test.ts
+++ b/tests/swap-wallet.test.ts
@@ -156,7 +156,7 @@ describe("BaseWallet swap abstraction", () => {
   it("executes provider prepareSwap calls with options", async () => {
     const wallet = new TestWallet();
     const amountIn = Amount.parse("50", mockToken);
-    const options: ExecuteOptions = { feeMode: "sponsored" };
+    const options: ExecuteOptions = { feeMode: { type: "paymaster" } };
 
     const provider: SwapProvider = {
       id: "provider",
@@ -305,7 +305,7 @@ describe("BaseWallet swap abstraction", () => {
 
   it("supports swap(request, options) via default provider", async () => {
     const amountIn = Amount.parse("50", mockToken);
-    const options: ExecuteOptions = { feeMode: "sponsored" };
+    const options: ExecuteOptions = { feeMode: { type: "paymaster" } };
     const provider: SwapProvider = {
       id: "default",
       supportsChain: () => true,

--- a/tests/tx-builder.test.ts
+++ b/tests/tx-builder.test.ts
@@ -1107,7 +1107,7 @@ describe("TxBuilder", () => {
 
     it("should pass execute options through", async () => {
       const wallet = createMockWallet();
-      const options = { feeMode: "sponsored" as const };
+      const options = { feeMode: { type: "paymaster" } as const };
 
       await new TxBuilder(wallet).add(rawCall).send(options);
 

--- a/tests/wallet-utils.test.ts
+++ b/tests/wallet-utils.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import type { RpcProvider } from "starknet";
 import {
-  assertNoGasTokenConflict,
   checkDeployed,
   ensureWalletReady,
+  isPaymasterMode,
+  normalizeFeeMode,
   paymasterDetails,
 } from "@/wallet/utils";
 import { fromAddress } from "@/types";
@@ -81,7 +82,7 @@ describe("wallet utils", () => {
       expect(wait).toHaveBeenCalledTimes(1);
     });
 
-    it("forwards gasToken to deploy when provided", async () => {
+    it("forwards paymaster feeMode with gasToken to deploy", async () => {
       const wait = vi.fn().mockResolvedValue(undefined);
       const deploy = vi.fn().mockResolvedValue({ wait });
       const isDeployed = vi.fn().mockResolvedValue(false);
@@ -89,27 +90,30 @@ describe("wallet utils", () => {
 
       await ensureWalletReady(
         { isDeployed, deploy },
-        { deploy: "if_needed", gasToken }
+        { deploy: "if_needed", feeMode: { type: "paymaster", gasToken } }
       );
 
       expect(deploy).toHaveBeenCalledWith(
-        expect.objectContaining({ gasToken })
+        expect.objectContaining({
+          feeMode: { type: "paymaster", gasToken },
+        })
       );
     });
 
-    it("forwards feeMode and gasToken together to deploy", async () => {
+    it("forwards paymaster feeMode without gasToken to deploy", async () => {
       const wait = vi.fn().mockResolvedValue(undefined);
       const deploy = vi.fn().mockResolvedValue({ wait });
       const isDeployed = vi.fn().mockResolvedValue(false);
-      const gasToken = fromAddress("0x053c91253bc9");
 
       await ensureWalletReady(
         { isDeployed, deploy },
-        { deploy: "if_needed", feeMode: "sponsored", gasToken }
+        { deploy: "if_needed", feeMode: { type: "paymaster" } }
       );
 
       expect(deploy).toHaveBeenCalledWith(
-        expect.objectContaining({ feeMode: "sponsored", gasToken })
+        expect.objectContaining({
+          feeMode: { type: "paymaster" },
+        })
       );
     });
   });
@@ -120,7 +124,9 @@ describe("wallet utils", () => {
     );
 
     it("returns { mode: 'default', gasToken } when gasToken is provided", () => {
-      const result = paymasterDetails({ gasToken: gasTokenAddress });
+      const result = paymasterDetails({
+        feeMode: { type: "paymaster", gasToken: gasTokenAddress },
+      });
 
       expect(result.feeMode).toEqual({
         mode: "default",
@@ -129,20 +135,19 @@ describe("wallet utils", () => {
     });
 
     it("returns { mode: 'sponsored' } when gasToken is omitted", () => {
-      const result = paymasterDetails();
-
-      expect(result.feeMode).toEqual({ mode: "sponsored" });
-    });
-
-    it("returns { mode: 'sponsored' } when called with empty options", () => {
-      const result = paymasterDetails({});
+      const result = paymasterDetails({
+        feeMode: { type: "paymaster" },
+      });
 
       expect(result.feeMode).toEqual({ mode: "sponsored" });
     });
 
     it("includes timeBounds when provided", () => {
       const timeBounds = { executeBefore: 12345 };
-      const result = paymasterDetails({ timeBounds });
+      const result = paymasterDetails({
+        feeMode: { type: "paymaster" },
+        timeBounds,
+      });
 
       expect(result.timeBounds).toEqual(timeBounds);
     });
@@ -154,48 +159,84 @@ describe("wallet utils", () => {
         constructor_calldata: ["0x1"],
         version: "0x1" as const,
       };
-      const result = paymasterDetails({ deploymentData });
+      const result = paymasterDetails({
+        feeMode: { type: "paymaster" },
+        deploymentData,
+      });
 
       expect(result.deploymentData).toEqual(deploymentData);
     });
 
     it("omits timeBounds and deploymentData when not provided", () => {
-      const result = paymasterDetails({ gasToken: gasTokenAddress });
+      const result = paymasterDetails({
+        feeMode: { type: "paymaster", gasToken: gasTokenAddress },
+      });
 
       expect(result).not.toHaveProperty("timeBounds");
       expect(result).not.toHaveProperty("deploymentData");
     });
   });
 
-  describe("assertNoGasTokenConflict", () => {
-    const gasToken = fromAddress("0x053c91253bc9");
+  describe("normalizeFeeMode", () => {
+    it('converts deprecated "sponsored" to { type: "paymaster" }', () => {
+      expect(normalizeFeeMode("sponsored")).toEqual({ type: "paymaster" });
+    });
 
-    it("throws when feeMode is 'user_pays' and gasToken is set", () => {
-      expect(() => assertNoGasTokenConflict("user_pays", gasToken)).toThrow(
-        "Cannot combine feeMode 'user_pays' with gasToken"
+    it('passes "user_pays" through unchanged', () => {
+      expect(normalizeFeeMode("user_pays")).toBe("user_pays");
+    });
+
+    it("passes paymaster object through unchanged", () => {
+      const gasToken = fromAddress("0x053c91253bc9");
+      const mode = { type: "paymaster" as const, gasToken };
+      expect(normalizeFeeMode(mode)).toEqual(mode);
+    });
+
+    it("passes paymaster object without gasToken through unchanged", () => {
+      const mode = { type: "paymaster" as const };
+      expect(normalizeFeeMode(mode)).toEqual(mode);
+    });
+  });
+
+  describe("isPaymasterMode", () => {
+    it('returns true for { type: "paymaster" }', () => {
+      expect(isPaymasterMode({ type: "paymaster" })).toBe(true);
+    });
+
+    it("returns true for paymaster with gasToken", () => {
+      const gasToken = fromAddress("0x053c91253bc9");
+      expect(isPaymasterMode({ type: "paymaster", gasToken })).toBe(true);
+    });
+
+    it('returns true for deprecated "sponsored"', () => {
+      expect(isPaymasterMode("sponsored")).toBe(true);
+    });
+
+    it('returns false for "user_pays"', () => {
+      expect(isPaymasterMode("user_pays")).toBe(false);
+    });
+
+    it("returns false for undefined", () => {
+      expect(isPaymasterMode(undefined)).toBe(false);
+    });
+  });
+
+  describe("backward compat: deprecated sponsored alias", () => {
+    it('forwards deprecated "sponsored" feeMode through ensureWalletReady to deploy', async () => {
+      const wait = vi.fn().mockResolvedValue(undefined);
+      const deploy = vi.fn().mockResolvedValue({ wait });
+      const isDeployed = vi.fn().mockResolvedValue(false);
+
+      await ensureWalletReady(
+        { isDeployed, deploy },
+        { deploy: "if_needed", feeMode: "sponsored" }
       );
-    });
 
-    it("does not throw when feeMode is 'sponsored' and gasToken is set", () => {
-      expect(() =>
-        assertNoGasTokenConflict("sponsored", gasToken)
-      ).not.toThrow();
-    });
-
-    it("does not throw when feeMode is undefined and gasToken is set", () => {
-      expect(() => assertNoGasTokenConflict(undefined, gasToken)).not.toThrow();
-    });
-
-    it("does not throw when gasToken is undefined", () => {
-      expect(() =>
-        assertNoGasTokenConflict("user_pays", undefined)
-      ).not.toThrow();
-    });
-
-    it("does not throw when both are undefined", () => {
-      expect(() =>
-        assertNoGasTokenConflict(undefined, undefined)
-      ).not.toThrow();
+      expect(deploy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          feeMode: "sponsored",
+        })
+      );
     });
   });
 });

--- a/tests/wallet-utils.test.ts
+++ b/tests/wallet-utils.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import type { RpcProvider } from "starknet";
-import { checkDeployed, ensureWalletReady } from "@/wallet/utils";
+import {
+  assertNoGasTokenConflict,
+  checkDeployed,
+  ensureWalletReady,
+  paymasterDetails,
+} from "@/wallet/utils";
 import { fromAddress } from "@/types";
 
 describe("wallet utils", () => {
@@ -74,6 +79,123 @@ describe("wallet utils", () => {
 
       expect(deploy).toHaveBeenCalledTimes(1);
       expect(wait).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards gasToken to deploy when provided", async () => {
+      const wait = vi.fn().mockResolvedValue(undefined);
+      const deploy = vi.fn().mockResolvedValue({ wait });
+      const isDeployed = vi.fn().mockResolvedValue(false);
+      const gasToken = fromAddress("0x053c91253bc9");
+
+      await ensureWalletReady(
+        { isDeployed, deploy },
+        { deploy: "if_needed", gasToken }
+      );
+
+      expect(deploy).toHaveBeenCalledWith(
+        expect.objectContaining({ gasToken })
+      );
+    });
+
+    it("forwards feeMode and gasToken together to deploy", async () => {
+      const wait = vi.fn().mockResolvedValue(undefined);
+      const deploy = vi.fn().mockResolvedValue({ wait });
+      const isDeployed = vi.fn().mockResolvedValue(false);
+      const gasToken = fromAddress("0x053c91253bc9");
+
+      await ensureWalletReady(
+        { isDeployed, deploy },
+        { deploy: "if_needed", feeMode: "sponsored", gasToken }
+      );
+
+      expect(deploy).toHaveBeenCalledWith(
+        expect.objectContaining({ feeMode: "sponsored", gasToken })
+      );
+    });
+  });
+
+  describe("paymasterDetails", () => {
+    const gasTokenAddress = fromAddress(
+      "0x053c91253bc96bfed3be381a97265e250ed0a2e2cbf1a54898ad0d2f7982f78f"
+    );
+
+    it("returns { mode: 'default', gasToken } when gasToken is provided", () => {
+      const result = paymasterDetails({ gasToken: gasTokenAddress });
+
+      expect(result.feeMode).toEqual({
+        mode: "default",
+        gasToken: gasTokenAddress,
+      });
+    });
+
+    it("returns { mode: 'sponsored' } when gasToken is omitted", () => {
+      const result = paymasterDetails();
+
+      expect(result.feeMode).toEqual({ mode: "sponsored" });
+    });
+
+    it("returns { mode: 'sponsored' } when called with empty options", () => {
+      const result = paymasterDetails({});
+
+      expect(result.feeMode).toEqual({ mode: "sponsored" });
+    });
+
+    it("includes timeBounds when provided", () => {
+      const timeBounds = { executeBefore: 12345 };
+      const result = paymasterDetails({ timeBounds });
+
+      expect(result.timeBounds).toEqual(timeBounds);
+    });
+
+    it("includes deploymentData when provided", () => {
+      const deploymentData = {
+        class_hash: "0xabc",
+        contract_address_salt: "0xdef",
+        constructor_calldata: ["0x1"],
+        version: "0x1" as const,
+      };
+      const result = paymasterDetails({ deploymentData });
+
+      expect(result.deploymentData).toEqual(deploymentData);
+    });
+
+    it("omits timeBounds and deploymentData when not provided", () => {
+      const result = paymasterDetails({ gasToken: gasTokenAddress });
+
+      expect(result).not.toHaveProperty("timeBounds");
+      expect(result).not.toHaveProperty("deploymentData");
+    });
+  });
+
+  describe("assertNoGasTokenConflict", () => {
+    const gasToken = fromAddress("0x053c91253bc9");
+
+    it("throws when feeMode is 'user_pays' and gasToken is set", () => {
+      expect(() => assertNoGasTokenConflict("user_pays", gasToken)).toThrow(
+        "Cannot combine feeMode 'user_pays' with gasToken"
+      );
+    });
+
+    it("does not throw when feeMode is 'sponsored' and gasToken is set", () => {
+      expect(() =>
+        assertNoGasTokenConflict("sponsored", gasToken)
+      ).not.toThrow();
+    });
+
+    it("does not throw when feeMode is undefined and gasToken is set", () => {
+      expect(() => assertNoGasTokenConflict(undefined, gasToken)).not.toThrow();
+    });
+
+    it("does not throw when gasToken is undefined", () => {
+      expect(() =>
+        assertNoGasTokenConflict("user_pays", undefined)
+      ).not.toThrow();
+    });
+
+    it("does not throw when both are undefined", () => {
+      expect(() =>
+        assertNoGasTokenConflict(undefined, undefined)
+      ).not.toThrow();
     });
   });
 });

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -375,6 +375,91 @@ describe("Wallet", () => {
 
       expect(deployed).toBe(false);
     });
+
+    it("should throw when gasToken combined with feeMode 'user_pays'", async () => {
+      const signer = new StarkSigner(testPrivateKeys.key1);
+      const wallet = await sdk.connectWallet({
+        account: { signer },
+      });
+
+      const account = wallet.getAccount();
+      vi.spyOn(account, "estimateAccountDeployFee").mockResolvedValue({
+        resourceBounds: {
+          l1_gas: { max_amount: 1n, max_price_per_unit: 1n },
+          l2_gas: { max_amount: 1n, max_price_per_unit: 1n },
+          l1_data_gas: { max_amount: 1n, max_price_per_unit: 1n },
+        },
+      } as Awaited<ReturnType<typeof account.estimateAccountDeployFee>>);
+
+      await expect(
+        wallet.deploy({
+          feeMode: "user_pays",
+          gasToken: fromAddress("0x053c91253bc9"),
+        })
+      ).rejects.toThrow("Cannot combine feeMode 'user_pays' with gasToken");
+    });
+  });
+
+  describe("execute", () => {
+    it("should throw when gasToken combined with feeMode 'user_pays'", async () => {
+      const signer = new StarkSigner(testPrivateKeys.key1);
+      const wallet = await sdk.connectWallet({
+        account: { signer },
+      });
+
+      await expect(
+        wallet.execute(
+          [
+            {
+              contractAddress: "0x123",
+              entrypoint: "transfer",
+              calldata: [],
+            },
+          ],
+          {
+            feeMode: "user_pays",
+            gasToken: fromAddress("0x053c91253bc9"),
+          }
+        )
+      ).rejects.toThrow("Cannot combine feeMode 'user_pays' with gasToken");
+    });
+
+    it("should not throw when gasToken is set without explicit feeMode", async () => {
+      const signer = new StarkSigner(testPrivateKeys.key1);
+      const wallet = await sdk.connectWallet({
+        account: { signer },
+      });
+
+      const account = wallet.getAccount();
+      vi.spyOn(wallet, "isDeployed").mockResolvedValue(true);
+      const paymasterSpy = vi
+        .spyOn(account, "executePaymasterTransaction")
+        .mockResolvedValue({ transaction_hash: "0xgas" });
+
+      const tx = await wallet.execute(
+        [
+          {
+            contractAddress: "0x123",
+            entrypoint: "transfer",
+            calldata: [],
+          },
+        ],
+        {
+          gasToken: fromAddress("0x053c91253bc9"),
+        }
+      );
+
+      expect(tx.hash).toBe("0xgas");
+      expect(paymasterSpy).toHaveBeenCalledTimes(1);
+      expect(paymasterSpy).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          feeMode: expect.objectContaining({
+            mode: "default",
+          }),
+        })
+      );
+    });
   });
 
   describe("preflight", () => {

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -539,6 +539,29 @@ describe("Wallet", () => {
       expect(result.ok).toBe(true);
       expect(simulateSpy).not.toHaveBeenCalled();
     });
+
+    it("should return ok for undeployed account with gasToken", async () => {
+      const signer = new StarkSigner(testPrivateKeys.random());
+      const wallet = await sdk.connectWallet({
+        account: { signer },
+      });
+      vi.spyOn(wallet, "isDeployed").mockResolvedValue(false);
+      const simulateSpy = vi.spyOn(wallet.getAccount(), "simulateTransaction");
+
+      const result = await wallet.preflight({
+        calls: [
+          {
+            contractAddress: "0x123",
+            entrypoint: "transfer",
+            calldata: [],
+          },
+        ],
+        gasToken: fromAddress("0x053c91253bc9"),
+      });
+
+      expect(result.ok).toBe(true);
+      expect(simulateSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("getAccount", () => {

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -122,7 +122,7 @@ describe("Wallet", () => {
       const signer = new StarkSigner(privateKey);
       const wallet = await sdk.connectWallet({
         account: { signer },
-        feeMode: "sponsored",
+        feeMode: { type: "paymaster" },
         timeBounds: {
           executeBefore: Math.floor(Date.now() / 1000) + 3600,
         },
@@ -375,56 +375,10 @@ describe("Wallet", () => {
 
       expect(deployed).toBe(false);
     });
-
-    it("should throw when gasToken combined with feeMode 'user_pays'", async () => {
-      const signer = new StarkSigner(testPrivateKeys.key1);
-      const wallet = await sdk.connectWallet({
-        account: { signer },
-      });
-
-      const account = wallet.getAccount();
-      vi.spyOn(account, "estimateAccountDeployFee").mockResolvedValue({
-        resourceBounds: {
-          l1_gas: { max_amount: 1n, max_price_per_unit: 1n },
-          l2_gas: { max_amount: 1n, max_price_per_unit: 1n },
-          l1_data_gas: { max_amount: 1n, max_price_per_unit: 1n },
-        },
-      } as Awaited<ReturnType<typeof account.estimateAccountDeployFee>>);
-
-      await expect(
-        wallet.deploy({
-          feeMode: "user_pays",
-          gasToken: fromAddress("0x053c91253bc9"),
-        })
-      ).rejects.toThrow("Cannot combine feeMode 'user_pays' with gasToken");
-    });
   });
 
   describe("execute", () => {
-    it("should throw when gasToken combined with feeMode 'user_pays'", async () => {
-      const signer = new StarkSigner(testPrivateKeys.key1);
-      const wallet = await sdk.connectWallet({
-        account: { signer },
-      });
-
-      await expect(
-        wallet.execute(
-          [
-            {
-              contractAddress: "0x123",
-              entrypoint: "transfer",
-              calldata: [],
-            },
-          ],
-          {
-            feeMode: "user_pays",
-            gasToken: fromAddress("0x053c91253bc9"),
-          }
-        )
-      ).rejects.toThrow("Cannot combine feeMode 'user_pays' with gasToken");
-    });
-
-    it("should not throw when gasToken is set without explicit feeMode", async () => {
+    it("should route to paymaster when gasToken is set via feeMode", async () => {
       const signer = new StarkSigner(testPrivateKeys.key1);
       const wallet = await sdk.connectWallet({
         account: { signer },
@@ -445,7 +399,10 @@ describe("Wallet", () => {
           },
         ],
         {
-          gasToken: fromAddress("0x053c91253bc9"),
+          feeMode: {
+            type: "paymaster",
+            gasToken: fromAddress("0x053c91253bc9"),
+          },
         }
       );
 
@@ -456,6 +413,41 @@ describe("Wallet", () => {
         expect.objectContaining({
           feeMode: expect.objectContaining({
             mode: "default",
+          }),
+        })
+      );
+    });
+
+    it('should route deprecated "sponsored" to paymaster path', async () => {
+      const signer = new StarkSigner(testPrivateKeys.key1);
+      const wallet = await sdk.connectWallet({
+        account: { signer },
+      });
+
+      const account = wallet.getAccount();
+      vi.spyOn(wallet, "isDeployed").mockResolvedValue(true);
+      const paymasterSpy = vi
+        .spyOn(account, "executePaymasterTransaction")
+        .mockResolvedValue({ transaction_hash: "0xsponsored" });
+
+      const tx = await wallet.execute(
+        [
+          {
+            contractAddress: "0x123",
+            entrypoint: "transfer",
+            calldata: [],
+          },
+        ],
+        { feeMode: "sponsored" }
+      );
+
+      expect(tx.hash).toBe("0xsponsored");
+      expect(paymasterSpy).toHaveBeenCalledTimes(1);
+      expect(paymasterSpy).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          feeMode: expect.objectContaining({
+            mode: "sponsored",
           }),
         })
       );
@@ -491,7 +483,7 @@ describe("Wallet", () => {
       const signer = new StarkSigner(testPrivateKeys.random());
       const wallet = await sdk.connectWallet({
         account: { signer },
-        feeMode: "sponsored",
+        feeMode: { type: "paymaster" },
       });
       vi.spyOn(wallet, "isDeployed").mockResolvedValue(false);
       const simulateSpy = vi.spyOn(wallet.getAccount(), "simulateTransaction");
@@ -521,7 +513,7 @@ describe("Wallet", () => {
       const signer = new StarkSigner(testPrivateKeys.random());
       const wallet = await paymasterSdk.connectWallet({
         account: { signer },
-        feeMode: "sponsored",
+        feeMode: { type: "paymaster" },
       });
       vi.spyOn(wallet, "isDeployed").mockResolvedValue(false);
       const simulateSpy = vi.spyOn(wallet.getAccount(), "simulateTransaction");
@@ -540,7 +532,7 @@ describe("Wallet", () => {
       expect(simulateSpy).not.toHaveBeenCalled();
     });
 
-    it("should return ok for undeployed account with gasToken", async () => {
+    it("should return ok for undeployed account with paymaster gasToken", async () => {
       const signer = new StarkSigner(testPrivateKeys.random());
       const wallet = await sdk.connectWallet({
         account: { signer },
@@ -556,7 +548,10 @@ describe("Wallet", () => {
             calldata: [],
           },
         ],
-        gasToken: fromAddress("0x053c91253bc9"),
+        feeMode: {
+          type: "paymaster",
+          gasToken: fromAddress("0x053c91253bc9"),
+        },
       });
 
       expect(result.ok).toBe(true);


### PR DESCRIPTION
Closes #118

## What

Adds an optional `gasToken` field to `ExecuteOptions` and `DeployOptions`, allowing users to pay gas fees with ERC-20 tokens (USDC, STRK, etc.) through the AVNU Paymaster.

When `gasToken` is set, the SDK calls `executePaymasterTransaction` with `{ mode: 'default', gasToken }` instead of `{ mode: 'sponsored' }`. When omitted, nothing changes.

## Changes

| File | What changed |
|------|-------------|
| `src/types/wallet.ts` | Added `gasToken?: Address` to `ExecuteOptions` and `DeployOptions` |
| `src/wallet/utils.ts` | `sponsoredDetails()` now accepts `gasToken` and produces the correct fee mode |
| `src/wallet/index.ts` | `execute()` and `deploy()` read and forward `gasToken` through the full chain |
| `src/wallet/cartridge.ts` | `execute()` forwards `gasToken`; `deploy()` guards against it |

## Usage

```typescript
// Pay gas with USDC
await wallet.execute(calls, {
  gasToken: "0x053c91253bc...368a8",
});

// Sponsored (unchanged)
await wallet.execute(calls, { feeMode: "sponsored" });

// User pays ETH (unchanged)
await wallet.execute(calls);
```

## Tests

All 116 unit tests pass. No breaking changes.
