### PR TITLE
Reject overprecise Amount scalars

### DIFF
--- a/src/types/amount.ts
+++ b/src/types/amount.ts
@@ -74,17 +74,20 @@ function expandScientificNotation(value: string): string {
   return `${integerPart.slice(0, splitIndex)}.${integerPart.slice(splitIndex)}${fractionPart}`;
 }
 
-function normalizeUnitNumberish(amount: BigNumberish): string {
+function normalizeUnitNumberish(
+  amount: BigNumberish,
+  label = "unit amount"
+): string {
   if (typeof amount === "number") {
     if (!Number.isFinite(amount) || amount < 0) {
       throw new Error(
-        `Invalid unit amount: "${amount}". Must be a positive number.`
+        `Invalid ${label}: "${amount}". Must be a positive number.`
       );
     }
 
     if (Number.isInteger(amount) && !Number.isSafeInteger(amount)) {
       throw new Error(
-        "Amount.parse(number) only accepts safe integers. Pass a string or bigint for exact large values."
+        `Invalid ${label}: "${amount}". Number values must be safe integers; pass a string or bigint for exact large values.`
       );
     }
 
@@ -94,7 +97,7 @@ function normalizeUnitNumberish(amount: BigNumberish): string {
       );
       if (significantDigits > MAX_SIGNIFICANT_NUMBER_DIGITS) {
         throw new Error(
-          "Amount.parse(number) cannot safely represent this decimal. Pass a string for exact values."
+          `Invalid ${label}: "${amount}". A number cannot safely represent this decimal; pass a string for exact values.`
         );
       }
     }
@@ -125,19 +128,17 @@ function normalizeRawNumberish(amount: BigNumberish): string {
   return expandScientificNotation(amount.toString());
 }
 
-function isZeroString(value: string): boolean {
-  return /^0+(\.0+)?$/.test(value);
-}
-
 function parseScalarToScaledBigInt(
   value: BigNumberish,
   label: string,
   precision: number
 ): bigint {
-  const valueStr = normalizeUnitNumberish(value);
+  const valueStr = normalizeUnitNumberish(value, label);
 
   if (!valueStr.match(/^\d+(\.\d+)?$/)) {
-    throw new Error(`Invalid ${label}: "${valueStr}". Must be a positive number.`);
+    throw new Error(
+      `Invalid ${label}: "${valueStr}". Must be a positive number.`
+    );
   }
 
   const [integer, fraction = ""] = valueStr.split(".");
@@ -635,19 +636,15 @@ export class Amount {
     // Use high precision for scalar operations
     const PRECISION = 18;
     const scaleFactor = 10n ** BigInt(PRECISION);
-    const divisorStr = normalizeUnitNumberish(divisor);
     const scaledDivisor = parseScalarToScaledBigInt(
       divisor,
       "divisor",
       PRECISION
     );
 
+    // Over-precise divisors are already rejected by parseScalarToScaledBigInt,
+    // so a zero scaled divisor can only come from an actual zero input.
     if (scaledDivisor === 0n) {
-      if (!isZeroString(divisorStr)) {
-        throw new Error(
-          `Divisor "${divisorStr}" is too small: precision is limited to ${PRECISION} decimal places.`
-        );
-      }
       throw new Error("Division by zero");
     }
 

--- a/src/types/amount.ts
+++ b/src/types/amount.ts
@@ -129,6 +129,27 @@ function isZeroString(value: string): boolean {
   return /^0+(\.0+)?$/.test(value);
 }
 
+function parseScalarToScaledBigInt(
+  value: BigNumberish,
+  label: string,
+  precision: number
+): bigint {
+  const valueStr = normalizeUnitNumberish(value);
+
+  if (!valueStr.match(/^\d+(\.\d+)?$/)) {
+    throw new Error(`Invalid ${label}: "${valueStr}". Must be a positive number.`);
+  }
+
+  const [integer, fraction = ""] = valueStr.split(".");
+  if (fraction.length > precision) {
+    throw new Error(
+      `${label} "${valueStr}" exceeds ${precision} decimal places.`
+    );
+  }
+
+  return BigInt(`${integer}${fraction.padEnd(precision, "0")}`);
+}
+
 function formatIntegerPart(integerPart: string): string {
   try {
     return BigInt(integerPart).toLocaleString("default");
@@ -573,22 +594,14 @@ export class Amount {
    * ```
    */
   public multiply(multiplier: BigNumberish): Amount {
-    const multiplierStr = multiplier.toString();
-
-    if (!multiplierStr.match(/^\d+(\.\d+)?$/)) {
-      throw new Error(
-        `Invalid multiplier: "${multiplierStr}". Must be a positive number.`
-      );
-    }
-
     // Use high precision for scalar operations
     const PRECISION = 18;
     const scaleFactor = 10n ** BigInt(PRECISION);
-
-    // Convert multiplier to scaled bigint
-    const [integer, fraction = ""] = multiplierStr.split(".");
-    const paddedFraction = fraction.padEnd(PRECISION, "0").slice(0, PRECISION);
-    const scaledMultiplier = BigInt(`${integer}${paddedFraction}`);
+    const scaledMultiplier = parseScalarToScaledBigInt(
+      multiplier,
+      "multiplier",
+      PRECISION
+    );
 
     // Multiply and scale back down
     const result = (this.baseValue * scaledMultiplier) / scaleFactor;
@@ -619,22 +632,15 @@ export class Amount {
    * ```
    */
   public divide(divisor: BigNumberish): Amount {
-    const divisorStr = divisor.toString();
-
-    if (!divisorStr.match(/^\d+(\.\d+)?$/)) {
-      throw new Error(
-        `Invalid divisor: "${divisorStr}". Must be a positive number.`
-      );
-    }
-
     // Use high precision for scalar operations
     const PRECISION = 18;
     const scaleFactor = 10n ** BigInt(PRECISION);
-
-    // Convert divisor to scaled bigint
-    const [integer, fraction = ""] = divisorStr.split(".");
-    const paddedFraction = fraction.padEnd(PRECISION, "0").slice(0, PRECISION);
-    const scaledDivisor = BigInt(`${integer}${paddedFraction}`);
+    const divisorStr = normalizeUnitNumberish(divisor);
+    const scaledDivisor = parseScalarToScaledBigInt(
+      divisor,
+      "divisor",
+      PRECISION
+    );
 
     if (scaledDivisor === 0n) {
       if (!isZeroString(divisorStr)) {

--- a/tests/amount.test.ts
+++ b/tests/amount.test.ts
@@ -809,6 +809,23 @@ describe("Amount arithmetic operations", () => {
       const amount = Amount.parse("10", 18, "ETH");
       expect(amount.multiply("1e-1").toUnit()).toBe("1");
     });
+
+    it("should floor low-decimal tokens when result is sub-unit", () => {
+      // For USDC (6 decimals), 1 USDC × 1e-18 = 0.000000000000001 base units
+      // Since we can't represent fractional base units, this floors to 0
+      const usdc = Amount.parse("1", 6, "USDC");
+      const result = usdc.multiply("0.000000000000000001");
+      expect(result.toBase()).toBe(0n);
+      expect(result.toUnit()).toBe("0");
+    });
+
+    it("should preserve sub-unit fractional multiplication for 18-decimal tokens", () => {
+      // For ETH (18 decimals), the same scalar preserves the fraction
+      const eth = Amount.parse("1", 18, "ETH");
+      const result = eth.multiply("0.000000000000000001");
+      expect(result.toBase()).toBe(1n);
+      expect(result.toUnit()).toBe("0.000000000000000001");
+    });
   });
 
   describe("divide", () => {
@@ -898,6 +915,24 @@ describe("Amount arithmetic operations", () => {
     it("should support scientific notation divisors", () => {
       const amount = Amount.parse("10", 18, "ETH");
       expect(amount.divide("1e1").toUnit()).toBe("1");
+    });
+
+    it("should floor low-decimal tokens when result is sub-unit", () => {
+      // For USDC (6 decimals), dividing by a small number can produce sub-unit fractions.
+      // 1 USDC ÷ 1e18 = 1e-12 base units (fractional), floors to 0.
+      const usdc = Amount.parse("1", 6, "USDC");
+      const result = usdc.divide("1000000000000000000");
+      expect(result.toBase()).toBe(0n);
+      expect(result.toUnit()).toBe("0");
+    });
+
+    it("should preserve sub-unit fractional division for 18-decimal tokens", () => {
+      // For ETH (18 decimals), the same divisor preserves the fraction.
+      // 1 ETH ÷ 1e18 = 1e-18 ETH (one wei).
+      const eth = Amount.parse("1", 18, "ETH");
+      const result = eth.divide("1000000000000000000");
+      expect(result.toBase()).toBe(1n);
+      expect(result.toUnit()).toBe("0.000000000000000001");
     });
   });
 

--- a/tests/amount.test.ts
+++ b/tests/amount.test.ts
@@ -789,6 +789,18 @@ describe("Amount arithmetic operations", () => {
       const amount = Amount.parse("10", 18, "ETH");
       expect(amount.multiply(3n).toUnit()).toBe("30");
     });
+
+    it("should reject multipliers above scalar precision", () => {
+      const amount = Amount.parse("1", 18, "ETH");
+      expect(() => amount.multiply("1.0000000000000000001")).toThrow(
+        "exceeds 18 decimal places"
+      );
+    });
+
+    it("should support scientific notation multipliers", () => {
+      const amount = Amount.parse("10", 18, "ETH");
+      expect(amount.multiply("1e-1").toUnit()).toBe("1");
+    });
   });
 
   describe("divide", () => {
@@ -855,6 +867,18 @@ describe("Amount arithmetic operations", () => {
       const result = amount.divide(3);
       // The result should be close to 3.333...
       expect(result.toUnit()).toBe("3.333333333333333333");
+    });
+
+    it("should reject divisors above scalar precision", () => {
+      const amount = Amount.parse("1", 18, "ETH");
+      expect(() => amount.divide("1.0000000000000000001")).toThrow(
+        "exceeds 18 decimal places"
+      );
+    });
+
+    it("should support scientific notation divisors", () => {
+      const amount = Amount.parse("10", 18, "ETH");
+      expect(amount.divide("1e1").toUnit()).toBe("1");
     });
   });
 

--- a/tests/amount.test.ts
+++ b/tests/amount.test.ts
@@ -797,6 +797,14 @@ describe("Amount arithmetic operations", () => {
       );
     });
 
+    it("should honor a multiplier at the 18-decimal precision boundary", () => {
+      // 1 ETH × 1e-18 must keep the 18th fraction digit (no silent truncation)
+      const amount = Amount.parse("1", 18, "ETH");
+      const result = amount.multiply("0.000000000000000001");
+      expect(result.toBase()).toBe(1n);
+      expect(result.toUnit()).toBe("0.000000000000000001");
+    });
+
     it("should support scientific notation multipliers", () => {
       const amount = Amount.parse("10", 18, "ETH");
       expect(amount.multiply("1e-1").toUnit()).toBe("1");
@@ -836,7 +844,9 @@ describe("Amount arithmetic operations", () => {
 
     it("should throw a precision error on tiny non-zero divisors", () => {
       const amount = Amount.parse("10", 18, "ETH");
-      expect(() => amount.divide("0.0000000000000000001")).toThrow("too small");
+      expect(() => amount.divide("0.0000000000000000001")).toThrow(
+        "exceeds 18 decimal places"
+      );
     });
 
     it("should preserve decimals and symbol", () => {
@@ -873,6 +883,15 @@ describe("Amount arithmetic operations", () => {
       const amount = Amount.parse("1", 18, "ETH");
       expect(() => amount.divide("1.0000000000000000001")).toThrow(
         "exceeds 18 decimal places"
+      );
+    });
+
+    it("should honor a divisor at the 18-decimal precision boundary", () => {
+      // dividing by 1e-18 (smallest representable divisor) must use the full
+      // 18-digit fraction, not a truncated one: 1 / 1e-18 = 1e18
+      const amount = Amount.parse("1", 18, "ETH");
+      expect(amount.divide("0.000000000000000001").toUnit()).toBe(
+        "1000000000000000000"
       );
     });
 


### PR DESCRIPTION
Amount multiply and divide silently truncated scalar fractions beyond 18 decimals, which can turn a precise input into a different value.

This rejects scalars above the supported precision and keeps scientific notation normalization consistent with Amount parsing.