### PR TITLE
feat: add Paycrest fiat on/off-ramp module

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -57,6 +57,7 @@
           "mintlify-docs/build/consumer-app-sdk/connecting-wallets",
           "mintlify-docs/build/consumer-app-sdk/erc20",
           "mintlify-docs/build/consumer-app-sdk/staking",
+          "mintlify-docs/build/consumer-app-sdk/paycrest-fiat-ramp",
           "mintlify-docs/build/consumer-app-sdk/transactions",
           "mintlify-docs/build/consumer-app-sdk/tx-builder"
         ]

--- a/examples/paycrest/.env.example
+++ b/examples/paycrest/.env.example
@@ -1,0 +1,9 @@
+PAYCREST_API_KEY=your_paycrest_api_key_here
+RPC_URL=https://starknet-mainnet.public.blastapi.io
+PRIVATE_KEY=0x...
+WALLET_ADDRESS=0x...
+
+# Recipient bank account (NGN example via GTB)
+RECIPIENT_INSTITUTION=GTBINGLA
+RECIPIENT_ACCOUNT_IDENTIFIER=0123456789
+RECIPIENT_ACCOUNT_NAME=John Doe

--- a/examples/paycrest/offramp-api.ts
+++ b/examples/paycrest/offramp-api.ts
@@ -1,0 +1,83 @@
+import "dotenv/config";
+import {
+  Amount,
+  ChainId,
+  fromAddress,
+  Paycrest,
+  PaycrestOrderError,
+  StarkSigner,
+  StarkZap,
+  mainnetTokens,
+} from "starkzap";
+
+/**
+ * Off-ramp via the Sender API path: Paycrest creates the order,
+ * returns a `receiveAddress`, and the SDK transfers the tokens to it.
+ *
+ * Same final outcome as the gateway path, just orchestrated off-chain.
+ */
+async function main() {
+  const apiKey = required("PAYCREST_API_KEY");
+  const rpcUrl = required("RPC_URL");
+  const privateKey = required("PRIVATE_KEY");
+  const walletAddress = fromAddress(required("WALLET_ADDRESS"));
+
+  const sdk = new StarkZap({
+    rpcUrl,
+    chainId: ChainId.MAINNET,
+    paycrest: { apiKey },
+  });
+
+  const wallet = await sdk.connectWallet({
+    accountAddress: walletAddress,
+    account: { signer: new StarkSigner(privateKey) },
+  });
+  await wallet.ensureReady({ deploy: "if_needed" });
+
+  const paycrest = new Paycrest({ apiKey });
+  const result = await paycrest.offramp(wallet, {
+    path: "api",
+    from: {
+      token: mainnetTokens.USDC,
+      amount: Amount.parse("1", mainnetTokens.USDC),
+    },
+    to: {
+      currency: "NGN",
+      recipient: {
+        institution: required("RECIPIENT_INSTITUTION"),
+        accountIdentifier: required("RECIPIENT_ACCOUNT_IDENTIFIER"),
+        accountName: required("RECIPIENT_ACCOUNT_NAME"),
+      },
+    },
+    reference: `demo-${Date.now()}`,
+  });
+
+  console.log("orderId:", await result.orderId);
+  console.log("receiveAddress:", result.receiveAddress);
+  console.log("validUntil:", result.providerAccount?.validUntil);
+  console.log("submitted transfer tx:", result.tx.hash);
+
+  // result.wait() polls /v2/sender/orders/{uuid} until terminal
+  // (api path uses the UUID, gateway path uses the on-chain id).
+  try {
+    const status = await result.wait();
+    console.log("final status:", status.status);
+  } catch (err) {
+    if (err instanceof PaycrestOrderError) {
+      console.error("order ended in:", err.order.status, err.order);
+      process.exit(2);
+    }
+    throw err;
+  }
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/paycrest/offramp-gateway.ts
+++ b/examples/paycrest/offramp-gateway.ts
@@ -1,0 +1,92 @@
+import "dotenv/config";
+import {
+  Amount,
+  ChainId,
+  fromAddress,
+  Paycrest,
+  PaycrestOrderError,
+  StarkSigner,
+  StarkZap,
+  mainnetTokens,
+} from "starkzap";
+
+/**
+ * Off-ramp 1 USDC on Starknet -> NGN bank account, via the on-chain
+ * Cairo Gateway path. Requires a real mainnet wallet with USDC and an
+ * API key from app.paycrest.io.
+ *
+ * Paycrest is mainnet-only — there is no testnet variant.
+ */
+async function main() {
+  const apiKey = required("PAYCREST_API_KEY");
+  const rpcUrl = required("RPC_URL");
+  const privateKey = required("PRIVATE_KEY");
+  const walletAddress = fromAddress(required("WALLET_ADDRESS"));
+
+  const sdk = new StarkZap({
+    rpcUrl,
+    chainId: ChainId.MAINNET,
+    paycrest: { apiKey },
+  });
+
+  const wallet = await sdk.connectWallet({
+    accountAddress: walletAddress,
+    account: { signer: new StarkSigner(privateKey) },
+  });
+
+  await wallet.ensureReady({ deploy: "if_needed" });
+
+  const paycrest = new Paycrest({ apiKey });
+  const result = await paycrest.offramp(wallet, {
+    path: "gateway",
+    from: {
+      token: mainnetTokens.USDC,
+      amount: Amount.parse("1", mainnetTokens.USDC),
+    },
+    to: {
+      currency: "NGN",
+      recipient: {
+        institution: required("RECIPIENT_INSTITUTION"),
+        accountIdentifier: required("RECIPIENT_ACCOUNT_IDENTIFIER"),
+        accountName: required("RECIPIENT_ACCOUNT_NAME"),
+        memo: "starkzap demo",
+      },
+    },
+  });
+
+  console.log("submitted:", result.tx.hash);
+  console.log("rate:", result.rate);
+
+  // result.wait() handles the full lifecycle: waits for the L2
+  // receipt, parses the on-chain order id, then polls Paycrest until
+  // the order reaches a terminal status. For the gateway path it
+  // hits /v2/orders/{chain_id}/{gateway_id}; for the api path it
+  // hits /v2/sender/orders/{uuid}. Production servers should prefer
+  // webhooks via Paycrest.verifyWebhookSignature.
+  try {
+    const status = await result.wait();
+    console.log("orderId:", status.orderId);
+    console.log("final status:", status.status);
+  } catch (err) {
+    if (err instanceof PaycrestOrderError) {
+      console.error(
+        "order ended in non-success state:",
+        err.order.status,
+        err.order
+      );
+      process.exit(2);
+    }
+    throw err;
+  }
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/paycrest/onramp.ts
+++ b/examples/paycrest/onramp.ts
@@ -1,0 +1,56 @@
+import "dotenv/config";
+import { fromAddress, Paycrest, StarkZap, mainnetTokens } from "starkzap";
+
+/**
+ * On-ramp 50000 NGN -> USDC delivered to a Starknet wallet.
+ *
+ * On-ramp is Sender-API-only — Paycrest does not support on-ramp via
+ * the Cairo Gateway. The response carries the bank account the user
+ * must transfer fiat into; tokens are delivered after the transfer is
+ * verified.
+ */
+async function main() {
+  const apiKey = required("PAYCREST_API_KEY");
+  const walletAddress = fromAddress(required("WALLET_ADDRESS"));
+
+  // No wallet connection needed for on-ramp; the SDK is only used to
+  // hold the chainId/network identifier. You can also just construct
+  // `new Paycrest(...)` directly.
+  void new StarkZap({ network: "mainnet", paycrest: { apiKey } });
+
+  const paycrest = new Paycrest({ apiKey });
+  const result = await paycrest.onramp({
+    from: {
+      currency: "NGN",
+      amount: 50_000,
+      refundAccount: {
+        institution: required("RECIPIENT_INSTITUTION"),
+        accountIdentifier: required("RECIPIENT_ACCOUNT_IDENTIFIER"),
+        accountName: required("RECIPIENT_ACCOUNT_NAME"),
+      },
+    },
+    to: { token: mainnetTokens.USDC, recipient: walletAddress },
+    reference: `onramp-${Date.now()}`,
+  });
+
+  console.log("Pay this account to fund your wallet:");
+  console.log(`  bank:     ${result.providerAccount.institution}`);
+  console.log(`  account:  ${result.providerAccount.accountIdentifier}`);
+  console.log(`  name:     ${result.providerAccount.accountName}`);
+  console.log(
+    `  amount:   ${result.providerAccount.amountToTransfer} ${result.providerAccount.currency}`
+  );
+  console.log(`  expires:  ${result.validUntil}`);
+  console.log(`Order id:   ${result.orderId}`);
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/paycrest/package.json
+++ b/examples/paycrest/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "starkzap-example-paycrest",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "offramp:gateway": "node --import tsx offramp-gateway.ts",
+    "offramp:api": "node --import tsx offramp-api.ts",
+    "onramp": "node --import tsx onramp.ts",
+    "postinstall": "cd ../.. && npm run build"
+  },
+  "dependencies": {
+    "dotenv": "^17.2.3",
+    "starkzap": "file:../.."
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2"
+  }
+}

--- a/mintlify-docs/build/consumer-app-sdk/paycrest-fiat-ramp.mdx
+++ b/mintlify-docs/build/consumer-app-sdk/paycrest-fiat-ramp.mdx
@@ -1,0 +1,203 @@
+---
+title: Fiat on/off-ramp (Paycrest)
+description: Move money in and out of fiat from any StarkZap app — NGN, KES, UGX, TZS, MWK — with a single SDK module.
+---
+
+The Paycrest module turns USDC/USDT on Starknet into local fiat (and vice versa) without sending users to a third-party widget. Two transports share one TypeScript surface:
+
+- **Gateway path** (off-ramp default): emits an approve + `create_order` Call pair on the Cairo Gateway. Fully on-chain — composable with any other call in `wallet.tx()`.
+- **Sender API path**: REST call to Paycrest's backend; the SDK transfers tokens to the assigned receive address. Fastest time-to-live for app teams.
+
+On-ramp is Sender-API-only — the Cairo Gateway doesn't accept on-ramp orders. Webhooks can be verified with `Paycrest.verifyWebhookSignature()`.
+
+<Note>
+Paycrest is **mainnet-only** — there is no testnet backend or Gateway. The SDK throws a clear error on Sepolia.
+</Note>
+
+## Quick start
+
+```ts
+import { Amount, Paycrest, StarkZap, mainnetTokens } from "starkzap";
+
+const sdk = new StarkZap({
+  network: "mainnet",
+  paycrest: { apiKey: process.env.PAYCREST_API_KEY },
+});
+
+const wallet = await sdk.connectWallet({ /* ... your signer ... */ });
+const paycrest = new Paycrest({ apiKey: process.env.PAYCREST_API_KEY });
+
+// 100 USDC -> NGN bank account, on-chain via Gateway
+const off = await paycrest.offramp(wallet, {
+  from: { token: mainnetTokens.USDC, amount: Amount.parse("100", mainnetTokens.USDC) },
+  to: {
+    currency: "NGN",
+    recipient: {
+      institution: "GTBINGLA",
+      accountIdentifier: "0123456789",
+      accountName: "John Doe",
+      memo: "Salary",
+    },
+  },
+});
+
+// `orderId` is a Promise — it internally waits for the L2 receipt and
+// parses the on-chain `OrderCreated` event. You don't need to call
+// `tx.wait()` separately. Resolves to `null` if the tx reverts.
+console.log(await off.orderId);  // felt252 hex string
+```
+
+## Off-ramp via the Sender API
+
+Same shape, just `path: "api"`. The SDK posts the order, then transfers your tokens to the assigned receive address.
+
+```ts
+const off = await paycrest.offramp(wallet, {
+  path: "api",
+  from: { token: mainnetTokens.USDC, amount: Amount.parse("100", mainnetTokens.USDC) },
+  to: {
+    currency: "NGN",
+    recipient: { institution, accountIdentifier, accountName },
+  },
+  reference: "order-001",
+});
+
+console.log(await off.orderId, off.receiveAddress);
+await off.tx.wait();
+```
+
+The API path resolves the rate server-side. To display a quote in your UI before submitting, pre-fetch with `paycrest.getRate(...)` and pass it on the input as `rate`:
+
+```ts
+const quote = await paycrest.getRate({
+  network: "starknet",
+  token: "USDC",
+  amount: "100",
+  fiat: "NGN",
+  side: "sell",
+});
+console.log(quote.sell?.rate);
+
+const off = await paycrest.offramp(wallet, {
+  path: "api",
+  from: { ... },
+  to: { ... },
+  rate: quote.sell?.rate,
+});
+```
+
+## On-ramp (Sender API)
+
+On-ramp returns the bank account the user must transfer fiat into. No on-chain action — the app is responsible for displaying `providerAccount` and watching for settlement.
+
+```ts
+const on = await paycrest.onramp({
+  from: {
+    currency: "NGN",
+    amount: 50_000,
+    refundAccount: { institution, accountIdentifier, accountName },
+  },
+  to: { token: mainnetTokens.USDC, recipient: wallet.address },
+  reference: "onramp-001",
+});
+
+console.log(on.providerAccount);
+// { institution, accountIdentifier, accountName, amountToTransfer, currency, validUntil }
+```
+
+## Composing with other Calls
+
+The gateway-path off-ramp slots into `wallet.tx()` like any other module. Useful for batching with a pre-swap:
+
+```ts
+const tx = await wallet.tx()
+  .swap({ tokenIn: STRK, tokenOut: mainnetTokens.USDC, amountIn: Amount.parse("250", STRK) })
+  .paycrestOfframp({
+    from: { token: mainnetTokens.USDC, amount: Amount.parse("100", mainnetTokens.USDC) },
+    to: { currency: "NGN", recipient: { institution, accountIdentifier, accountName } },
+  })
+  .send();
+```
+
+`paycrestOfframp` only supports the gateway path — for the API path, call `paycrest.offramp(wallet, { path: "api", ... })` directly.
+
+## Tracking order status to terminal
+
+The on-chain transaction is just the first leg of an off-ramp. The order then routes through Paycrest's provider network and only finishes when the fiat side completes (`validated` or `settled`) or fails (`refunded` or `expired`). Two patterns:
+
+### Polling (good for scripts and short flows)
+
+`off.wait()` polls until the order reaches a terminal status. It picks the right endpoint based on the path the off-ramp took:
+
+- **api path** uses `GET /v2/sender/orders/{uuid}` — full order shape.
+- **gateway path** uses `GET /v2/orders/{chain_id}/{gateway_id}` — `/v2/sender/orders` doesn't index `gateway_id`, so this is the only public endpoint that does. Returns a smaller status shape (no `providerAccount`, no `direction`).
+
+```ts
+import { PaycrestOrderError } from "starkzap";
+
+try {
+  const status = await off.wait();
+  // status.status is "validated" or "settled"
+  // status.orderId is the UUID (api) or felt252 gateway_id (gateway)
+  // status.raw is the full underlying API response
+} catch (err) {
+  if (err instanceof PaycrestOrderError) {
+    // err.order.status is "refunded" or "expired"
+  } else {
+    throw err; // e.g. timeout
+  }
+}
+```
+
+For lower-level use, `paycrest.waitForOrder(uuidOrReference)` and `paycrest.waitForGatewayOrder(gatewayId, { chainId? })` are both exposed. Defaults: 5s poll interval, 10 min timeout, success states `["validated","settled"]`, error states `["refunded","expired"]`. Pass `signal: AbortSignal` to cancel.
+
+### Webhooks (good for production servers)
+
+For long-running services, prefer webhooks over polling. Paycrest signs webhook bodies with `X-Paycrest-Signature` (HMAC-SHA256 of the raw body). Verify with the static helper before trusting a payload:
+
+```ts
+import { Paycrest } from "starkzap";
+
+app.post("/webhooks/paycrest", express.raw({ type: "application/json" }), async (req, res) => {
+  const ok = await Paycrest.verifyWebhookSignature(
+    req.body.toString("utf8"),
+    req.header("X-Paycrest-Signature") ?? "",
+    process.env.PAYCREST_API_SECRET!
+  );
+  if (!ok) return res.status(401).end();
+
+  const payload = JSON.parse(req.body.toString("utf8"));
+  // handle payload.event: "payment_order.settled" | "payment_order.refunded" | ...
+  res.status(204).end();
+});
+```
+
+## Reference
+
+| Method | Description |
+| --- | --- |
+| `paycrest.listCurrencies()` | Fiat currencies available on Paycrest. |
+| `paycrest.listInstitutions(currencyCode)` | Banks / mobile-money operators for a currency. |
+| `paycrest.listTokens(network?)` | Stablecoins accepted, optionally by network. |
+| `paycrest.getRate({ network, token, amount, fiat, side? })` | Quote for an off-ramp / on-ramp. |
+| `paycrest.getOrder(id)` | Single-shot order status by UUID or `reference`. |
+| `paycrest.waitForOrder(id, options?)` | Poll `/v2/sender/orders/{id}` until terminal. UUID/reference only — won't accept gateway_id. |
+| `paycrest.waitForGatewayOrder(gatewayId, options?)` | Poll `/v2/orders/{chain_id}/{gateway_id}` until terminal. Use this when you only have the on-chain felt252 id. `chainId` defaults to `STARKNET_MAINNET_CHAIN_ID`. |
+| `off.wait(options?)` | Convenience that dispatches to the right endpoint based on `off.path`. **Recommended** unless you need the lower-level methods. |
+| `paycrest.offramp(wallet, input, options?)` | Off-ramp via gateway (default) or `path: "api"`. |
+| `paycrest.populateOfframp(wallet, input)` | Build approve + `create_order` Calls without executing. Gateway path only. |
+| `paycrest.onramp(input)` | Create an on-ramp order. Returns provider bank details. |
+| `Paycrest.verifyWebhookSignature(body, sig, secret)` | HMAC-SHA256 timing-safe verifier. |
+
+### Supported tokens (Starknet mainnet)
+
+- USDC — `0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb`
+- USDT — `0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8`
+
+### Supported corridors
+
+NGN, KES, UGX, TZS, MWK. Refresh at runtime via `paycrest.listCurrencies()`.
+
+### Cairo Gateway
+
+`0x06ff3a3b1532da65594fc98f9ca7200af6c3dbaf37e7339b0ebd3b3f2390c583`. Override per-instance with `new Paycrest({ gatewayAddress })` if you ever need to point at a fork.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4083,6 +4083,22 @@
         "xstream": "^11.14.0"
       }
     },
+    "node_modules/@cosmjs/socket/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@cosmjs/socket/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -15393,6 +15409,22 @@
         "ws": "^7.5.1"
       }
     },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -21514,6 +21546,22 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/hardhat/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/hardhat/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -22616,6 +22664,22 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/jayson/node_modules/uuid": {
       "version": "8.3.2",
@@ -33068,6 +33132,22 @@
         "@ethersproject/wordlists": "5.7.0"
       }
     },
+    "node_modules/zksync-ethers/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/zksync-ethers/node_modules/ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
@@ -33114,7 +33194,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "starkzap": "^2.0.0",
+        "starkzap": "^3.0.0",
         "zod": "^3.25.0"
       },
       "bin": {

--- a/src/abi/paycrest.ts
+++ b/src/abi/paycrest.ts
@@ -1,0 +1,985 @@
+export const ABI = [
+  {
+    type: "impl",
+    name: "UpgradeableImpl",
+    interface_name: "openzeppelin_upgrades::interface::IUpgradeable",
+  },
+  {
+    type: "interface",
+    name: "openzeppelin_upgrades::interface::IUpgradeable",
+    items: [
+      {
+        type: "function",
+        name: "upgrade",
+        inputs: [
+          {
+            name: "new_class_hash",
+            type: "core::starknet::class_hash::ClassHash",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+    ],
+  },
+  {
+    type: "impl",
+    name: "GatewayImpl",
+    interface_name: "paycrest::interfaces::IGateway::IGateway",
+  },
+  {
+    type: "struct",
+    name: "core::integer::u256",
+    members: [
+      {
+        name: "low",
+        type: "core::integer::u128",
+      },
+      {
+        name: "high",
+        type: "core::integer::u128",
+      },
+    ],
+  },
+  {
+    type: "struct",
+    name: "core::byte_array::ByteArray",
+    members: [
+      {
+        name: "data",
+        type: "core::array::Array::<core::bytes_31::bytes31>",
+      },
+      {
+        name: "pending_word",
+        type: "core::felt252",
+      },
+      {
+        name: "pending_word_len",
+        type: "core::internal::bounded_int::BoundedInt::<0, 30>",
+      },
+    ],
+  },
+  {
+    type: "enum",
+    name: "core::bool",
+    variants: [
+      {
+        name: "False",
+        type: "()",
+      },
+      {
+        name: "True",
+        type: "()",
+      },
+    ],
+  },
+  {
+    type: "struct",
+    name: "paycrest::interfaces::IGateway::Order",
+    members: [
+      {
+        name: "sender",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        name: "token",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        name: "sender_fee_recipient",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        name: "sender_fee",
+        type: "core::integer::u256",
+      },
+      {
+        name: "protocol_fee",
+        type: "core::integer::u256",
+      },
+      {
+        name: "is_fulfilled",
+        type: "core::bool",
+      },
+      {
+        name: "is_refunded",
+        type: "core::bool",
+      },
+      {
+        name: "refund_address",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        name: "current_bps",
+        type: "core::integer::u64",
+      },
+      {
+        name: "amount",
+        type: "core::integer::u256",
+      },
+    ],
+  },
+  {
+    type: "interface",
+    name: "paycrest::interfaces::IGateway::IGateway",
+    items: [
+      {
+        type: "function",
+        name: "create_order",
+        inputs: [
+          {
+            name: "token",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "amount",
+            type: "core::integer::u256",
+          },
+          {
+            name: "rate",
+            type: "core::integer::u128",
+          },
+          {
+            name: "sender_fee_recipient",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "sender_fee",
+            type: "core::integer::u256",
+          },
+          {
+            name: "refund_address",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "message_hash",
+            type: "core::byte_array::ByteArray",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::felt252",
+          },
+        ],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "settle_out",
+        inputs: [
+          {
+            name: "split_order_id",
+            type: "core::felt252",
+          },
+          {
+            name: "order_id",
+            type: "core::felt252",
+          },
+          {
+            name: "liquidity_provider",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "settle_percent",
+            type: "core::integer::u64",
+          },
+          {
+            name: "rebate_percent",
+            type: "core::integer::u64",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "settle_in",
+        inputs: [
+          {
+            name: "order_id",
+            type: "core::felt252",
+          },
+          {
+            name: "token",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "amount",
+            type: "core::integer::u256",
+          },
+          {
+            name: "sender_fee_recipient",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "sender_fee",
+            type: "core::integer::u256",
+          },
+          {
+            name: "recipient",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "rate",
+            type: "core::integer::u128",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "refund",
+        inputs: [
+          {
+            name: "fee",
+            type: "core::integer::u256",
+          },
+          {
+            name: "order_id",
+            type: "core::felt252",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "is_token_supported",
+        inputs: [
+          {
+            name: "token",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        type: "function",
+        name: "get_order_info",
+        inputs: [
+          {
+            name: "order_id",
+            type: "core::felt252",
+          },
+        ],
+        outputs: [
+          {
+            type: "paycrest::interfaces::IGateway::Order",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        type: "function",
+        name: "get_aggregator",
+        inputs: [],
+        outputs: [
+          {
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        state_mutability: "view",
+      },
+    ],
+  },
+  {
+    type: "impl",
+    name: "OwnableTwoStepMixinImpl",
+    interface_name:
+      "openzeppelin_access::ownable::interface::OwnableTwoStepABI",
+  },
+  {
+    type: "interface",
+    name: "openzeppelin_access::ownable::interface::OwnableTwoStepABI",
+    items: [
+      {
+        type: "function",
+        name: "owner",
+        inputs: [],
+        outputs: [
+          {
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        type: "function",
+        name: "pending_owner",
+        inputs: [],
+        outputs: [
+          {
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        type: "function",
+        name: "accept_ownership",
+        inputs: [],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "transfer_ownership",
+        inputs: [
+          {
+            name: "new_owner",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "renounce_ownership",
+        inputs: [],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "pendingOwner",
+        inputs: [],
+        outputs: [
+          {
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        type: "function",
+        name: "acceptOwnership",
+        inputs: [],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "transferOwnership",
+        inputs: [
+          {
+            name: "newOwner",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "renounceOwnership",
+        inputs: [],
+        outputs: [],
+        state_mutability: "external",
+      },
+    ],
+  },
+  {
+    type: "impl",
+    name: "PausableImpl",
+    interface_name: "openzeppelin_security::interface::IPausable",
+  },
+  {
+    type: "interface",
+    name: "openzeppelin_security::interface::IPausable",
+    items: [
+      {
+        type: "function",
+        name: "is_paused",
+        inputs: [],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "view",
+      },
+    ],
+  },
+  {
+    type: "constructor",
+    name: "constructor",
+    inputs: [
+      {
+        name: "owner",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+  },
+  {
+    type: "function",
+    name: "pause",
+    inputs: [],
+    outputs: [],
+    state_mutability: "external",
+  },
+  {
+    type: "function",
+    name: "unpause",
+    inputs: [],
+    outputs: [],
+    state_mutability: "external",
+  },
+  {
+    type: "function",
+    name: "setting_manager_bool",
+    inputs: [
+      {
+        name: "what",
+        type: "core::felt252",
+      },
+      {
+        name: "value",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        name: "status",
+        type: "core::integer::u256",
+      },
+    ],
+    outputs: [],
+    state_mutability: "external",
+  },
+  {
+    type: "function",
+    name: "update_protocol_address",
+    inputs: [
+      {
+        name: "what",
+        type: "core::felt252",
+      },
+      {
+        name: "value",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+    outputs: [],
+    state_mutability: "external",
+  },
+  {
+    type: "function",
+    name: "set_token_fee_settings",
+    inputs: [
+      {
+        name: "token",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        name: "sender_to_provider",
+        type: "core::integer::u64",
+      },
+      {
+        name: "provider_to_aggregator",
+        type: "core::integer::u64",
+      },
+      {
+        name: "sender_to_aggregator",
+        type: "core::integer::u64",
+      },
+      {
+        name: "provider_to_aggregator_fx",
+        type: "core::integer::u64",
+      },
+    ],
+    outputs: [],
+    state_mutability: "external",
+  },
+  {
+    type: "event",
+    name: "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferred",
+    kind: "struct",
+    members: [
+      {
+        name: "previous_owner",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "key",
+      },
+      {
+        name: "new_owner",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "key",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferStarted",
+    kind: "struct",
+    members: [
+      {
+        name: "previous_owner",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "key",
+      },
+      {
+        name: "new_owner",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "key",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "openzeppelin_access::ownable::ownable::OwnableComponent::Event",
+    kind: "enum",
+    variants: [
+      {
+        name: "OwnershipTransferred",
+        type: "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferred",
+        kind: "nested",
+      },
+      {
+        name: "OwnershipTransferStarted",
+        type: "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferStarted",
+        kind: "nested",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "openzeppelin_security::pausable::PausableComponent::Paused",
+    kind: "struct",
+    members: [
+      {
+        name: "account",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "openzeppelin_security::pausable::PausableComponent::Unpaused",
+    kind: "struct",
+    members: [
+      {
+        name: "account",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "openzeppelin_security::pausable::PausableComponent::Event",
+    kind: "enum",
+    variants: [
+      {
+        name: "Paused",
+        type: "openzeppelin_security::pausable::PausableComponent::Paused",
+        kind: "nested",
+      },
+      {
+        name: "Unpaused",
+        type: "openzeppelin_security::pausable::PausableComponent::Unpaused",
+        kind: "nested",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Upgraded",
+    kind: "struct",
+    members: [
+      {
+        name: "class_hash",
+        type: "core::starknet::class_hash::ClassHash",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Event",
+    kind: "enum",
+    variants: [
+      {
+        name: "Upgraded",
+        type: "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Upgraded",
+        kind: "nested",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "paycrest::contracts::GatewaySettingManager::GatewaySettingManagerComponent::SettingManagerBool",
+    kind: "struct",
+    members: [
+      {
+        name: "what",
+        type: "core::felt252",
+        kind: "key",
+      },
+      {
+        name: "value",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "key",
+      },
+      {
+        name: "status",
+        type: "core::integer::u256",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "paycrest::contracts::GatewaySettingManager::GatewaySettingManagerComponent::ProtocolAddressUpdated",
+    kind: "struct",
+    members: [
+      {
+        name: "what",
+        type: "core::felt252",
+        kind: "key",
+      },
+      {
+        name: "address",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "key",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "paycrest::contracts::GatewaySettingManager::GatewaySettingManagerComponent::TokenFeeSettingsUpdated",
+    kind: "struct",
+    members: [
+      {
+        name: "token",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "key",
+      },
+      {
+        name: "sender_to_provider",
+        type: "core::integer::u64",
+        kind: "data",
+      },
+      {
+        name: "provider_to_aggregator",
+        type: "core::integer::u64",
+        kind: "data",
+      },
+      {
+        name: "sender_to_aggregator",
+        type: "core::integer::u64",
+        kind: "data",
+      },
+      {
+        name: "provider_to_aggregator_fx",
+        type: "core::integer::u64",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "paycrest::contracts::GatewaySettingManager::GatewaySettingManagerComponent::Event",
+    kind: "enum",
+    variants: [
+      {
+        name: "SettingManagerBool",
+        type: "paycrest::contracts::GatewaySettingManager::GatewaySettingManagerComponent::SettingManagerBool",
+        kind: "nested",
+      },
+      {
+        name: "ProtocolAddressUpdated",
+        type: "paycrest::contracts::GatewaySettingManager::GatewaySettingManagerComponent::ProtocolAddressUpdated",
+        kind: "nested",
+      },
+      {
+        name: "TokenFeeSettingsUpdated",
+        type: "paycrest::contracts::GatewaySettingManager::GatewaySettingManagerComponent::TokenFeeSettingsUpdated",
+        kind: "nested",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "paycrest::interfaces::IGateway::OrderCreated",
+    kind: "struct",
+    members: [
+      {
+        name: "sender",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "key",
+      },
+      {
+        name: "token",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "key",
+      },
+      {
+        name: "amount",
+        type: "core::integer::u256",
+        kind: "key",
+      },
+      {
+        name: "protocol_fee",
+        type: "core::integer::u256",
+        kind: "data",
+      },
+      {
+        name: "order_id",
+        type: "core::felt252",
+        kind: "data",
+      },
+      {
+        name: "rate",
+        type: "core::integer::u128",
+        kind: "data",
+      },
+      {
+        name: "message_hash",
+        type: "core::byte_array::ByteArray",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "paycrest::interfaces::IGateway::SettleOut",
+    kind: "struct",
+    members: [
+      {
+        name: "split_order_id",
+        type: "core::felt252",
+        kind: "data",
+      },
+      {
+        name: "order_id",
+        type: "core::felt252",
+        kind: "key",
+      },
+      {
+        name: "liquidity_provider",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "key",
+      },
+      {
+        name: "settle_percent",
+        type: "core::integer::u64",
+        kind: "data",
+      },
+      {
+        name: "rebate_percent",
+        type: "core::integer::u64",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "paycrest::interfaces::IGateway::SettleIn",
+    kind: "struct",
+    members: [
+      {
+        name: "order_id",
+        type: "core::felt252",
+        kind: "key",
+      },
+      {
+        name: "liquidity_provider",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "key",
+      },
+      {
+        name: "recipient",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "key",
+      },
+      {
+        name: "amount",
+        type: "core::integer::u256",
+        kind: "data",
+      },
+      {
+        name: "token",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "data",
+      },
+      {
+        name: "aggregator_fee",
+        type: "core::integer::u256",
+        kind: "data",
+      },
+      {
+        name: "rate",
+        type: "core::integer::u128",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "paycrest::interfaces::IGateway::OrderRefunded",
+    kind: "struct",
+    members: [
+      {
+        name: "fee",
+        type: "core::integer::u256",
+        kind: "data",
+      },
+      {
+        name: "order_id",
+        type: "core::felt252",
+        kind: "key",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "paycrest::interfaces::IGateway::SenderFeeTransferred",
+    kind: "struct",
+    members: [
+      {
+        name: "order_id",
+        type: "core::felt252",
+        kind: "key",
+      },
+      {
+        name: "sender",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "key",
+      },
+      {
+        name: "amount",
+        type: "core::integer::u256",
+        kind: "key",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "paycrest::interfaces::IGateway::LocalTransferFeeSplit",
+    kind: "struct",
+    members: [
+      {
+        name: "order_id",
+        type: "core::felt252",
+        kind: "key",
+      },
+      {
+        name: "sender_amount",
+        type: "core::integer::u256",
+        kind: "data",
+      },
+      {
+        name: "provider_amount",
+        type: "core::integer::u256",
+        kind: "data",
+      },
+      {
+        name: "aggregator_amount",
+        type: "core::integer::u256",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "paycrest::interfaces::IGateway::FxTransferFeeSplit",
+    kind: "struct",
+    members: [
+      {
+        name: "order_id",
+        type: "core::felt252",
+        kind: "key",
+      },
+      {
+        name: "sender_amount",
+        type: "core::integer::u256",
+        kind: "data",
+      },
+      {
+        name: "aggregator_amount",
+        type: "core::integer::u256",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "paycrest::contracts::Gateway::Gateway::Event",
+    kind: "enum",
+    variants: [
+      {
+        name: "OwnableEvent",
+        type: "openzeppelin_access::ownable::ownable::OwnableComponent::Event",
+        kind: "flat",
+      },
+      {
+        name: "PausableEvent",
+        type: "openzeppelin_security::pausable::PausableComponent::Event",
+        kind: "flat",
+      },
+      {
+        name: "UpgradeableEvent",
+        type: "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Event",
+        kind: "flat",
+      },
+      {
+        name: "GatewaySettingManagerEvent",
+        type: "paycrest::contracts::GatewaySettingManager::GatewaySettingManagerComponent::Event",
+        kind: "flat",
+      },
+      {
+        name: "OrderCreated",
+        type: "paycrest::interfaces::IGateway::OrderCreated",
+        kind: "nested",
+      },
+      {
+        name: "SettleOut",
+        type: "paycrest::interfaces::IGateway::SettleOut",
+        kind: "nested",
+      },
+      {
+        name: "SettleIn",
+        type: "paycrest::interfaces::IGateway::SettleIn",
+        kind: "nested",
+      },
+      {
+        name: "OrderRefunded",
+        type: "paycrest::interfaces::IGateway::OrderRefunded",
+        kind: "nested",
+      },
+      {
+        name: "SenderFeeTransferred",
+        type: "paycrest::interfaces::IGateway::SenderFeeTransferred",
+        kind: "nested",
+      },
+      {
+        name: "LocalTransferFeeSplit",
+        type: "paycrest::interfaces::IGateway::LocalTransferFeeSplit",
+        kind: "nested",
+      },
+      {
+        name: "FxTransferFeeSplit",
+        type: "paycrest::interfaces::IGateway::FxTransferFeeSplit",
+        kind: "nested",
+      },
+    ],
+  },
+] as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,9 @@ export * from "@/connect";
 // Troves
 export * from "@/troves";
 
+// Paycrest (fiat on/off-ramp)
+export * from "@/paycrest";
+
 // Logger
 export type { Logger, LoggerConfig, LogLevel } from "@/logger";
 

--- a/src/paycrest/api.ts
+++ b/src/paycrest/api.ts
@@ -1,0 +1,242 @@
+import { assertSafeHttpUrl } from "@/utils";
+import type {
+  PaycrestCurrency,
+  PaycrestInstitution,
+  PaycrestNetwork,
+  PaycrestOrder,
+  PaycrestProviderOrderStatus,
+  PaycrestRate,
+  PaycrestToken,
+} from "@/paycrest/types";
+
+export const PAYCREST_API_BASE_DEFAULT = "https://api.paycrest.io";
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export interface PaycrestApiOptions {
+  apiBaseUrl?: string;
+  apiKey?: string;
+  fetch?: typeof fetch;
+  requestTimeoutMs?: number;
+}
+
+interface PaycrestEnvelope<T> {
+  status: string;
+  message?: string;
+  data: T;
+}
+
+/**
+ * Thin REST client for the Paycrest Sender API. Mirrors the HTTP pattern
+ * used by `src/signer/privy.ts` — URL validation up front, AbortController
+ * timeout, JSON-error extraction with multiple fallback keys.
+ *
+ * Unauthenticated endpoints (currencies, institutions, tokens, rates,
+ * pubkey) work without an API key; order-creating endpoints require one.
+ */
+export class PaycrestApi {
+  private readonly baseUrl: string;
+  private readonly apiKey: string | undefined;
+  private readonly fetcher: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(options: PaycrestApiOptions = {}) {
+    const rawBase = options.apiBaseUrl ?? PAYCREST_API_BASE_DEFAULT;
+    this.baseUrl = assertSafeHttpUrl(rawBase, "PaycrestOptions.apiBaseUrl")
+      .toString()
+      .replace(/\/+$/, "");
+    this.apiKey = options.apiKey;
+    this.fetcher =
+      options.fetch ??
+      ((url: RequestInfo | URL, init?: RequestInit) => fetch(url, init));
+    this.timeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  /** RSA public key (PEM) used to encrypt recipient details on the gateway path. */
+  async getPublicKey(): Promise<string> {
+    const env = await this.request<string>("/v2/pubkey", { method: "GET" });
+    return env;
+  }
+
+  async getCurrencies(): Promise<PaycrestCurrency[]> {
+    return this.request<PaycrestCurrency[]>("/v2/currencies", {
+      method: "GET",
+    });
+  }
+
+  async getInstitutions(currencyCode: string): Promise<PaycrestInstitution[]> {
+    if (!currencyCode) {
+      throw new Error("Paycrest.getInstitutions: currencyCode is required");
+    }
+    return this.request<PaycrestInstitution[]>(
+      `/v2/institutions/${encodeURIComponent(currencyCode)}`,
+      { method: "GET" }
+    );
+  }
+
+  async getTokens(network?: PaycrestNetwork): Promise<PaycrestToken[]> {
+    const path = network
+      ? `/v2/tokens?network=${encodeURIComponent(network)}`
+      : "/v2/tokens";
+    return this.request<PaycrestToken[]>(path, { method: "GET" });
+  }
+
+  async getRate(args: {
+    network: PaycrestNetwork;
+    token: string;
+    amount: string | number;
+    fiat: string;
+    side?: "buy" | "sell";
+    providerId?: string;
+  }): Promise<PaycrestRate> {
+    const { network, token, amount, fiat, side, providerId } = args;
+    const params = new URLSearchParams();
+    if (side) params.set("side", side);
+    if (providerId) params.set("provider_id", providerId);
+    const query = params.toString();
+    const path = `/v2/rates/${encodeURIComponent(network)}/${encodeURIComponent(token)}/${encodeURIComponent(String(amount))}/${encodeURIComponent(fiat)}${query ? `?${query}` : ""}`;
+    return this.request<PaycrestRate>(path, { method: "GET" });
+  }
+
+  async createOrder(body: unknown): Promise<PaycrestOrder> {
+    this.requireApiKey("createOrder");
+    return this.request<PaycrestOrder>("/v2/sender/orders", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  }
+
+  async getOrder(id: string): Promise<PaycrestOrder> {
+    this.requireApiKey("getOrder");
+    return this.request<PaycrestOrder>(
+      `/v2/sender/orders/${encodeURIComponent(id)}`,
+      { method: "GET" }
+    );
+  }
+
+  async listOrders(filter?: Record<string, string | number>): Promise<{
+    orders: PaycrestOrder[];
+    [key: string]: unknown;
+  }> {
+    this.requireApiKey("listOrders");
+    let path = "/v2/sender/orders";
+    if (filter && Object.keys(filter).length > 0) {
+      const params = new URLSearchParams();
+      for (const [k, v] of Object.entries(filter)) params.set(k, String(v));
+      path += `?${params.toString()}`;
+    }
+    return this.request<{ orders: PaycrestOrder[] }>(path, { method: "GET" });
+  }
+
+  /**
+   * Look up an order by its on-chain gateway_id. Hits
+   * `GET /v2/orders/{chain_id}/{gateway_id}` (the
+   * `GetProviderOrderStatus` endpoint), which is the only public
+   * endpoint that indexes by gateway_id.
+   *
+   * Public endpoint — no API key required. Returns a smaller status
+   * shape than the full `PaycrestOrder`.
+   *
+   * `chainId` is the aggregator's fictional int64 for the network —
+   * for Starknet mainnet it's `STARKNET_MAINNET_CHAIN_ID` from
+   * `presets.ts`. Stored as `bigint` because the value exceeds
+   * `Number.MAX_SAFE_INTEGER`.
+   */
+  async getProviderOrderStatus(
+    chainId: bigint | number | string,
+    gatewayId: string
+  ): Promise<PaycrestProviderOrderStatus> {
+    if (!gatewayId) {
+      throw new Error("Paycrest.getProviderOrderStatus: gatewayId is required");
+    }
+    return this.request<PaycrestProviderOrderStatus>(
+      `/v2/orders/${encodeURIComponent(String(chainId))}/${encodeURIComponent(gatewayId)}`,
+      { method: "GET" }
+    );
+  }
+
+  private requireApiKey(method: string): void {
+    if (!this.apiKey) {
+      throw new Error(
+        `Paycrest.${method} requires an API key — pass apiKey to the Paycrest constructor or via SDKConfig.paycrest.apiKey.`
+      );
+    }
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+    };
+    if (init.body !== undefined) headers["Content-Type"] = "application/json";
+    if (this.apiKey) headers["API-Key"] = this.apiKey;
+    if (init.headers)
+      Object.assign(headers, init.headers as Record<string, string>);
+
+    try {
+      const res = await this.fetcher(`${this.baseUrl}${path}`, {
+        ...init,
+        headers,
+        signal: controller.signal,
+      });
+
+      let parsed: unknown;
+      try {
+        parsed = await res.json();
+      } catch {
+        if (!res.ok) {
+          throw new Error(
+            `Paycrest API ${init.method ?? "GET"} ${path} failed: ${res.status} ${res.statusText}`
+          );
+        }
+        throw new Error(`Paycrest API returned non-JSON response for ${path}`);
+      }
+
+      if (!res.ok) {
+        const message =
+          extractErrorMessage(parsed) ?? `${res.status} ${res.statusText}`;
+        throw new Error(
+          `Paycrest API ${init.method ?? "GET"} ${path} failed: ${message}`
+        );
+      }
+
+      const envelope = parsed as Partial<PaycrestEnvelope<T>>;
+      if (envelope && "data" in envelope) {
+        return envelope.data as T;
+      }
+      // Some endpoints (e.g. raw key) may return a value directly.
+      return parsed as T;
+    } catch (error) {
+      const name = errorName(error);
+      if (name === "AbortError") {
+        throw new Error(
+          `Paycrest API ${init.method ?? "GET"} ${path} timed out after ${this.timeoutMs}ms`
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function extractErrorMessage(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+  for (const key of ["message", "error", "details"]) {
+    const entry = v[key];
+    if (typeof entry === "string" && entry.length > 0) return entry;
+  }
+  if (typeof v["data"] === "object" && v["data"] !== null) {
+    return extractErrorMessage(v["data"]);
+  }
+  return null;
+}
+
+function errorName(error: unknown): string {
+  if (error && typeof error === "object" && "name" in error) {
+    const n = (error as { name?: unknown }).name;
+    return typeof n === "string" ? n : "";
+  }
+  return "";
+}

--- a/src/paycrest/encryption.ts
+++ b/src/paycrest/encryption.ts
@@ -1,0 +1,156 @@
+/**
+ * RSA-OAEP-SHA256 encryption for Paycrest recipient details (gateway path).
+ *
+ * Auto-detects the runtime: prefers `globalThis.crypto.subtle` (browsers,
+ * React Native via polyfills, modern workers) and falls back to Node's
+ * `node:crypto.publicEncrypt` when SubtleCrypto isn't available.
+ *
+ * The Cairo Gateway expects the encrypted blob as a UTF-8 ByteArray on
+ * `create_order`. Both code paths return a base64-encoded string; pass it
+ * straight to `populateCreateOrder({ messageHash })`.
+ */
+
+const PEM_BEGIN = "-----BEGIN PUBLIC KEY-----";
+const PEM_END = "-----END PUBLIC KEY-----";
+
+/**
+ * Strip PEM armor and base64-decode the SPKI body to a Uint8Array
+ * suitable for `crypto.subtle.importKey("spki", ...)`.
+ */
+function pemToSpki(pem: string): Uint8Array {
+  const trimmed = pem.trim();
+  const start = trimmed.indexOf(PEM_BEGIN);
+  const end = trimmed.indexOf(PEM_END);
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error(
+      "Paycrest public key is not a valid PEM (missing BEGIN/END PUBLIC KEY markers)"
+    );
+  }
+  const body = trimmed
+    .slice(start + PEM_BEGIN.length, end)
+    .replace(/[\r\n\s]+/g, "");
+  return base64Decode(body);
+}
+
+function base64Decode(value: string): Uint8Array {
+  if (typeof globalThis.atob === "function") {
+    const binary = globalThis.atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+  // Node fallback (atob is global on Node 18+, but be defensive).
+  const buf = (
+    globalThis as { Buffer?: { from(s: string, e: string): Uint8Array } }
+  ).Buffer?.from(value, "base64");
+  if (buf) return new Uint8Array(buf);
+  throw new Error("No base64 decoder available in this environment");
+}
+
+function base64Encode(bytes: Uint8Array): string {
+  if (typeof globalThis.btoa === "function") {
+    let binary = "";
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i]!);
+    }
+    return globalThis.btoa(binary);
+  }
+  const Buf = (
+    globalThis as {
+      Buffer?: { from(b: Uint8Array): { toString(e: string): string } };
+    }
+  ).Buffer;
+  if (Buf) return Buf.from(bytes).toString("base64");
+  throw new Error("No base64 encoder available in this environment");
+}
+
+interface SubtleCryptoLike {
+  importKey(
+    format: "spki",
+    keyData: BufferSource,
+    algorithm: { name: "RSA-OAEP"; hash: "SHA-256" },
+    extractable: boolean,
+    keyUsages: ["encrypt"]
+  ): Promise<CryptoKey>;
+  encrypt(
+    algorithm: { name: "RSA-OAEP" },
+    key: CryptoKey,
+    data: BufferSource
+  ): Promise<ArrayBuffer>;
+}
+
+function getSubtle(): SubtleCryptoLike | null {
+  const subtle = (globalThis as { crypto?: { subtle?: SubtleCryptoLike } })
+    .crypto?.subtle;
+  return subtle ?? null;
+}
+
+async function encryptViaSubtle(
+  subtle: SubtleCryptoLike,
+  pem: string,
+  plaintext: string
+): Promise<string> {
+  const spki = pemToSpki(pem);
+  const key = await subtle.importKey(
+    "spki",
+    toArrayBuffer(spki),
+    { name: "RSA-OAEP", hash: "SHA-256" },
+    false,
+    ["encrypt"]
+  );
+  const encoded = new TextEncoder().encode(plaintext);
+  const ciphertext = await subtle.encrypt(
+    { name: "RSA-OAEP" },
+    key,
+    toArrayBuffer(encoded)
+  );
+  return base64Encode(new Uint8Array(ciphertext));
+}
+
+/**
+ * Copy a `Uint8Array` into a fresh `ArrayBuffer` so it satisfies the
+ * `BufferSource` constraint on SubtleCrypto methods (TS now requires
+ * `ArrayBufferView<ArrayBuffer>`, not `ArrayBufferLike`).
+ */
+function toArrayBuffer(view: Uint8Array): ArrayBuffer {
+  const buf = new ArrayBuffer(view.byteLength);
+  new Uint8Array(buf).set(view);
+  return buf;
+}
+
+async function encryptViaNode(pem: string, plaintext: string): Promise<string> {
+  // Lazy-load `node:crypto` so bundlers don't pull it into browser builds.
+  const nodeCrypto =
+    (await import("node:crypto")) as typeof import("node:crypto");
+  const ciphertext = nodeCrypto.publicEncrypt(
+    {
+      key: pem,
+      padding: nodeCrypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "sha256",
+    },
+    Buffer.from(plaintext, "utf8")
+  );
+  return ciphertext.toString("base64");
+}
+
+/**
+ * Encrypts `plaintext` with the aggregator's RSA public key (PEM, SPKI).
+ *
+ * - Uses `crypto.subtle.encrypt({name: "RSA-OAEP"}, ...)` when SubtleCrypto
+ *   is available (browsers, React Native, modern workers).
+ * - Falls back to `node:crypto.publicEncrypt(..., RSA_PKCS1_OAEP_PADDING,
+ *   oaepHash: "sha256")` in Node.
+ *
+ * Returns base64-encoded ciphertext. Output of both paths decrypts to the
+ * same plaintext via the corresponding private key.
+ */
+export async function encryptRecipient(
+  publicKeyPem: string,
+  plaintext: string
+): Promise<string> {
+  const subtle = getSubtle();
+  if (subtle) return encryptViaSubtle(subtle, publicKeyPem, plaintext);
+  return encryptViaNode(publicKeyPem, plaintext);
+}

--- a/src/paycrest/gateway.ts
+++ b/src/paycrest/gateway.ts
@@ -1,0 +1,178 @@
+import {
+  type Call,
+  Contract,
+  hash,
+  num,
+  type RpcProvider,
+  type TypedContractV2,
+  uint256,
+} from "starknet";
+import { ABI as PAYCREST_GATEWAY_ABI } from "@/abi/paycrest";
+import { fromAddress, type Address } from "@/types";
+import type { PaycrestOrderInfo } from "@/paycrest/types";
+
+/**
+ * Cairo selector for `OrderCreated`. Computed at module load — matches
+ * `keys[0]` of the event emitted by `create_order`.
+ *
+ * `keys[0] = selector("OrderCreated")`,
+ * `keys[1] = sender`, `keys[2] = token`,
+ * `keys[3..4] = amount.low/high (indexed u256)`,
+ * `data[0..1] = protocol_fee.low/high`,
+ * `data[2] = order_id (felt252)`,
+ * `data[3] = rate (u128)`,
+ * `data[4..] = message_hash (ByteArray serialization)`
+ */
+export const ORDER_CREATED_EVENT_SELECTOR = num.toHex(
+  hash.starknetKeccak("OrderCreated")
+);
+
+const ZERO_ADDRESS_FELT = "0x0";
+
+export interface PopulateCreateOrderArgs {
+  token: Address;
+  /** Token amount in base units (e.g. `Amount.toBase()`). */
+  amount: bigint;
+  /** Rate as `u128`, scaled per the Paycrest convention (see notes in paycrest.ts). */
+  rate: bigint;
+  /** Optional sender-fee recipient. Defaults to the zero address. */
+  senderFeeRecipient?: Address;
+  /** Optional sender fee in token base units. Defaults to `0n`. */
+  senderFee?: bigint;
+  /** Refund address — typically the wallet sending the order. */
+  refundAddress: Address;
+  /** Base64-encoded RSA-OAEP ciphertext of the recipient JSON. */
+  messageHash: string;
+}
+
+/**
+ * Wrapper around the Cairo Gateway contract. Mirrors the `Erc20` class:
+ * an instance per gateway address with `populate*` builders and read
+ * helpers. The off-ramp gateway path uses `populateCreateOrder` to
+ * produce a `Call` for batching alongside the ERC20 approve.
+ */
+export class PaycrestGateway {
+  readonly address: Address;
+  private readonly contract: TypedContractV2<typeof PAYCREST_GATEWAY_ABI>;
+
+  constructor(address: Address, provider: RpcProvider) {
+    this.address = address;
+    this.contract = new Contract({
+      abi: PAYCREST_GATEWAY_ABI,
+      address,
+      providerOrAccount: provider,
+    }).typedv2(PAYCREST_GATEWAY_ABI);
+  }
+
+  /**
+   * Build a `create_order` Call without executing. Compose with an
+   * ERC20 approve to the gateway (for `amount + senderFee`) and submit
+   * atomically via `wallet.execute([approve, createOrder])`.
+   */
+  populateCreateOrder(args: PopulateCreateOrderArgs): Call {
+    const senderFeeRecipient =
+      args.senderFeeRecipient ?? (ZERO_ADDRESS_FELT as Address);
+    const senderFee = args.senderFee ?? 0n;
+    return this.contract.populateTransaction.create_order(
+      args.token,
+      uint256.bnToUint256(args.amount),
+      args.rate,
+      senderFeeRecipient,
+      uint256.bnToUint256(senderFee),
+      args.refundAddress,
+      args.messageHash
+    );
+  }
+
+  /** Whether the gateway accepts orders for `token`. */
+  async isTokenSupported(token: Address): Promise<boolean> {
+    return this.contract.is_token_supported(token);
+  }
+
+  /** Read the on-chain order struct by id (felt252 hex string). */
+  async getOrderInfo(orderId: string): Promise<PaycrestOrderInfo> {
+    const raw = (await this.contract.get_order_info(orderId)) as unknown as {
+      sender: bigint | string;
+      token: bigint | string;
+      sender_fee_recipient: bigint | string;
+      sender_fee:
+        | bigint
+        | string
+        | { low: bigint | string; high: bigint | string };
+      protocol_fee:
+        | bigint
+        | string
+        | { low: bigint | string; high: bigint | string };
+      is_fulfilled: boolean;
+      is_refunded: boolean;
+      refund_address: bigint | string;
+      current_bps: bigint | string;
+      amount: bigint | string | { low: bigint | string; high: bigint | string };
+    };
+    return {
+      sender: fromAddress(raw.sender),
+      token: fromAddress(raw.token),
+      senderFeeRecipient: fromAddress(raw.sender_fee_recipient),
+      senderFee: toBigInt(raw.sender_fee),
+      protocolFee: toBigInt(raw.protocol_fee),
+      isFulfilled: raw.is_fulfilled,
+      isRefunded: raw.is_refunded,
+      refundAddress: fromAddress(raw.refund_address),
+      currentBps: toBigInt(raw.current_bps),
+      amount: toBigInt(raw.amount),
+    };
+  }
+}
+
+function toBigInt(
+  value: bigint | string | { low: bigint | string; high: bigint | string }
+): bigint {
+  if (typeof value === "bigint") return value;
+  if (typeof value === "string") return BigInt(value);
+  // u256 returned by the typed contract is `{low, high}` already as
+  // bigint/string — fold it back into a single bigint.
+  return uint256.uint256ToBN({
+    low: BigInt(value.low),
+    high: BigInt(value.high),
+  });
+}
+
+/**
+ * Find the `OrderCreated` event for a given gateway in the receipt's
+ * event list and return the order id (felt252 hex string). Returns
+ * `null` if no matching event is present.
+ *
+ * Receipts from `account.execute()` typically include events under
+ * `events: { from_address, keys, data }[]`. We match by both
+ * `from_address` (the gateway) and `keys[0]` (the event selector).
+ */
+export function extractOrderIdFromReceipt(
+  receipt: {
+    events?: ReadonlyArray<{
+      from_address?: string;
+      keys?: string[];
+      data?: string[];
+    }>;
+  },
+  gatewayAddress: Address
+): string | null {
+  const events = receipt.events;
+  if (!events || events.length === 0) return null;
+  const gatewayHex = num.toHex(num.toBigInt(gatewayAddress));
+  const targetKey = num.toHex(num.toBigInt(ORDER_CREATED_EVENT_SELECTOR));
+  for (const e of events) {
+    const fromHex = e.from_address
+      ? num.toHex(num.toBigInt(e.from_address))
+      : "";
+    if (fromHex !== gatewayHex) continue;
+    const keys = e.keys ?? [];
+    if (keys.length === 0) continue;
+    const k0 = num.toHex(num.toBigInt(keys[0]!));
+    if (k0 !== targetKey) continue;
+    // data layout: protocol_fee (2 felts), order_id (1 felt), rate (1 felt), message_hash (...)
+    const data = e.data ?? [];
+    if (data.length < 3) continue;
+    return num.toHex(num.toBigInt(data[2]!));
+  }
+  return null;
+}

--- a/src/paycrest/index.ts
+++ b/src/paycrest/index.ts
@@ -1,0 +1,44 @@
+export { Paycrest, PaycrestOrderError } from "@/paycrest/paycrest";
+export { PaycrestApi, PAYCREST_API_BASE_DEFAULT } from "@/paycrest/api";
+export {
+  PaycrestGateway,
+  ORDER_CREATED_EVENT_SELECTOR,
+  extractOrderIdFromReceipt,
+} from "@/paycrest/gateway";
+export { encryptRecipient } from "@/paycrest/encryption";
+export {
+  PAYCREST_GATEWAY_MAINNET,
+  STARKNET_MAINNET_CHAIN_ID,
+  paycrestChainIdFor,
+  paycrestGatewayFor,
+  paycrestNetworkFor,
+  paycrestTokensFor,
+  paycrestMainnetTokens,
+} from "@/paycrest/presets";
+export type {
+  OfframpInput,
+  OfframpResult,
+  OnrampInput,
+  OnrampResult,
+  PaycrestCurrency,
+  PaycrestEncryptor,
+  PaycrestExecuteOptions,
+  PaycrestInstitution,
+  PaycrestNetwork,
+  PaycrestOfframpStatus,
+  PaycrestOptions,
+  PaycrestOrder,
+  PaycrestOrderInfo,
+  PaycrestOrderStatus,
+  PaycrestPath,
+  PaycrestProviderAccount,
+  PaycrestProviderOrderStatus,
+  PaycrestRate,
+  PaycrestRateSide,
+  PaycrestRecipient,
+  PaycrestRefundAccount,
+  PaycrestToken,
+  PaycrestWaitForOrderOptions,
+  PaycrestWebhookEventName,
+  PaycrestWebhookPayload,
+} from "@/paycrest/types";

--- a/src/paycrest/paycrest.ts
+++ b/src/paycrest/paycrest.ts
@@ -1,0 +1,768 @@
+import { type Call } from "starknet";
+import {
+  Amount,
+  ChainId,
+  fromAddress,
+  type Address,
+  type ExecuteOptions,
+} from "@/types";
+import type { Tx } from "@/tx";
+import type { WalletInterface } from "@/wallet/interface";
+import { PaycrestApi } from "@/paycrest/api";
+import { encryptRecipient as defaultEncryptRecipient } from "@/paycrest/encryption";
+import { extractOrderIdFromReceipt, PaycrestGateway } from "@/paycrest/gateway";
+import {
+  paycrestChainIdFor,
+  paycrestGatewayFor,
+  paycrestNetworkFor,
+} from "@/paycrest/presets";
+import type {
+  OfframpInput,
+  OfframpResult,
+  OnrampInput,
+  OnrampResult,
+  PaycrestCurrency,
+  PaycrestEncryptor,
+  PaycrestInstitution,
+  PaycrestNetwork,
+  PaycrestOfframpStatus,
+  PaycrestOptions,
+  PaycrestOrder,
+  PaycrestOrderStatus,
+  PaycrestProviderAccount,
+  PaycrestProviderOrderStatus,
+  PaycrestRate,
+  PaycrestRateSide,
+  PaycrestRecipient,
+  PaycrestToken,
+  PaycrestWaitForOrderOptions,
+} from "@/paycrest/types";
+
+/**
+ * Thrown by `Paycrest.waitForOrder` when an order reaches a terminal
+ * failure state (`refunded`, `expired`, or any state listed in
+ * `options.errorStates`). The `order` field carries the final
+ * server-side state for inspection.
+ */
+export class PaycrestOrderError extends Error {
+  readonly order: PaycrestOrder;
+  constructor(message: string, order: PaycrestOrder) {
+    super(message);
+    this.name = "PaycrestOrderError";
+    this.order = order;
+  }
+}
+
+const DEFAULT_SUCCESS_STATES: readonly PaycrestOrderStatus[] = [
+  "validated",
+  "settled",
+];
+const DEFAULT_ERROR_STATES: readonly PaycrestOrderStatus[] = [
+  "refunded",
+  "expired",
+];
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_WAIT_TIMEOUT_MS = 10 * 60_000;
+
+/**
+ * Paycrest's rate convention: `/v2/rates` returns the fiat rate as a
+ * decimal string (e.g. `"1500.50"`). The on-chain Gateway accepts the
+ * rate as an integer scaled by 100 — i.e. 2 decimal places. This
+ * matches the EVM Paycrest deployments (e.g. an on-chain rate of
+ * `156000` represents `1560.00`; `136192` represents `1361.92`).
+ */
+const RATE_DECIMALS = 2n;
+
+/**
+ * Fiat on/off-ramp module backed by Paycrest. Two paths share the same
+ * TypeScript surface:
+ *
+ * - `path: "gateway"` (off-ramp default) — encrypts recipient details
+ *   with the aggregator's RSA public key and emits an approve +
+ *   `create_order` Call pair on the Cairo Gateway. Fully on-chain.
+ * - `path: "api"` — POSTs to the Sender API and returns a single ERC20
+ *   transfer Call to the assigned receive address.
+ *
+ * On-ramp uses the Sender API only — Gateway on-ramp isn't supported by
+ * Paycrest. Webhook signatures can be verified statically via
+ * `Paycrest.verifyWebhookSignature(body, signature, secret)`.
+ *
+ * @example
+ * ```ts
+ * const paycrest = new Paycrest({ apiKey: process.env.PAYCREST_API_KEY });
+ *
+ * // Off-ramp via Gateway (default path)
+ * const off = await paycrest.offramp(wallet, {
+ *   from: { token: USDC, amount: Amount.parse("100", USDC) },
+ *   to: { currency: "NGN", recipient: { institution, accountIdentifier, accountName } },
+ * });
+ * await off.tx.wait();
+ *
+ * // On-ramp (Sender API only)
+ * const on = await paycrest.onramp({
+ *   from: { currency: "NGN", amount: 50000, refundAccount },
+ *   to: { token: USDC, recipient: wallet.address },
+ * });
+ * console.log(on.providerAccount);
+ * ```
+ */
+export class Paycrest {
+  private readonly api: PaycrestApi;
+  private readonly apiKey: string | undefined;
+  private readonly gatewayAddressOverride: Address | undefined;
+  private readonly encryptor: PaycrestEncryptor;
+  private cachedPublicKey: string | null = null;
+
+  constructor(options: PaycrestOptions = {}) {
+    this.apiKey = options.apiKey;
+    this.gatewayAddressOverride = options.gatewayAddress;
+    this.encryptor = options.encryptRecipient ?? defaultEncryptRecipient;
+    const apiOpts: ConstructorParameters<typeof PaycrestApi>[0] = {};
+    if (options.apiBaseUrl !== undefined)
+      apiOpts.apiBaseUrl = options.apiBaseUrl;
+    if (options.apiKey !== undefined) apiOpts.apiKey = options.apiKey;
+    if (options.fetch !== undefined) apiOpts.fetch = options.fetch;
+    if (options.requestTimeoutMs !== undefined)
+      apiOpts.requestTimeoutMs = options.requestTimeoutMs;
+    this.api = new PaycrestApi(apiOpts);
+  }
+
+  // ##################################################################
+  //                     READ-ONLY API HELPERS
+  // ##################################################################
+
+  /** List all fiat currencies available on Paycrest. Public endpoint. */
+  async listCurrencies(): Promise<PaycrestCurrency[]> {
+    return this.api.getCurrencies();
+  }
+
+  /** List all banks / mobile-money operators for a given currency. Public endpoint. */
+  async listInstitutions(currencyCode: string): Promise<PaycrestInstitution[]> {
+    return this.api.getInstitutions(currencyCode);
+  }
+
+  /**
+   * List Paycrest-supported stablecoins, optionally filtered to a
+   * single network. Public endpoint.
+   */
+  async listTokens(network?: PaycrestNetwork): Promise<PaycrestToken[]> {
+    return this.api.getTokens(network);
+  }
+
+  /**
+   * Fetch the public quote for an off-ramp / on-ramp. The gateway path
+   * fetches this internally; you only need to call it explicitly if you
+   * want to display a rate to the user before submitting an order.
+   */
+  async getRate(args: {
+    network: PaycrestNetwork;
+    token: string;
+    amount: string | number;
+    fiat: string;
+    side?: "buy" | "sell";
+    providerId?: string;
+  }): Promise<PaycrestRate> {
+    return this.api.getRate(args);
+  }
+
+  /** Fetch order metadata by id. Requires an API key. */
+  async getOrder(id: string): Promise<PaycrestOrder> {
+    return this.api.getOrder(id);
+  }
+
+  /** List orders attached to your sender profile. Requires an API key. */
+  async listOrders(filter?: Record<string, string | number>): Promise<{
+    orders: PaycrestOrder[];
+    [key: string]: unknown;
+  }> {
+    return this.api.listOrders(filter);
+  }
+
+  /**
+   * Poll `GET /v2/sender/orders/{id}` until the order reaches a
+   * terminal status. Resolves with the final order on success
+   * (`validated` or `settled` by default) and throws
+   * `PaycrestOrderError` on failure (`refunded` or `expired`).
+   *
+   * For production servers, prefer webhooks
+   * (`Paycrest.verifyWebhookSignature`) — polling is most useful for
+   * scripts, jobs, and end-to-end tests where you don't want to stand
+   * up an HTTP endpoint just to await settlement.
+   *
+   * Defaults: 5s poll interval, 10 min timeout. Pass `signal` to abort.
+   *
+   * @example
+   * ```ts
+   * const off = await paycrest.offramp(wallet, { ... });
+   * const orderId = await off.orderId;
+   * if (!orderId) throw new Error("on-chain create_order reverted");
+   *
+   * try {
+   *   const order = await paycrest.waitForOrder(orderId);
+   *   // order.status is "validated" or "settled"
+   *   console.log("done:", order.status);
+   * } catch (err) {
+   *   if (err instanceof PaycrestOrderError) {
+   *     console.warn("order ended in", err.order.status);
+   *   } else {
+   *     throw err;
+   *   }
+   * }
+   * ```
+   */
+  async waitForOrder(
+    id: string,
+    options: PaycrestWaitForOrderOptions = {}
+  ): Promise<PaycrestOrder> {
+    return this.pollUntilTerminal(
+      `waitForOrder(${id})`,
+      () => this.api.getOrder(id),
+      options
+    );
+  }
+
+  /**
+   * Poll `GET /v2/orders/{chain_id}/{gateway_id}` until the order
+   * reaches a terminal status. Used for gateway-path off-ramps where
+   * only the on-chain felt252 gateway_id is known — the
+   * `/v2/sender/orders/{id}` endpoint doesn't index gateway_id.
+   *
+   * `chainId` defaults to `STARKNET_MAINNET_CHAIN_ID`; pass an
+   * override for forks or future redeployments. Same terminal-state
+   * semantics as `waitForOrder`: resolves on `validated` / `settled`,
+   * throws `PaycrestOrderError` on `refunded` / `expired`.
+   */
+  async waitForGatewayOrder(
+    gatewayId: string,
+    options: PaycrestWaitForOrderOptions & {
+      chainId?: bigint | number | string;
+    } = {}
+  ): Promise<PaycrestProviderOrderStatus> {
+    const chainId = options.chainId ?? paycrestChainIdFor(ChainId.MAINNET);
+    return this.pollUntilTerminal<PaycrestProviderOrderStatus>(
+      `waitForGatewayOrder(${gatewayId})`,
+      () => this.api.getProviderOrderStatus(chainId, gatewayId),
+      options
+    );
+  }
+
+  /**
+   * Generic terminal-state poller. Both `waitForOrder` and
+   * `waitForGatewayOrder` share this loop — the `fetchStatus`
+   * callback is the only path-specific bit.
+   */
+  private async pollUntilTerminal<T extends { status: PaycrestOrderStatus }>(
+    label: string,
+    fetchStatus: () => Promise<T>,
+    options: PaycrestWaitForOrderOptions
+  ): Promise<T> {
+    const successStates = options.successStates ?? DEFAULT_SUCCESS_STATES;
+    const errorStates = options.errorStates ?? DEFAULT_ERROR_STATES;
+    const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS;
+    const deadline = Date.now() + timeoutMs;
+    let lastStatus: PaycrestOrderStatus | undefined;
+
+    for (;;) {
+      if (options.signal?.aborted) {
+        throw new Error(
+          `Paycrest.${label} aborted by signal (last status: ${lastStatus ?? "<none>"})`
+        );
+      }
+      const result = await fetchStatus();
+      lastStatus = result.status;
+      if (successStates.includes(result.status)) return result;
+      if (errorStates.includes(result.status)) {
+        // Wrap status-only responses into the PaycrestOrder shape so
+        // PaycrestOrderError.order is uniform across both endpoints.
+        const orderLike = (result as unknown as { id?: string }).id
+          ? (result as unknown as PaycrestOrder)
+          : ({
+              ...result,
+              id: (result as unknown as { orderId?: string }).orderId ?? "",
+            } as unknown as PaycrestOrder);
+        throw new PaycrestOrderError(
+          `Paycrest order reached terminal failure state: ${result.status}`,
+          orderLike
+        );
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Paycrest.${label} timed out after ${timeoutMs}ms (last status: ${result.status})`
+        );
+      }
+      await sleep(pollIntervalMs, options.signal);
+    }
+  }
+
+  /**
+   * Path-aware off-ramp settlement wait. Called by
+   * `OfframpResult.wait()` — dispatches to the correct endpoint based
+   * on `result.path` and returns a unified
+   * `{ status, txHash, orderId, raw }` shape.
+   *
+   * @internal Used by the result builder; users call `result.wait()`.
+   */
+  async waitForOfframp(
+    result: Pick<OfframpResult, "path" | "orderId">,
+    options: PaycrestWaitForOrderOptions & {
+      chainId?: bigint | number | string;
+    } = {}
+  ): Promise<PaycrestOfframpStatus> {
+    const id = await result.orderId;
+    if (!id) {
+      throw new Error(
+        result.path === "gateway"
+          ? `Paycrest gateway off-ramp has no on-chain order id (create_order likely reverted — check tx.wait()).`
+          : `Paycrest api off-ramp has no order id (server response was missing 'id').`
+      );
+    }
+    if (result.path === "api") {
+      const order = await this.waitForOrder(id, options);
+      const status: PaycrestOfframpStatus = {
+        path: "api",
+        orderId: id,
+        status: order.status,
+        raw: order,
+      };
+      if (order.txHash !== undefined) status.txHash = order.txHash;
+      return status;
+    }
+    const provider = await this.waitForGatewayOrder(id, options);
+    const status: PaycrestOfframpStatus = {
+      path: "gateway",
+      orderId: id,
+      status: provider.status,
+      raw: provider,
+    };
+    if (provider.txHash !== undefined) status.txHash = provider.txHash;
+    return status;
+  }
+
+  // ##################################################################
+  //                          OFF-RAMP
+  // ##################################################################
+
+  /**
+   * Build the on-chain Calls for a gateway-path off-ramp without
+   * executing. Returns `{ calls, rate }` so callers can compose the
+   * approve + create_order pair atomically with other operations via
+   * `wallet.tx().add(...)`.
+   *
+   * Throws if `path` is `"api"` — the API path requires an HTTP order
+   * creation step that doesn't fit the synchronous builder shape.
+   */
+  async populateOfframp(
+    wallet: WalletInterface,
+    input: OfframpInput
+  ): Promise<{ calls: Call[]; rate: string }> {
+    const path = input.path ?? "gateway";
+    if (path !== "gateway") {
+      throw new Error(
+        `Paycrest.populateOfframp only supports the gateway path. For api-path offramp, call Paycrest.offramp directly.`
+      );
+    }
+    return this.buildGatewayOfframpCalls(wallet, input);
+  }
+
+  /**
+   * Submit an off-ramp order. Defaults to the gateway path; pass
+   * `path: "api"` to route via the Sender API instead.
+   */
+  async offramp(
+    wallet: WalletInterface,
+    input: OfframpInput,
+    options?: ExecuteOptions
+  ): Promise<OfframpResult> {
+    const path = input.path ?? "gateway";
+    if (path === "gateway")
+      return this.offrampViaGateway(wallet, input, options);
+    return this.offrampViaApi(wallet, input, options);
+  }
+
+  private async offrampViaGateway(
+    wallet: WalletInterface,
+    input: OfframpInput,
+    options?: ExecuteOptions
+  ): Promise<OfframpResult> {
+    const { calls, rate } = await this.buildGatewayOfframpCalls(wallet, input);
+    const tx = await wallet.execute(calls, options);
+    const gateway = this.resolveGatewayAddress(wallet.getChainId());
+    return this.attachWait({
+      path: "gateway",
+      orderId: this.resolveGatewayOrderId(tx, gateway),
+      tx,
+      calls,
+      rate,
+    });
+  }
+
+  /**
+   * Attach a `wait()` method to a partially-built `OfframpResult`. The
+   * method delegates to `waitForOfframp`, dispatching to the correct
+   * endpoint based on `result.path`.
+   */
+  private attachWait(partial: Omit<OfframpResult, "wait">): OfframpResult {
+    const result = partial as OfframpResult;
+    result.wait = (waitOptions?: PaycrestWaitForOrderOptions) =>
+      this.waitForOfframp(result, waitOptions ?? {});
+    return result;
+  }
+
+  /**
+   * Wait for the L2 receipt and parse the `OrderCreated` event for the
+   * gateway off-ramp. Returns `null` if the receipt has no matching
+   * event (typically a revert — `tx.wait()` will surface the reason).
+   */
+  private async resolveGatewayOrderId(
+    tx: Tx,
+    gateway: Address
+  ): Promise<string | null> {
+    try {
+      await tx.wait();
+    } catch {
+      return null;
+    }
+    const receipt = (await tx.receipt()) as {
+      events?: ReadonlyArray<{
+        from_address?: string;
+        keys?: string[];
+        data?: string[];
+      }>;
+    };
+    return extractOrderIdFromReceipt(receipt, gateway);
+  }
+
+  private async offrampViaApi(
+    wallet: WalletInterface,
+    input: OfframpInput,
+    options?: ExecuteOptions
+  ): Promise<OfframpResult> {
+    const network = paycrestNetworkFor(wallet.getChainId());
+    const body = buildOfframpApiBody({
+      input,
+      network,
+      refundAddress: wallet.address,
+    });
+    const order = await this.api.createOrder(body);
+    const receiveAddress = order.providerAccount?.receiveAddress;
+    if (!receiveAddress) {
+      throw new Error(
+        `Paycrest API order ${order.id ?? "<unknown>"} returned no receiveAddress`
+      );
+    }
+    const erc20 = wallet.erc20(input.from.token);
+    const calls = erc20.populateTransfer([
+      { to: fromAddress(receiveAddress), amount: input.from.amount },
+    ]);
+    const tx = await wallet.execute(calls, options);
+
+    const partial: Omit<OfframpResult, "wait"> = {
+      path: "api",
+      orderId: Promise.resolve(order.id ?? null),
+      tx,
+      calls,
+      receiveAddress,
+    };
+    if (order.providerAccount) partial.providerAccount = order.providerAccount;
+    if (input.rate) partial.rate = input.rate;
+    return this.attachWait(partial);
+  }
+
+  private async buildGatewayOfframpCalls(
+    wallet: WalletInterface,
+    input: OfframpInput
+  ): Promise<{ calls: Call[]; rate: string }> {
+    const chainId = wallet.getChainId();
+    const network = paycrestNetworkFor(chainId);
+    const gatewayAddress = this.resolveGatewayAddress(chainId);
+
+    const rateString = await this.fetchRate({
+      network,
+      token: input.from.token.symbol,
+      amount: input.from.amount.toUnit(),
+      fiat: input.to.currency,
+    });
+
+    const messageHash = await this.encryptRecipientPayload(input.to.recipient);
+
+    const senderFeeAmount = input.senderFee?.amount ?? 0n;
+    const senderFeeRecipient =
+      input.senderFee?.recipient ?? (fromAddress("0x0") as Address);
+
+    const erc20 = wallet.erc20(input.from.token);
+    const approveAmount = input.from.amount.toBase() + senderFeeAmount;
+    const approveCall = erc20.populateApprove(
+      gatewayAddress,
+      approveAmount === input.from.amount.toBase()
+        ? input.from.amount
+        : Amount.fromRaw(approveAmount, input.from.token)
+    );
+
+    const gateway = new PaycrestGateway(gatewayAddress, wallet.getProvider());
+    const createOrderCall = gateway.populateCreateOrder({
+      token: input.from.token.address,
+      amount: input.from.amount.toBase(),
+      rate: rateToU128(rateString),
+      senderFeeRecipient,
+      senderFee: senderFeeAmount,
+      refundAddress: wallet.address,
+      messageHash,
+    });
+
+    return { calls: [approveCall, createOrderCall], rate: rateString };
+  }
+
+  private resolveGatewayAddress(chainId: ChainId): Address {
+    return this.gatewayAddressOverride ?? paycrestGatewayFor(chainId);
+  }
+
+  private async fetchRate(args: {
+    network: PaycrestNetwork;
+    token: string;
+    amount: string;
+    fiat: string;
+  }): Promise<string> {
+    const rate = await this.api.getRate({ ...args, side: "sell" });
+    const side: PaycrestRateSide | undefined = rate.sell ?? rate.buy;
+    if (!side?.rate) {
+      throw new Error(
+        `Paycrest /v2/rates returned no rate for ${args.token}/${args.fiat} on ${args.network}`
+      );
+    }
+    return side.rate;
+  }
+
+  private async encryptRecipientPayload(
+    recipient: PaycrestRecipient
+  ): Promise<string> {
+    if (!this.apiKey) {
+      throw new Error(
+        `Paycrest gateway off-ramp requires an apiKey — pass it to the Paycrest constructor or via SDKConfig.paycrest.apiKey.`
+      );
+    }
+    const pem = await this.getOrFetchPublicKey();
+    const payload: Record<string, unknown> = {
+      institution: recipient.institution,
+      accountIdentifier: recipient.accountIdentifier,
+      accountName: recipient.accountName,
+      metadata: { apiKey: this.apiKey },
+    };
+    if (recipient.memo !== undefined) payload["memo"] = recipient.memo;
+    return this.encryptor(pem, JSON.stringify(payload));
+  }
+
+  private async getOrFetchPublicKey(): Promise<string> {
+    if (this.cachedPublicKey !== null) return this.cachedPublicKey;
+    const pem = await this.api.getPublicKey();
+    this.cachedPublicKey = pem;
+    return pem;
+  }
+
+  // ##################################################################
+  //                          ON-RAMP
+  // ##################################################################
+
+  /**
+   * Submit an on-ramp order via the Sender API. Returns the bank
+   * details the user must transfer fiat into. No on-chain transaction
+   * is created — the app is responsible for displaying the response
+   * `providerAccount` to the user and waiting for a webhook (or
+   * polling `getOrder(id)`) before treating the order as settled.
+   */
+  async onramp(input: OnrampInput): Promise<OnrampResult> {
+    const network = inferStarknetNetwork(input.to.recipient);
+    const body = buildOnrampApiBody({ input, network });
+    const order = await this.api.createOrder(body);
+    if (!order.providerAccount) {
+      throw new Error(
+        `Paycrest onramp order ${order.id ?? "<unknown>"} returned no providerAccount`
+      );
+    }
+    const result: OnrampResult = {
+      orderId: order.id,
+      status: order.status,
+      providerAccount: order.providerAccount as PaycrestProviderAccount,
+    };
+    if (order.validUntil !== undefined) result.validUntil = order.validUntil;
+    if (input.reference !== undefined) result.reference = input.reference;
+    return result;
+  }
+
+  // ##################################################################
+  //                          WEBHOOKS
+  // ##################################################################
+
+  /**
+   * Verify an `X-Paycrest-Signature` header against a raw request body
+   * using HMAC-SHA256 timing-safe comparison.
+   *
+   * Run this before trusting webhook payloads. Pass the **raw** request
+   * body string (not parsed JSON) — any whitespace difference will fail
+   * verification.
+   */
+  static async verifyWebhookSignature(
+    rawBody: string,
+    signature: string,
+    apiSecret: string
+  ): Promise<boolean> {
+    if (!signature || !apiSecret) return false;
+    const subtle = (globalThis as { crypto?: { subtle?: SubtleCrypto } }).crypto
+      ?.subtle;
+    if (subtle) {
+      const enc = new TextEncoder();
+      const key = await subtle.importKey(
+        "raw",
+        enc.encode(apiSecret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"]
+      );
+      const sigBuf = await subtle.sign("HMAC", key, enc.encode(rawBody));
+      const computed = bytesToHex(new Uint8Array(sigBuf));
+      return timingSafeEqualHex(computed, signature.trim());
+    }
+    const nodeCrypto =
+      (await import("node:crypto")) as typeof import("node:crypto");
+    const computed = nodeCrypto
+      .createHmac("sha256", apiSecret)
+      .update(rawBody, "utf8")
+      .digest("hex");
+    return timingSafeEqualHex(computed, signature.trim());
+  }
+}
+
+// ====================================================================
+//                            HELPERS
+// ====================================================================
+
+function buildOfframpApiBody(args: {
+  input: OfframpInput;
+  network: PaycrestNetwork;
+  refundAddress: Address;
+}): Record<string, unknown> {
+  const { input, network, refundAddress } = args;
+  const recipient: Record<string, unknown> = {
+    institution: input.to.recipient.institution,
+    accountIdentifier: input.to.recipient.accountIdentifier,
+    accountName: input.to.recipient.accountName,
+  };
+  if (input.to.recipient.memo !== undefined)
+    recipient["memo"] = input.to.recipient.memo;
+
+  const body: Record<string, unknown> = {
+    amount: input.from.amount.toUnit(),
+    source: {
+      type: "crypto",
+      currency: input.from.token.symbol,
+      network,
+      refundAddress,
+    },
+    destination: {
+      type: "fiat",
+      currency: input.to.currency,
+      recipient,
+    },
+  };
+  if (input.reference !== undefined) body["reference"] = input.reference;
+  if (input.rate !== undefined) body["rate"] = input.rate;
+  return body;
+}
+
+function buildOnrampApiBody(args: {
+  input: OnrampInput;
+  network: PaycrestNetwork;
+}): Record<string, unknown> {
+  const { input, network } = args;
+  const body: Record<string, unknown> = {
+    amount: String(input.from.amount),
+    amountIn: "fiat",
+    source: {
+      type: "fiat",
+      currency: input.from.currency,
+      refundAccount: {
+        institution: input.from.refundAccount.institution,
+        accountIdentifier: input.from.refundAccount.accountIdentifier,
+        accountName: input.from.refundAccount.accountName,
+      },
+    },
+    destination: {
+      type: "crypto",
+      currency: input.to.token.symbol,
+      recipient: {
+        address: input.to.recipient,
+        network,
+      },
+    },
+  };
+  if (input.reference !== undefined) body["reference"] = input.reference;
+  return body;
+}
+
+/**
+ * On-ramp doesn't carry a `chainId` directly. Since this SDK is
+ * Starknet-only, we always return `"starknet"` and defensively flag
+ * obviously non-Starknet recipients (40-char EVM hex addresses).
+ */
+function inferStarknetNetwork(recipient: Address): PaycrestNetwork {
+  if (typeof recipient === "string" && /^0x[0-9a-fA-F]{40}$/.test(recipient)) {
+    throw new Error(
+      `Paycrest.onramp: recipient looks like an EVM address — Paycrest on Starknet expects a Starknet wallet address.`
+    );
+  }
+  return "starknet";
+}
+
+/**
+ * Convert a decimal-string rate from `/v2/rates` (e.g. `"1500.50"`)
+ * into the integer the on-chain `create_order` accepts (`150050n`).
+ *
+ * Exported for tests; not part of the public Paycrest API.
+ *
+ * @internal
+ */
+export function rateToU128(decimalString: string): bigint {
+  // Convert "1500.50" -> 150050n given RATE_DECIMALS = 2.
+  const [whole = "0", fractional = ""] = decimalString.split(".");
+  const padded = (fractional + "0".repeat(Number(RATE_DECIMALS))).slice(
+    0,
+    Number(RATE_DECIMALS)
+  );
+  const cleanedWhole = whole.replace(/^[^0-9]+/, "");
+  return BigInt(cleanedWhole + padded);
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error("Paycrest.waitForOrder aborted by signal"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    function onAbort(): void {
+      clearTimeout(timer);
+      reject(new Error("Paycrest.waitForOrder aborted by signal"));
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    out += bytes[i]!.toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/src/paycrest/presets.ts
+++ b/src/paycrest/presets.ts
@@ -1,0 +1,75 @@
+import { mainnetTokens } from "@/erc20/token/presets";
+import { ChainId, fromAddress, type Address, type Token } from "@/types";
+import type { PaycrestNetwork } from "@/paycrest/types";
+
+/**
+ * Paycrest is **mainnet-only** today — there is no sepolia/devnet backend
+ * or testnet Cairo Gateway. Helpers in this module throw with a clear
+ * "Paycrest does not support testnets" message for any non-mainnet chain.
+ */
+
+/** Live Cairo Gateway contract on Starknet mainnet. */
+export const PAYCREST_GATEWAY_MAINNET = fromAddress(
+  "0x06ff3a3b1532da65594fc98f9ca7200af6c3dbaf37e7339b0ebd3b3f2390c583"
+);
+
+/**
+ * Numeric chain id the Paycrest aggregator uses for Starknet mainnet
+ * in its `networks.chain_id` column. Required by the
+ * `GET /v2/orders/{chain_id}/{gateway_id}` lookup endpoint that
+ * accepts the on-chain felt252 order id.
+ *
+ * Starknet's true chain id is the felt `SN_MAIN`
+ * (`393402133025997798000961`) which overflows int64, so the aggregator
+ * uses a fictional int64 value chosen by Paycrest ops. As of 2026 this
+ * is `23448594291968334`.
+ *
+ * Stored as `bigint` because it exceeds `Number.MAX_SAFE_INTEGER`.
+ */
+export const STARKNET_MAINNET_CHAIN_ID = 23_448_594_291_968_334n;
+
+/** Resolve the Paycrest aggregator chain id for a Starknet chain. Mainnet only. */
+export function paycrestChainIdFor(chainId: ChainId): bigint {
+  if (chainId.isMainnet()) return STARKNET_MAINNET_CHAIN_ID;
+  throw new Error(
+    `Paycrest is mainnet-only — no aggregator chain_id is configured for ${chainId.toLiteral()}.`
+  );
+}
+
+/**
+ * Tokens accepted by the Paycrest Starknet Gateway. Sourced from
+ * `GET /v2/tokens?network=starknet` and reconciled with
+ * `mainnetTokens` so we don't redefine the same Token shape twice.
+ */
+export const paycrestMainnetTokens: readonly Token[] = [
+  mainnetTokens.USDC,
+  mainnetTokens.USDT,
+];
+
+/** Resolve the Cairo Gateway address for a chain. Mainnet only. */
+export function paycrestGatewayFor(chainId: ChainId): Address {
+  if (chainId.isMainnet()) return PAYCREST_GATEWAY_MAINNET;
+  throw new Error(
+    `Paycrest is mainnet-only — no Gateway is deployed on ${chainId.toLiteral()}. See https://docs.paycrest.io.`
+  );
+}
+
+/**
+ * Map a Starknet `ChainId` to the Paycrest network identifier used in the
+ * Sender API (`source.network`, `destination.recipient.network`, and the
+ * `{network}` segment of the rates endpoint).
+ */
+export function paycrestNetworkFor(chainId: ChainId): PaycrestNetwork {
+  if (chainId.isMainnet()) return "starknet";
+  throw new Error(
+    `Paycrest is mainnet-only — ${chainId.toLiteral()} is not a supported network. See https://docs.paycrest.io.`
+  );
+}
+
+/** Tokens accepted by the Paycrest Gateway on the given chain. Mainnet only. */
+export function paycrestTokensFor(chainId: ChainId): readonly Token[] {
+  if (chainId.isMainnet()) return paycrestMainnetTokens;
+  throw new Error(
+    `Paycrest is mainnet-only — no tokens are configured for ${chainId.toLiteral()}.`
+  );
+}

--- a/src/paycrest/types.ts
+++ b/src/paycrest/types.ts
@@ -1,0 +1,377 @@
+import type { Address } from "@/types/address";
+import type { Amount } from "@/types/amount";
+import type { Token } from "@/types/token";
+import type { ExecuteOptions } from "@/types/wallet";
+import type { Tx } from "@/tx";
+import type { Call } from "starknet";
+
+/**
+ * Networks recognised by the Paycrest backend. The Sender API uses these
+ * literals in `source.network` / `destination.recipient.network` and as
+ * the `{network}` path segment in the rates endpoint.
+ */
+export type PaycrestNetwork =
+  | "starknet"
+  | "ethereum"
+  | "base"
+  | "arbitrum-one"
+  | "polygon"
+  | "bnb-smart-chain"
+  | "lisk"
+  | "celo"
+  | "scroll"
+  | "asset-chain";
+
+/** Off-ramp transport: on-chain via the Cairo Gateway, or REST via the Sender API. */
+export type PaycrestPath = "gateway" | "api";
+
+/**
+ * Wire format returned by `GET /v2/tokens`. Contract addresses are returned
+ * as raw strings — callers should pass them through `fromAddress()` before
+ * using them as Starknet contract addresses.
+ */
+export interface PaycrestToken {
+  symbol: string;
+  contractAddress: string;
+  decimals: number;
+  baseCurrency: string;
+  network: PaycrestNetwork;
+}
+
+/** Wire format returned by `GET /v2/currencies`. */
+export interface PaycrestCurrency {
+  code: string;
+  name: string;
+  shortName: string;
+  decimals: number;
+  symbol: string;
+  marketBuyRate: string;
+  marketSellRate: string;
+}
+
+/** Wire format returned by `GET /v2/institutions/{currencyCode}`. */
+export interface PaycrestInstitution {
+  name: string;
+  code: string;
+  type: "bank" | "mobile_money";
+}
+
+/** Wire format returned by `GET /v2/rates/{network}/{token}/{amount}/{fiat}`. */
+export interface PaycrestRate {
+  buy?: PaycrestRateSide;
+  sell?: PaycrestRateSide;
+}
+
+export interface PaycrestRateSide {
+  rate: string;
+  providerIds: string[];
+  orderType: string;
+  refundTimeoutMinutes: number;
+}
+
+/** Bank or mobile-money destination on the off-ramp side. */
+export interface PaycrestRecipient {
+  /** SWIFT code or Paycrest institution code (suffix `PC`). */
+  institution: string;
+  /** Bank account number or mobile-money number. */
+  accountIdentifier: string;
+  /** Account holder's verified name. */
+  accountName: string;
+  /** Optional payment memo / narration. */
+  memo?: string;
+}
+
+/** Fiat refund destination for an on-ramp order, used if the order can't be fulfilled. */
+export interface PaycrestRefundAccount {
+  institution: string;
+  accountIdentifier: string;
+  accountName: string;
+}
+
+/** Sub-status payment_order webhook event names. */
+export type PaycrestWebhookEventName =
+  | "payment_order.deposited"
+  | "payment_order.pending"
+  | "payment_order.validated"
+  | "payment_order.settling"
+  | "payment_order.settled"
+  | "payment_order.refunding"
+  | "payment_order.refunded"
+  | "payment_order.expired";
+
+export type PaycrestOrderStatus =
+  | "initiated"
+  | "pending"
+  | "deposited"
+  | "validated"
+  | "settling"
+  | "settled"
+  | "refunding"
+  | "refunded"
+  | "expired";
+
+/**
+ * Account details surfaced by the Sender API after creating an order.
+ *
+ * For off-ramp orders this carries `receiveAddress` (the on-chain address
+ * the app must send tokens to). For on-ramp orders this carries the
+ * institution + account number the user must transfer fiat into, plus
+ * `amountToTransfer` and `currency`.
+ */
+export interface PaycrestProviderAccount {
+  network?: PaycrestNetwork;
+  receiveAddress?: string;
+  institution?: string;
+  accountIdentifier?: string;
+  accountName?: string;
+  amountToTransfer?: string;
+  currency?: string;
+  validUntil?: string;
+}
+
+/** Generic order shape returned by the Sender API. */
+export interface PaycrestOrder {
+  id: string;
+  direction?: "onramp" | "offramp";
+  status: PaycrestOrderStatus;
+  amount?: string;
+  txHash?: string;
+  reference?: string;
+  providerAccount?: PaycrestProviderAccount;
+  validUntil?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Smaller shape returned by `GET /v2/orders/{chain_id}/{gateway_id}`
+ * (the aggregator's `GetProviderOrderStatus` endpoint). Used to look
+ * up gateway-path off-ramp orders by their on-chain felt252 id when
+ * the DB UUID isn't known.
+ *
+ * Field set is a subset of `PaycrestOrder` — there's no `id` (UUID),
+ * no `providerAccount`, no `direction`. The `orderId` field carries
+ * the gateway_id you used to look it up.
+ */
+export interface PaycrestProviderOrderStatus {
+  orderId: string;
+  status: PaycrestOrderStatus;
+  amount?: string;
+  amountInUSD?: string;
+  token?: string;
+  network?: PaycrestNetwork | string;
+  txHash?: string;
+  settlements?: unknown[];
+  txReceipts?: unknown[];
+  [key: string]: unknown;
+}
+
+/**
+ * Unified result returned by `OfframpResult.wait()` — abstracts over
+ * the two endpoints used internally (`/v2/sender/orders/{id}` for the
+ * api path, `/v2/orders/{chain_id}/{gateway_id}` for the gateway
+ * path). The `raw` field carries the underlying response if you need
+ * fields beyond status/txHash.
+ */
+export interface PaycrestOfframpStatus {
+  path: PaycrestPath;
+  /** Whichever id was used to look up the order (UUID for api, felt252 for gateway). */
+  orderId: string;
+  status: PaycrestOrderStatus;
+  txHash?: string;
+  raw: PaycrestOrder | PaycrestProviderOrderStatus;
+}
+
+/** Webhook payload posted to the configured endpoint by the Paycrest backend. */
+export interface PaycrestWebhookPayload {
+  event: PaycrestWebhookEventName;
+  webhookVersion: string;
+  data: PaycrestOrder;
+}
+
+/**
+ * Pluggable encryptor used for the Gateway path. The default implementation
+ * is RSA-OAEP-SHA256 backed by `crypto.subtle` in browsers/RN and
+ * `node:crypto.publicEncrypt` in Node — see `encryption.ts`. Inject a custom
+ * function only if you need a non-default RSA library.
+ */
+export type PaycrestEncryptor = (
+  publicKeyPem: string,
+  plaintext: string
+) => Promise<string>;
+
+/**
+ * Per-instance options accepted by `new Paycrest(...)`. Most apps will
+ * supply `apiKey` only; the rest are escape hatches for testing, custom
+ * deployments, or non-standard runtimes.
+ */
+export interface PaycrestOptions {
+  /** Paycrest API key. Required for any order-creating call. */
+  apiKey?: string;
+  /** Paycrest API secret. Required only for `Paycrest.verifyWebhookSignature`. */
+  apiSecret?: string;
+  /** Override the API base URL. Defaults to `https://api.paycrest.io`. */
+  apiBaseUrl?: string;
+  /**
+   * Override the Cairo Gateway contract address. Defaults to the
+   * mainnet preset. Useful for local forking or future redeployments.
+   */
+  gatewayAddress?: Address;
+  /** Inject a `fetch` implementation (testing or custom HTTP runtime). */
+  fetch?: typeof fetch;
+  /** Inject a custom recipient encryptor (default: built-in RSA-OAEP-SHA256). */
+  encryptRecipient?: PaycrestEncryptor;
+  /** Per-request timeout in milliseconds. Defaults to 15000. */
+  requestTimeoutMs?: number;
+}
+
+/**
+ * Input to `Paycrest.offramp(wallet, input)`.
+ *
+ * `path` defaults to `"gateway"`. The two paths surface the same shape
+ * to the caller; internally:
+ *   - `gateway` path: encrypts recipient details, fetches a rate, and
+ *     emits an approve + create_order Call pair on-chain.
+ *   - `api` path: POSTs to `/v2/sender/orders`, returns the receive
+ *     address, and emits a single ERC20 transfer Call to that address.
+ */
+export interface OfframpInput {
+  path?: PaycrestPath;
+  from: {
+    token: Token;
+    amount: Amount;
+  };
+  to: {
+    currency: string;
+    recipient: PaycrestRecipient;
+  };
+  /** App-side identifier echoed back on the order and webhook. Optional. */
+  reference?: string;
+  /**
+   * Optional pre-fetched rate. Used only for the API path; the gateway
+   * path always fetches its own rate from `/v2/rates`.
+   */
+  rate?: string;
+  /**
+   * Optional sender fee (gateway path only). Defaults to zero address +
+   * `0n`. When set, the approve amount is `amount + senderFee`.
+   */
+  senderFee?: {
+    recipient: Address;
+    amount: bigint;
+  };
+}
+
+/** Input to `Paycrest.onramp(input)`. On-ramp is API-path only. */
+export interface OnrampInput {
+  from: {
+    currency: string;
+    /** Fiat amount as a stringified or numeric value (Paycrest accepts both). */
+    amount: string | number;
+    refundAccount: PaycrestRefundAccount;
+  };
+  to: {
+    token: Token;
+    recipient: Address;
+  };
+  reference?: string;
+}
+
+/** Result returned by `Paycrest.offramp(...)`. */
+export interface OfframpResult {
+  path: PaycrestPath;
+  /**
+   * Resolves to the order id once it's known.
+   *
+   * - **api path**: resolves immediately to the UUID returned by `POST
+   *   /v2/sender/orders` — already known when `offramp()` returns.
+   * - **gateway path**: resolves to the felt252 hex order id parsed
+   *   from the `OrderCreated` event after the transaction confirms.
+   *   Internally waits for the L2 receipt; you do **not** need to call
+   *   `tx.wait()` separately before awaiting `orderId`. Resolves to
+   *   `null` if the receipt has no `OrderCreated` event (e.g. tx
+   *   reverted — check `tx.wait()` for the failure reason).
+   */
+  orderId: Promise<string | null>;
+  tx: Tx;
+  /** Underlying calls executed (returned for inspection / re-use). */
+  calls: Call[];
+  /** Sender API order metadata (api path only). */
+  providerAccount?: PaycrestProviderAccount;
+  /** ERC20 receive address on the api path. */
+  receiveAddress?: string;
+  /** Rate used for the order (gateway path only — string from `/v2/rates`). */
+  rate?: string;
+  /**
+   * Wait for fiat settlement. Polls the correct aggregator endpoint
+   * based on `path`:
+   *
+   * - **api path** uses `GET /v2/sender/orders/{uuid}` (full order).
+   * - **gateway path** uses `GET /v2/orders/{chain_id}/{gateway_id}`
+   *   (smaller status-only shape — the Sender API endpoint doesn't
+   *   index gateway_id).
+   *
+   * Resolves with the unified status when a success terminal is
+   * reached (`validated` or `settled`); throws `PaycrestOrderError`
+   * on `refunded` / `expired`. See `PaycrestWaitForOrderOptions` for
+   * tuning.
+   */
+  wait(options?: PaycrestWaitForOrderOptions): Promise<PaycrestOfframpStatus>;
+}
+
+/** Result returned by `Paycrest.onramp(...)`. */
+export interface OnrampResult {
+  orderId: string;
+  status: PaycrestOrderStatus;
+  providerAccount: PaycrestProviderAccount;
+  validUntil?: string;
+  reference?: string;
+}
+
+/** Re-export `ExecuteOptions` so callers don't need to dig into `@/types`. */
+export type PaycrestExecuteOptions = ExecuteOptions;
+
+/**
+ * Options for `Paycrest.waitForOrder(...)`. Mirrors the shape of
+ * `Tx.wait(WaitOptions)` — pass `successStates: []` to disable the
+ * built-in success terminals, or `errorStates: []` to never throw on
+ * refund/expiry (the order is returned regardless).
+ */
+export interface PaycrestWaitForOrderOptions {
+  /**
+   * Statuses that resolve the wait as success.
+   * Default: `["validated", "settled"]`.
+   *
+   * Off-ramp completion is conventionally `validated` (provider has
+   * confirmed fiat delivery); on-ramp completion is `settled` (tokens
+   * released). The default covers both directions.
+   */
+  successStates?: PaycrestOrderStatus[];
+  /**
+   * Statuses that reject the wait as failure.
+   * Default: `["refunded", "expired"]`.
+   */
+  errorStates?: PaycrestOrderStatus[];
+  /** Polling interval in milliseconds. Default: 5000. */
+  pollIntervalMs?: number;
+  /** Total wait timeout in milliseconds. Default: 600000 (10 min). */
+  timeoutMs?: number;
+  /** AbortSignal to cancel the wait early. */
+  signal?: AbortSignal;
+}
+
+/**
+ * On-chain `Order` struct returned by the Cairo Gateway's `get_order_info`.
+ * Mirrors `paycrest::interfaces::IGateway::Order`.
+ */
+export interface PaycrestOrderInfo {
+  sender: Address;
+  token: Address;
+  senderFeeRecipient: Address;
+  senderFee: bigint;
+  protocolFee: bigint;
+  isFulfilled: boolean;
+  isRefunded: boolean;
+  refundAddress: Address;
+  currentBps: bigint;
+  amount: bigint;
+}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -476,7 +476,8 @@ export class StarkZap {
         ...(this.config.logging && { logging: this.config.logging }),
       },
       this.config.staking,
-      this.config.bridging
+      this.config.bridging,
+      this.config.paycrest
     );
     return wallet as CartridgeWalletInterface;
   }

--- a/src/tx/builder.ts
+++ b/src/tx/builder.ts
@@ -12,6 +12,7 @@ import type {
   LendingWithdrawRequest,
 } from "@/lending";
 import type { TrovesDepositParams, TrovesWithdrawParams } from "@/troves";
+import type { OfframpInput } from "@/paycrest";
 import type {
   Address,
   Amount,
@@ -331,6 +332,29 @@ export class TxBuilder {
    */
   trovesWithdraw(params: TrovesWithdrawParams): this {
     this.queueAsyncCalls(this.wallet.troves().populateWithdraw(params));
+    return this;
+  }
+
+  /**
+   * Add a Paycrest off-ramp (gateway path) — emits an ERC20 approve to
+   * the Cairo Gateway plus a `create_order` Call carrying the encrypted
+   * recipient details.
+   *
+   * Gateway path only. The API path requires an HTTP order-creation
+   * step that doesn't fit the synchronous builder shape — call
+   * `wallet.paycrest().offramp(wallet, { ..., path: "api" })` instead.
+   */
+  paycrestOfframp(input: OfframpInput): this {
+    if (input.path !== undefined && input.path !== "gateway") {
+      throw new Error(
+        `tx.paycrestOfframp only supports the gateway path. For api-path offramp, call wallet.paycrest().offramp(...) directly.`
+      );
+    }
+    const p = this.wallet
+      .paycrest()
+      .populateOfframp(this.wallet, input)
+      .then((r) => r.calls);
+    this.queueAsyncCalls(p);
     return this;
   }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -186,6 +186,38 @@ export interface BridgingConfig {
 }
 
 /**
+ * Configuration for the Paycrest fiat on/off-ramp module.
+ *
+ * Paycrest is mainnet-only — there is no testnet backend or Gateway.
+ * `apiKey` is required for any order-creating call (offramp, onramp,
+ * getOrder); read-only endpoints (currencies, institutions, rates)
+ * work without one.
+ *
+ * @example
+ * ```ts
+ * const sdk = new StarkZap({
+ *   network: "mainnet",
+ *   paycrest: {
+ *     apiKey: process.env.PAYCREST_API_KEY,
+ *     apiSecret: process.env.PAYCREST_API_SECRET, // for webhook verification
+ *   },
+ * });
+ * ```
+ */
+export interface PaycrestConfig {
+  /** Paycrest API key from app.paycrest.io (required for order creation). */
+  apiKey?: string;
+  /** Paycrest API secret (required only for webhook signature verification). */
+  apiSecret?: string;
+  /** Override the API base URL. Defaults to `https://api.paycrest.io`. */
+  apiBaseUrl?: string;
+  /** Override the Cairo Gateway address (e.g. for forking). */
+  gatewayAddress?: Address;
+  /** Per-request timeout in milliseconds. Defaults to 15000. */
+  requestTimeoutMs?: number;
+}
+
+/**
  * Main configuration for the StarkZap.
  *
  * You can configure using a network preset or custom rpcUrl/chainId.
@@ -245,6 +277,16 @@ export interface SDKConfig {
    * @see {@link BridgingConfig}
    */
   bridging?: BridgingConfig;
+
+  /**
+   * Optional: configuration for the Paycrest fiat on/off-ramp module.
+   *
+   * Threaded through to `wallet.paycrest()` so apps don't need to pass
+   * the API key on every call.
+   *
+   * @see {@link PaycrestConfig}
+   */
+  paycrest?: PaycrestConfig;
 
   /**
    * Optional logging configuration for SDK diagnostics.

--- a/src/wallet/base.ts
+++ b/src/wallet/base.ts
@@ -43,6 +43,8 @@ import type {
 import { Erc20 } from "@/erc20";
 import { Staking, EndurStaking, type EndurStakingOptions } from "@/staking";
 import { Troves, type TrovesOptions } from "@/troves";
+import { Paycrest, type PaycrestOptions } from "@/paycrest";
+import type { PaycrestConfig } from "@/types/config";
 import type { PreparedSwap, SwapInput, SwapProvider, SwapQuote } from "@/swap";
 import { AvnuSwapProvider } from "@/swap";
 import { resolveSwapInput } from "@/swap/utils";
@@ -118,6 +120,8 @@ export abstract class BaseWallet implements WalletInterface {
   private stakingInFlight: Map<Address, Promise<Staking>> = new Map();
   private lstStakingMap: Map<string, EndurStaking> = new Map();
   private trovesInstance: Troves | undefined;
+  private paycrestInstance: Paycrest | undefined;
+  private readonly paycrestConfig: PaycrestConfig | undefined;
 
   private readonly bridging: BridgeOperator;
 
@@ -131,6 +135,7 @@ export abstract class BaseWallet implements WalletInterface {
     address: Address;
     stakingConfig?: StakingConfig | undefined;
     bridgingConfig?: BridgingConfig | undefined;
+    paycrestConfig?: PaycrestConfig | undefined;
     defaultSwapProvider?: SwapProvider | undefined;
     defaultLendingProvider?: LendingProvider | undefined;
     defaultDcaProvider?: DcaProvider | undefined;
@@ -138,6 +143,7 @@ export abstract class BaseWallet implements WalletInterface {
   }) {
     this.address = options.address;
     this.stakingConfig = options.stakingConfig;
+    this.paycrestConfig = options.paycrestConfig;
     this.logger = createLogger(options.logging);
     this.bridging = new BridgeOperator(
       this,
@@ -827,6 +833,23 @@ export abstract class BaseWallet implements WalletInterface {
       this.trovesInstance = new Troves(this, options);
     }
     return this.trovesInstance;
+  }
+
+  /**
+   * Get a Paycrest client for fiat on/off-ramps. Configuration is
+   * pulled from `SDKConfig.paycrest` if not overridden at call time.
+   *
+   * The same instance is returned across calls. `options` only takes
+   * effect on the first call — construct `Paycrest` directly if you
+   * need different settings later.
+   */
+  paycrest(options?: PaycrestOptions): Paycrest {
+    if (!this.paycrestInstance) {
+      const merged: PaycrestOptions = { ...(this.paycrestConfig ?? {}) };
+      if (options) Object.assign(merged, options);
+      this.paycrestInstance = new Paycrest(merged);
+    }
+    return this.paycrestInstance;
   }
 
   /** {@inheritDoc WalletInterface.initiateWithdraw} */

--- a/src/wallet/cartridge.ts
+++ b/src/wallet/cartridge.ts
@@ -9,6 +9,7 @@ import {
 import { Tx } from "@/tx";
 import {
   type BridgingConfig,
+  type PaycrestConfig,
   ChainId,
   type DeployOptions,
   type EnsureReadyOptions,
@@ -148,12 +149,14 @@ export class CartridgeWallet extends BaseWallet {
     classHash: string,
     stakingConfig: StakingConfig | undefined,
     bridgingConfig: BridgingConfig | undefined,
+    paycrestConfig: PaycrestConfig | undefined,
     options: CartridgeWalletOptions = {}
   ) {
     super({
       address: fromAddress(walletAccount.address),
       stakingConfig,
       bridgingConfig,
+      paycrestConfig,
       ...(options.logging && { logging: options.logging }),
     });
     this.controller = controller;
@@ -172,7 +175,8 @@ export class CartridgeWallet extends BaseWallet {
   static async create(
     options: CartridgeWalletOptions = {},
     stakingConfig?: StakingConfig | undefined,
-    bridgingConfig?: BridgingConfig | undefined
+    bridgingConfig?: BridgingConfig | undefined,
+    paycrestConfig?: PaycrestConfig | undefined
   ): Promise<CartridgeWallet> {
     const { default: Controller, toSessionPolicies } =
       await loadCartridgeControllerModule();
@@ -255,6 +259,7 @@ export class CartridgeWallet extends BaseWallet {
       classHash,
       stakingConfig,
       bridgingConfig,
+      paycrestConfig,
       options
     );
   }

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -22,6 +22,7 @@ import type {
   ExecuteOptions,
   ExplorerConfig,
   FeeMode,
+  PaycrestConfig,
   PreflightOptions,
   PreflightResult,
   ProviderOptions,
@@ -140,12 +141,14 @@ export class Wallet extends BaseWallet {
     defaultTimeBounds?: PaymasterTimeBounds;
     stakingConfig: StakingConfig | undefined;
     bridgingConfig?: BridgingConfig | undefined;
+    paycrestConfig?: PaycrestConfig | undefined;
     logging?: LoggerConfig;
   }) {
     super({
       address: options.address,
       stakingConfig: options.stakingConfig,
       bridgingConfig: options.bridgingConfig,
+      paycrestConfig: options.paycrestConfig,
       ...(options.logging && { logging: options.logging }),
     });
     this.accountProvider = options.accountProvider;
@@ -231,6 +234,7 @@ export class Wallet extends BaseWallet {
       ...(timeBounds && { defaultTimeBounds: timeBounds }),
       stakingConfig: options.config.staking,
       bridgingConfig: options.config.bridging,
+      paycrestConfig: options.config.paycrest,
       ...(config.logging && { logging: config.logging }),
     });
 

--- a/src/wallet/interface.ts
+++ b/src/wallet/interface.ts
@@ -13,6 +13,7 @@ import type { Staking, EndurStaking, EndurStakingOptions } from "@/staking";
 import type { LendingClient } from "@/lending";
 import type { DcaClientInterface } from "@/dca";
 import type { Troves, TrovesOptions } from "@/troves";
+import type { Paycrest, PaycrestOptions } from "@/paycrest";
 import type { PreparedSwap, SwapInput, SwapProvider, SwapQuote } from "@/swap";
 import type {
   Address,
@@ -353,4 +354,23 @@ export interface WalletInterface extends BridgeOperatorInterface {
    * (Troves is a mainnet-only service).
    */
   troves(options?: TrovesOptions): Troves;
+
+  // ============================================================
+  // Paycrest — fiat on/off-ramp
+  // ============================================================
+
+  /**
+   * Get a Paycrest client for fiat on/off-ramps.
+   *
+   * The same instance is returned across calls. **Options only apply on the
+   * first call** — subsequent calls ignore them and return the cached
+   * instance.
+   *
+   * Off-ramp methods (`offramp`, `populateOfframp`) take this wallet as
+   * their first argument; on-ramp (`onramp`) is wallet-independent. See
+   * `Paycrest` for the full API.
+   *
+   * Paycrest is mainnet-only.
+   */
+  paycrest(options?: PaycrestOptions): Paycrest;
 }

--- a/tests/paycrest-encryption.test.ts
+++ b/tests/paycrest-encryption.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import nodeCrypto from "node:crypto";
+import { encryptRecipient } from "@/paycrest";
+
+/**
+ * Generate an in-memory RSA key pair to encrypt against, then verify the
+ * SDK's encryptor (`crypto.subtle` in modern Node) produces ciphertext
+ * the matching private key can decrypt back to the original plaintext.
+ *
+ * This validates both:
+ *   - PEM (SPKI) → SubtleCrypto importKey path
+ *   - RSA-OAEP-SHA256 round-trip end to end
+ */
+describe("paycrest encryption (RSA-OAEP-SHA256)", () => {
+  it("encrypts a plaintext that decrypts via the matching private key", async () => {
+    const { publicKey, privateKey } = nodeCrypto.generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: "spki", format: "pem" },
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    });
+
+    const plaintext = JSON.stringify({
+      institution: "GTBINGLA",
+      accountIdentifier: "1234567890",
+      accountName: "Test User",
+      metadata: { apiKey: "test-key" },
+    });
+
+    const base64Ciphertext = await encryptRecipient(publicKey, plaintext);
+    expect(typeof base64Ciphertext).toBe("string");
+    expect(base64Ciphertext.length).toBeGreaterThan(0);
+    expect(base64Ciphertext).toMatch(/^[A-Za-z0-9+/=]+$/);
+
+    const decrypted = nodeCrypto.privateDecrypt(
+      {
+        key: privateKey,
+        padding: nodeCrypto.constants.RSA_PKCS1_OAEP_PADDING,
+        oaepHash: "sha256",
+      },
+      Buffer.from(base64Ciphertext, "base64")
+    );
+    expect(decrypted.toString("utf8")).toBe(plaintext);
+  });
+
+  it("throws on a malformed PEM (no BEGIN PUBLIC KEY armor)", async () => {
+    await expect(encryptRecipient("not-a-pem", "hello")).rejects.toThrow(
+      /PEM/i
+    );
+  });
+});

--- a/tests/paycrest.test.ts
+++ b/tests/paycrest.test.ts
@@ -1,0 +1,810 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import nodeCrypto from "node:crypto";
+import {
+  Amount,
+  ChainId,
+  fromAddress,
+  type Address,
+  type Token,
+} from "@/types";
+import {
+  Paycrest,
+  PAYCREST_GATEWAY_MAINNET,
+  PaycrestApi,
+  PaycrestOrderError,
+  paycrestNetworkFor,
+  paycrestGatewayFor,
+} from "@/paycrest";
+import type { WalletInterface } from "@/wallet/interface";
+import { Erc20 } from "@/erc20";
+import type { RpcProvider } from "starknet";
+
+const USDC: Token = {
+  name: "USDC",
+  address:
+    "0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb" as Address,
+  decimals: 6,
+  symbol: "USDC",
+};
+
+const SENDER = fromAddress(
+  "0x01abcdef0000000000000000000000000000000000000000000000000000abcd"
+);
+
+function buildKeyPair(): { publicKey: string; privateKey: string } {
+  const { publicKey, privateKey } = nodeCrypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  return { publicKey, privateKey };
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function envelope<T>(data: T): { status: string; data: T } {
+  return { status: "success", data };
+}
+
+function makeFakeWallet(): {
+  wallet: WalletInterface;
+  executeMock: ReturnType<typeof vi.fn>;
+  receiptMock: ReturnType<typeof vi.fn>;
+  waitMock: ReturnType<typeof vi.fn>;
+} {
+  const provider = {} as unknown as RpcProvider;
+  const receiptMock = vi.fn().mockResolvedValue({ events: [] });
+  const waitMock = vi.fn().mockResolvedValue(undefined);
+  const executeMock = vi
+    .fn()
+    .mockResolvedValue({ hash: "0xtx", receipt: receiptMock, wait: waitMock });
+  const erc20Map = new Map<Address, Erc20>();
+  const wallet = {
+    address: SENDER,
+    getChainId: () => ChainId.MAINNET,
+    getProvider: () => provider,
+    execute: executeMock,
+    erc20: (token: Token) => {
+      const cached = erc20Map.get(token.address);
+      if (cached) return cached;
+      const e = new Erc20(token, provider);
+      erc20Map.set(token.address, e);
+      return e;
+    },
+  } as unknown as WalletInterface;
+  return { wallet, executeMock, receiptMock, waitMock };
+}
+
+describe("Paycrest rate scaling (u128, 2 decimals)", () => {
+  it("matches the on-chain convention used by EVM Paycrest deployments", async () => {
+    const { rateToU128 } = await import("@/paycrest/paycrest");
+    // EVM convention: on-chain rate 156000 == 1560.00, 136192 == 1361.92.
+    expect(rateToU128("1560")).toBe(156000n);
+    expect(rateToU128("1560.00")).toBe(156000n);
+    expect(rateToU128("1361.92")).toBe(136192n);
+    // Edge cases
+    expect(rateToU128("0.01")).toBe(1n);
+    expect(rateToU128("1500.5")).toBe(150050n); // missing trailing zero is padded
+    expect(rateToU128("1500.50")).toBe(150050n);
+    // Strips any leading non-digit (e.g. accidental "$1500")
+    expect(rateToU128("$1500")).toBe(150000n);
+  });
+});
+
+describe("Paycrest presets", () => {
+  it("maps mainnet ChainId to the live Cairo Gateway address", () => {
+    expect(paycrestGatewayFor(ChainId.MAINNET)).toBe(PAYCREST_GATEWAY_MAINNET);
+    expect(paycrestNetworkFor(ChainId.MAINNET)).toBe("starknet");
+  });
+
+  it("rejects sepolia (Paycrest is mainnet-only)", () => {
+    expect(() => paycrestGatewayFor(ChainId.SEPOLIA)).toThrow(/mainnet-only/i);
+    expect(() => paycrestNetworkFor(ChainId.SEPOLIA)).toThrow(/mainnet-only/i);
+  });
+});
+
+describe("PaycrestApi", () => {
+  it("attaches the API-Key header when an apiKey is set", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, envelope({ orders: [] })));
+    const api = new PaycrestApi({
+      apiKey: "test-key",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await api.listOrders();
+    const [, init] = fetchMock.mock.calls[0]!;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["API-Key"]).toBe("test-key");
+  });
+
+  it("rejects order-creating calls when apiKey is missing", async () => {
+    const fetchMock = vi.fn();
+    const api = new PaycrestApi({
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await expect(api.createOrder({})).rejects.toThrow(/API key/i);
+  });
+
+  it("surfaces the server error message on 4xx responses", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(400, { status: "error", message: "validation failed" })
+      );
+    const api = new PaycrestApi({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await expect(api.getOrder("x")).rejects.toThrow(/validation failed/);
+  });
+});
+
+describe("Paycrest gateway off-ramp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits approve + create_order calls and forwards the rate", async () => {
+    const { publicKey, privateKey } = buildKeyPair();
+    const fetchMock = vi.fn().mockImplementation(async (url: string | URL) => {
+      const u = url.toString();
+      if (u.endsWith("/v2/pubkey")) {
+        return jsonResponse(200, envelope(publicKey));
+      }
+      if (u.includes("/v2/rates/")) {
+        return jsonResponse(
+          200,
+          envelope({
+            sell: {
+              rate: "1500.50",
+              providerIds: [],
+              orderType: "regular",
+              refundTimeoutMinutes: 60,
+            },
+          })
+        );
+      }
+      throw new Error(`unexpected fetch: ${u}`);
+    });
+
+    const paycrest = new Paycrest({
+      apiKey: "test-key",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const { wallet, executeMock, receiptMock, waitMock } = makeFakeWallet();
+    const orderIdHex =
+      "0x07f3b1c0000000000000000000000000000000000000000000000000000000ab";
+    const { ORDER_CREATED_EVENT_SELECTOR } = await import("@/paycrest/gateway");
+    receiptMock.mockResolvedValueOnce({
+      events: [
+        {
+          from_address: PAYCREST_GATEWAY_MAINNET,
+          keys: [
+            ORDER_CREATED_EVENT_SELECTOR,
+            SENDER,
+            USDC.address,
+            "0x" + (100n * 10n ** 6n).toString(16),
+            "0x0",
+          ],
+          data: ["0x0", "0x0", orderIdHex, "0x" + 150050n.toString(16)],
+        },
+      ],
+    });
+
+    const result = await paycrest.offramp(wallet, {
+      from: { token: USDC, amount: Amount.parse("100", USDC) },
+      to: {
+        currency: "NGN",
+        recipient: {
+          institution: "GTBINGLA",
+          accountIdentifier: "1234567890",
+          accountName: "Test",
+        },
+      },
+    });
+
+    expect(result.path).toBe("gateway");
+    expect(result.rate).toBe("1500.50");
+    expect(result.calls).toHaveLength(2);
+    expect(result.calls[0]!.entrypoint).toBe("approve");
+    expect(result.calls[1]!.entrypoint).toBe("create_order");
+    expect(result.calls[1]!.contractAddress).toBe(PAYCREST_GATEWAY_MAINNET);
+    expect(result.calls[1]!.calldata).toBeTruthy();
+    expect(executeMock).toHaveBeenCalledTimes(1);
+
+    // orderId is a lazy Promise — internally awaits tx.wait() and parses
+    // the OrderCreated event. Resolves only after we await it.
+    const id = await result.orderId;
+    expect(waitMock).toHaveBeenCalled();
+    // num.toHex strips leading zeros from felt252 hex.
+    expect(id).toBe(
+      "0x7f3b1c0000000000000000000000000000000000000000000000000000000ab"
+    );
+    void privateKey;
+  });
+
+  it("resolves orderId to null when the tx reverts", async () => {
+    const { publicKey } = buildKeyPair();
+    const fetchMock = vi.fn().mockImplementation(async (url: string | URL) => {
+      const u = url.toString();
+      if (u.endsWith("/v2/pubkey"))
+        return jsonResponse(200, envelope(publicKey));
+      if (u.includes("/v2/rates/"))
+        return jsonResponse(
+          200,
+          envelope({
+            sell: {
+              rate: "1500",
+              providerIds: [],
+              orderType: "regular",
+              refundTimeoutMinutes: 60,
+            },
+          })
+        );
+      throw new Error(`unexpected: ${u}`);
+    });
+    const paycrest = new Paycrest({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const { wallet, waitMock } = makeFakeWallet();
+    waitMock.mockRejectedValueOnce(new Error("reverted"));
+    const result = await paycrest.offramp(wallet, {
+      from: { token: USDC, amount: Amount.parse("100", USDC) },
+      to: {
+        currency: "NGN",
+        recipient: {
+          institution: "GTBINGLA",
+          accountIdentifier: "1",
+          accountName: "x",
+        },
+      },
+    });
+    expect(await result.orderId).toBeNull();
+  });
+
+  it("throws when offramp is called with a sepolia wallet", async () => {
+    const paycrest = new Paycrest({
+      apiKey: "k",
+      fetch: vi.fn() as unknown as typeof fetch,
+    });
+    const { wallet } = makeFakeWallet();
+    (wallet as unknown as { getChainId: () => ChainId }).getChainId = () =>
+      ChainId.SEPOLIA;
+
+    await expect(
+      paycrest.offramp(wallet, {
+        from: { token: USDC, amount: Amount.parse("100", USDC) },
+        to: {
+          currency: "NGN",
+          recipient: {
+            institution: "GTBINGLA",
+            accountIdentifier: "1",
+            accountName: "x",
+          },
+        },
+      })
+    ).rejects.toThrow(/mainnet-only/i);
+  });
+});
+
+describe("Paycrest API off-ramp", () => {
+  it("posts an offramp body and emits a transfer Call to receiveAddress", async () => {
+    const receiveAddress =
+      "0x05bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(
+        201,
+        envelope({
+          id: "ord-001",
+          status: "initiated",
+          providerAccount: { receiveAddress, network: "starknet" },
+        })
+      )
+    );
+
+    const paycrest = new Paycrest({
+      apiKey: "test-key",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const { wallet, executeMock } = makeFakeWallet();
+    const result = await paycrest.offramp(wallet, {
+      path: "api",
+      from: { token: USDC, amount: Amount.parse("50", USDC) },
+      to: {
+        currency: "NGN",
+        recipient: {
+          institution: "GTBINGLA",
+          accountIdentifier: "1234567890",
+          accountName: "Test",
+          memo: "Salary",
+        },
+      },
+      reference: "order-001",
+    });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse(init.body as string) as {
+      amount: string;
+      source: { network: string; refundAddress: string };
+      destination: { recipient: { memo?: string } };
+      reference: string;
+    };
+    expect(body.amount).toBe("50");
+    expect(body.source.network).toBe("starknet");
+    expect(body.source.refundAddress).toBe(SENDER);
+    expect(body.destination.recipient.memo).toBe("Salary");
+    expect(body.reference).toBe("order-001");
+
+    expect(result.path).toBe("api");
+    expect(await result.orderId).toBe("ord-001");
+    expect(result.receiveAddress).toBe(receiveAddress);
+    expect(result.calls).toHaveLength(1);
+    expect(result.calls[0]!.entrypoint).toBe("transfer");
+    expect(executeMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Paycrest on-ramp", () => {
+  it("posts an onramp body and returns providerAccount", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(
+        201,
+        envelope({
+          id: "ord-002",
+          status: "initiated",
+          providerAccount: {
+            institution: "GTB",
+            accountIdentifier: "0123456789",
+            accountName: "Provider A",
+            amountToTransfer: "50000",
+            currency: "NGN",
+            validUntil: "2026-03-01T10:05:00Z",
+          },
+        })
+      )
+    );
+    const paycrest = new Paycrest({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const result = await paycrest.onramp({
+      from: {
+        currency: "NGN",
+        amount: 50000,
+        refundAccount: {
+          institution: "GTBINGLA",
+          accountIdentifier: "1234567890",
+          accountName: "John Doe",
+        },
+      },
+      to: { token: USDC, recipient: SENDER },
+      reference: "order-002",
+    });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse(init.body as string) as {
+      amountIn: string;
+      source: { type: string; refundAccount: { institution: string } };
+      destination: { recipient: { network: string } };
+    };
+    expect(body.amountIn).toBe("fiat");
+    expect(body.source.type).toBe("fiat");
+    expect(body.source.refundAccount.institution).toBe("GTBINGLA");
+    expect(body.destination.recipient.network).toBe("starknet");
+
+    expect(result.orderId).toBe("ord-002");
+    expect(result.providerAccount.amountToTransfer).toBe("50000");
+    expect(result.providerAccount.currency).toBe("NGN");
+    expect(result.reference).toBe("order-002");
+  });
+
+  it("rejects EVM-looking recipients defensively", async () => {
+    const paycrest = new Paycrest({
+      apiKey: "k",
+      fetch: vi.fn() as unknown as typeof fetch,
+    });
+    await expect(
+      paycrest.onramp({
+        from: {
+          currency: "NGN",
+          amount: 1000,
+          refundAccount: {
+            institution: "GTB",
+            accountIdentifier: "1",
+            accountName: "x",
+          },
+        },
+        to: {
+          token: USDC,
+          // 40-char EVM hex address
+          recipient: "0xAbCdEf0000000000000000000000000000000001" as Address,
+        },
+      })
+    ).rejects.toThrow(/EVM/i);
+  });
+});
+
+describe("Paycrest.waitForOrder", () => {
+  function buildPaycrestWithOrderResponses(
+    responses: Array<{ status: string }>
+  ): {
+    paycrest: Paycrest;
+    fetchMock: ReturnType<typeof vi.fn>;
+  } {
+    let i = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      const next = responses[Math.min(i, responses.length - 1)]!;
+      i++;
+      return jsonResponse(200, envelope({ id: "ord-1", ...next }));
+    });
+    const paycrest = new Paycrest({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    return { paycrest, fetchMock };
+  }
+
+  it("polls until status reaches a success terminal (validated)", async () => {
+    const { paycrest, fetchMock } = buildPaycrestWithOrderResponses([
+      { status: "initiated" },
+      { status: "deposited" },
+      { status: "validated" },
+    ]);
+    const order = await paycrest.waitForOrder("ord-1", { pollIntervalMs: 1 });
+    expect(order.status).toBe("validated");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("resolves immediately when the first poll already shows settled", async () => {
+    const { paycrest, fetchMock } = buildPaycrestWithOrderResponses([
+      { status: "settled" },
+    ]);
+    const order = await paycrest.waitForOrder("ord-1", { pollIntervalMs: 1 });
+    expect(order.status).toBe("settled");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("succeeds on settled even when validated is skipped between polls", async () => {
+    // Poll cadence can be longer than the gap between validated and
+    // settled, so we may never observe validated. Both are success
+    // terminals — landing directly on settled must resolve.
+    const { paycrest } = buildPaycrestWithOrderResponses([
+      { status: "initiated" },
+      { status: "deposited" },
+      { status: "settled" },
+    ]);
+    const order = await paycrest.waitForOrder("ord-1", { pollIntervalMs: 1 });
+    expect(order.status).toBe("settled");
+  });
+
+  it("throws PaycrestOrderError when the order is refunded", async () => {
+    const { paycrest } = buildPaycrestWithOrderResponses([
+      { status: "refunding" },
+      { status: "refunded" },
+    ]);
+    await expect(
+      paycrest.waitForOrder("ord-1", { pollIntervalMs: 1 })
+    ).rejects.toBeInstanceOf(PaycrestOrderError);
+  });
+
+  it("throws PaycrestOrderError when the order expires", async () => {
+    const { paycrest } = buildPaycrestWithOrderResponses([
+      { status: "expired" },
+    ]);
+    let caught: unknown;
+    try {
+      await paycrest.waitForOrder("ord-1", { pollIntervalMs: 1 });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(PaycrestOrderError);
+    expect((caught as PaycrestOrderError).order.status).toBe("expired");
+  });
+
+  it("times out when no terminal state is reached", async () => {
+    const { paycrest } = buildPaycrestWithOrderResponses([
+      { status: "pending" },
+    ]);
+    await expect(
+      paycrest.waitForOrder("ord-1", {
+        pollIntervalMs: 5,
+        timeoutMs: 20,
+      })
+    ).rejects.toThrow(/timed out/i);
+  });
+
+  it("aborts when signal fires", async () => {
+    const { paycrest } = buildPaycrestWithOrderResponses([
+      { status: "pending" },
+    ]);
+    const ac = new AbortController();
+    setTimeout(() => ac.abort(), 10);
+    await expect(
+      paycrest.waitForOrder("ord-1", {
+        pollIntervalMs: 100,
+        timeoutMs: 60_000,
+        signal: ac.signal,
+      })
+    ).rejects.toThrow(/aborted by signal/i);
+  });
+
+  it("respects custom successStates / errorStates", async () => {
+    // Treat "deposited" as success and disable default error states.
+    const { paycrest } = buildPaycrestWithOrderResponses([
+      { status: "deposited" },
+    ]);
+    const order = await paycrest.waitForOrder("ord-1", {
+      pollIntervalMs: 1,
+      successStates: ["deposited"],
+      errorStates: [],
+    });
+    expect(order.status).toBe("deposited");
+  });
+});
+
+describe("Paycrest.waitForGatewayOrder", () => {
+  it("hits /v2/orders/{chain_id}/{gateway_id} with STARKNET_MAINNET_CHAIN_ID by default", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(200, envelope({ orderId: "0xabc", status: "settled" }))
+      );
+    const paycrest = new Paycrest({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const result = await paycrest.waitForGatewayOrder("0xabc", {
+      pollIntervalMs: 1,
+    });
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toContain("/v2/orders/23448594291968334/0xabc");
+    expect(result.status).toBe("settled");
+  });
+
+  it("accepts a chainId override", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(200, envelope({ orderId: "0xabc", status: "validated" }))
+      );
+    const paycrest = new Paycrest({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await paycrest.waitForGatewayOrder("0xabc", {
+      pollIntervalMs: 1,
+      chainId: 99999n,
+    });
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toContain("/v2/orders/99999/0xabc");
+  });
+
+  it("throws PaycrestOrderError when the order is refunded", async () => {
+    let i = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      const status = i++ === 0 ? "refunding" : "refunded";
+      return jsonResponse(200, envelope({ orderId: "0xabc", status }));
+    });
+    const paycrest = new Paycrest({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await expect(
+      paycrest.waitForGatewayOrder("0xabc", { pollIntervalMs: 1 })
+    ).rejects.toBeInstanceOf(PaycrestOrderError);
+  });
+});
+
+describe("OfframpResult.wait() dispatch", () => {
+  it("api-path result.wait() polls /v2/sender/orders/{uuid}", async () => {
+    const receiveAddress =
+      "0x05bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let calls = 0;
+    const fetchMock = vi.fn().mockImplementation(async (url: string | URL) => {
+      const u = String(url);
+      if (u.endsWith("/v2/sender/orders") && calls++ === 0) {
+        // POST createOrder response
+        return jsonResponse(
+          201,
+          envelope({
+            id: "uuid-1",
+            status: "initiated",
+            providerAccount: { receiveAddress, network: "starknet" },
+          })
+        );
+      }
+      if (u.includes("/v2/sender/orders/uuid-1")) {
+        return jsonResponse(200, envelope({ id: "uuid-1", status: "settled" }));
+      }
+      throw new Error(`unexpected: ${u}`);
+    });
+    const paycrest = new Paycrest({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const { wallet } = makeFakeWallet();
+    const result = await paycrest.offramp(wallet, {
+      path: "api",
+      from: { token: USDC, amount: Amount.parse("1", USDC) },
+      to: {
+        currency: "NGN",
+        recipient: {
+          institution: "GTBINGLA",
+          accountIdentifier: "1",
+          accountName: "x",
+        },
+      },
+    });
+    const status = await result.wait({ pollIntervalMs: 1 });
+    expect(status.path).toBe("api");
+    expect(status.orderId).toBe("uuid-1");
+    expect(status.status).toBe("settled");
+    // Confirms the lookup hit the sender-orders path, not the
+    // gateway-id path.
+    const lookupCalls = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes("/v2/sender/orders/uuid-1")
+    );
+    expect(lookupCalls.length).toBeGreaterThan(0);
+  });
+
+  it("gateway-path result.wait() polls /v2/orders/{chain_id}/{gateway_id}", async () => {
+    const { publicKey } = buildKeyPair();
+    const orderIdHex =
+      "0x07f3b1c0000000000000000000000000000000000000000000000000000000ab";
+    const { ORDER_CREATED_EVENT_SELECTOR } = await import("@/paycrest/gateway");
+
+    const fetchMock = vi.fn().mockImplementation(async (url: string | URL) => {
+      const u = String(url);
+      if (u.endsWith("/v2/pubkey"))
+        return jsonResponse(200, envelope(publicKey));
+      if (u.includes("/v2/rates/"))
+        return jsonResponse(
+          200,
+          envelope({
+            sell: {
+              rate: "1500",
+              providerIds: [],
+              orderType: "regular",
+              refundTimeoutMinutes: 60,
+            },
+          })
+        );
+      if (u.includes("/v2/orders/23448594291968334/")) {
+        return jsonResponse(
+          200,
+          envelope({ orderId: orderIdHex, status: "validated" })
+        );
+      }
+      throw new Error(`unexpected: ${u}`);
+    });
+
+    const paycrest = new Paycrest({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const { wallet, receiptMock } = makeFakeWallet();
+    receiptMock.mockResolvedValueOnce({
+      events: [
+        {
+          from_address: PAYCREST_GATEWAY_MAINNET,
+          keys: [
+            ORDER_CREATED_EVENT_SELECTOR,
+            SENDER,
+            USDC.address,
+            "0x" + (1n * 10n ** 6n).toString(16),
+            "0x0",
+          ],
+          data: ["0x0", "0x0", orderIdHex, "0x" + 150000n.toString(16)],
+        },
+      ],
+    });
+
+    const result = await paycrest.offramp(wallet, {
+      from: { token: USDC, amount: Amount.parse("1", USDC) },
+      to: {
+        currency: "NGN",
+        recipient: {
+          institution: "GTBINGLA",
+          accountIdentifier: "1",
+          accountName: "x",
+        },
+      },
+    });
+    const status = await result.wait({ pollIntervalMs: 1 });
+    expect(status.path).toBe("gateway");
+    expect(status.status).toBe("validated");
+    // Confirms the lookup hit the gateway-id endpoint, not /v2/sender/orders.
+    const lookupCalls = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes("/v2/orders/23448594291968334/")
+    );
+    expect(lookupCalls.length).toBeGreaterThan(0);
+    const senderCalls = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes("/v2/sender/orders/")
+    );
+    expect(senderCalls.length).toBe(0);
+  });
+
+  it("throws when gateway off-ramp tx reverted (no on-chain order id)", async () => {
+    const { publicKey } = buildKeyPair();
+    const fetchMock = vi.fn().mockImplementation(async (url: string | URL) => {
+      const u = String(url);
+      if (u.endsWith("/v2/pubkey"))
+        return jsonResponse(200, envelope(publicKey));
+      if (u.includes("/v2/rates/"))
+        return jsonResponse(
+          200,
+          envelope({
+            sell: {
+              rate: "1500",
+              providerIds: [],
+              orderType: "regular",
+              refundTimeoutMinutes: 60,
+            },
+          })
+        );
+      throw new Error(`unexpected: ${u}`);
+    });
+    const paycrest = new Paycrest({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const { wallet, waitMock } = makeFakeWallet();
+    waitMock.mockRejectedValueOnce(new Error("reverted"));
+    const result = await paycrest.offramp(wallet, {
+      from: { token: USDC, amount: Amount.parse("1", USDC) },
+      to: {
+        currency: "NGN",
+        recipient: {
+          institution: "GTBINGLA",
+          accountIdentifier: "1",
+          accountName: "x",
+        },
+      },
+    });
+    await expect(result.wait({ pollIntervalMs: 1 })).rejects.toThrow(
+      /no on-chain order id/i
+    );
+  });
+});
+
+describe("Paycrest webhook signature", () => {
+  it("verifies a valid HMAC-SHA256 signature", async () => {
+    const secret = "shh";
+    const body = JSON.stringify({ event: "payment_order.settled" });
+    const sig = nodeCrypto
+      .createHmac("sha256", secret)
+      .update(body, "utf8")
+      .digest("hex");
+    expect(await Paycrest.verifyWebhookSignature(body, sig, secret)).toBe(true);
+  });
+
+  it("rejects a tampered signature", async () => {
+    const secret = "shh";
+    const body = JSON.stringify({ event: "payment_order.settled" });
+    const sig = nodeCrypto
+      .createHmac("sha256", secret)
+      .update(body, "utf8")
+      .digest("hex");
+    const tampered = sig.replace(/^./, sig[0] === "a" ? "b" : "a");
+    expect(await Paycrest.verifyWebhookSignature(body, tampered, secret)).toBe(
+      false
+    );
+  });
+
+  it("rejects empty signature or secret", async () => {
+    expect(await Paycrest.verifyWebhookSignature("body", "", "k")).toBe(false);
+    expect(await Paycrest.verifyWebhookSignature("body", "sig", "")).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `Paycrest` module that ships fiat on/off-ramps as a first-class StarkZap primitive, closing the most-cited gap for any consumer app shipping on Starknet. The Cairo Gateway is already deployed at `0x06ff3a3b…0c583`, the Paycrest backend already routes Starknet orders, and two tokens are live (USDC, USDT) — this PR exposes that capability through the SDK.

- **Two transport paths, one TS surface.** `path: "gateway"` (default) emits an approve + on-chain `create_order` Call pair on the Cairo Gateway. `path: "api"` POSTs to Paycrest's Sender API and the SDK transfers tokens to the assigned receive address. On-ramp is Sender-API-only (Paycrest doesn't accept on-ramp via the Gateway).
- **Mainnet-only.** Paycrest has no testnet backend — the module hard-errors with a clear message on Sepolia.
- **Zero new runtime deps.** RSA-OAEP-SHA256 recipient encryption auto-detects the runtime: `crypto.subtle` in browsers/RN, `node:crypto.publicEncrypt` in Node.

## What ships

| Concern | File | Notes |
| --- | --- | --- |
| Main class | `src/paycrest/paycrest.ts` | `Paycrest` — `offramp`, `onramp`, `populateOfframp`, `waitForOrder`, `waitForGatewayOrder`, static `verifyWebhookSignature`, plus read helpers (currencies/institutions/tokens/rates/orders) |
| Cairo wrapper | `src/paycrest/gateway.ts` | `PaycrestGateway` + `OrderCreated` event parser |
| Sender API | `src/paycrest/api.ts` | HTTP client mirrors `src/signer/privy.ts` pattern (URL validation, AbortController timeout, JSON-error extraction) |
| Encryption | `src/paycrest/encryption.ts` | Dual-runtime RSA-OAEP-SHA256, base64 output |
| Presets | `src/paycrest/presets.ts` | Mainnet Gateway address, `STARKNET_MAINNET_CHAIN_ID = 23448594291968334n` (the aggregator's fictional int64 for Starknet — the felt `SN_MAIN` overflows int64) |
| ABI | `src/abi/paycrest.ts` | Extracted from the deployed contract via Alchemy public RPC |
| Wallet integration | `src/wallet/{base,index,cartridge,interface}.ts` | `wallet.paycrest(options?)` cached method, `SDKConfig.paycrest` threading |
| TxBuilder | `src/tx/builder.ts` | `.paycrestOfframp(input)` chainable for batching with other ops (gateway path only) |
| Tests | `tests/paycrest{,-encryption}.test.ts` | 31 unit tests covering rate scaling, presets, encryption round-trip, both off-ramp paths, on-ramp, webhook HMAC, and `waitForOrder` / `waitForGatewayOrder` / `result.wait()` dispatch including timeout, abort, and refund/expiry terminals |
| Examples | `examples/paycrest/` | Three Node scripts: `offramp-gateway.ts`, `offramp-api.ts`, `onramp.ts` |
| Docs | `mintlify-docs/build/consumer-app-sdk/paycrest-fiat-ramp.mdx` + `docs.json` nav | Full module guide |

## Recommended caller pattern

```ts
import { Amount, Paycrest, StarkZap, mainnetTokens } from "starkzap";

const sdk = new StarkZap({
  network: "mainnet",
  paycrest: { apiKey: process.env.PAYCREST_API_KEY },
});
const wallet = await sdk.connectWallet({ /* signer */ });

// 100 USDC -> NGN, fully on-chain via the Cairo Gateway
const off = await wallet.paycrest().offramp(wallet, {
  from: { token: mainnetTokens.USDC, amount: Amount.parse("100", mainnetTokens.USDC) },
  to: { currency: "NGN", recipient: { institution, accountIdentifier, accountName } },
});

// One-line wait — dispatches to the right endpoint based on path:
//   gateway -> /v2/orders/{chain_id}/{gateway_id}
//   api     -> /v2/sender/orders/{uuid}
const status = await off.wait();  // resolves on validated/settled, throws PaycrestOrderError on refunded/expired
```

## Design decisions worth flagging

1. **Two lookup endpoints, one `wait()`.** The aggregator's `/v2/sender/orders/{id}` only accepts the DB UUID or `reference` — never `gateway_id`. Gateway-path orders get their on-chain felt252 id from the `OrderCreated` event, so the SDK uses `/v2/orders/{chain_id}/{gateway_id}` (the `GetProviderOrderStatus` endpoint) for that path and unifies the return shape via `PaycrestOfframpStatus`.
2. **Rate scaling.** `/v2/rates` returns a decimal string; the on-chain `u128 rate` field uses ×100 (e.g. `1361.92` ↔ `136192`). Locked in by a unit test against the EVM convention.
3. **`OfframpResult.orderId` is a `Promise<string \| null>`.** The gateway path resolves it after `tx.wait()` + parsing the `OrderCreated` event; the api path resolves it immediately from the POST response. Keeps the surface uniform.
4. **No package.json subpath additions.** `Paycrest` is exported from the SDK root, matching how every other module (Troves, Staking, Lending) is exposed.

## Out of scope (tracked separately)

- **Aggregator follow-up:** add a `reference` field to `PaymentOrderRecipient` so the SDK can inject one through the encrypted `message_hash`, then on-chain orders could be looked up via `/v2/sender/orders/{reference}` like API-path orders. Would let us drop the dual-endpoint complexity in a future SDK version.
- **Pluggable ramp interface.** The proposal mentions this as Phase 3 / "optional"; v1 ships as a single `Paycrest` class. Future ramp providers will be a separate refactor.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run prettier:check`
- [x] `npm test` — 710 unit tests pass (4 pre-existing live-network tests skipped); 31 of those are new for Paycrest
- [ ] **Manual mainnet smoke (gateway off-ramp):** run `examples/paycrest/offramp-gateway.ts` with a small real amount (~\$0.50 USDC) and a test bank account, confirm `off.wait()` reaches `validated` / `settled`
- [ ] **Manual mainnet smoke (Sender API off-ramp):** same with `path: "api"` via `examples/paycrest/offramp-api.ts`
- [ ] **Manual mainnet smoke (on-ramp):** confirm `paycrest.onramp({...})` returns a real `providerAccount` with bank details