### PR TITLE
Update starknet js + other

### DIFF
--- a/.claude/skills/starknet-upgrade.md
+++ b/.claude/skills/starknet-upgrade.md
@@ -1,0 +1,95 @@
+---
+name: Starknet Upgrade
+triggers:
+  - upgrade starknet
+  - bump starknet
+  - starknet-types
+  - starknet-io
+  - PAYMASTER_API
+  - L1Message
+  - phantom dependency
+---
+
+# Starknet Upgrade
+
+<purpose>
+Keep the `@starknet-io/starknet-types-*` spec package in sync when bumping `starknet`.
+The SDK imports RPC spec types directly from that package, so a starknet bump that
+changes its aliased spec version silently strands our pin and duplicates the types.
+</purpose>
+
+<context>
+`starknet` re-exports spec types only as value bindings:
+
+```ts
+declare const index$4_PAYMASTER_API: typeof PAYMASTER_API;
+declare const index$4_RPCSPEC0103: typeof RPCSPEC0103;
+```
+
+`typeof` consts are unusable in type position, so `RPC.PAYMASTER_API.X` and
+`RPC.RPCSPEC0103.X` do not compile. The only reachable namespace is `RPC.RPCSPEC09`,
+which aliases `types-js@~0.9.2` — do not reach for it to dodge the dependency; it
+pins spec-0.9 types into a v10 SDK. Import from the aliased spec package instead.
+
+Current importers:
+
+| File | Type |
+| --- | --- |
+| `src/wallet/utils.ts` | `PAYMASTER_API` |
+| `src/wallet/accounts/provider.ts` | `PAYMASTER_API` |
+| `src/bridge/ethereum/canonical/CanonicalEthereumBridge.ts` | `L1Message` |
+| `src/bridge/ethereum/lords/LordsBridge.ts` | `L1Message` |
+
+History: starknet v9 resolved these via `-010`; v10.5 uses `-0103`. The alias name
+tracks the RPC spec version, so it changes on spec bumps, not on every release.
+</context>
+
+<procedure>
+1. Bump `starknet` in `package.json`.
+2. Read the alias starknet now uses for its spec types:
+   `node -e 'const fs=require("fs");const p=JSON.parse(fs.readFileSync("node_modules/starknet/package.json","utf8"));console.log(p.dependencies)' | grep starknet-types`
+3. If the alias name changed (e.g. `-0103` → `-0104`):
+   - Update our `dependencies` entry in `package.json` to the same alias and the
+     same exact version starknet pins.
+   - Update the import specifier in every importer listed above.
+4. `npm install` and confirm a single resolved copy (see `<verification>`).
+5. Run `npm run typecheck && npm run build && npm test`.
+</procedure>
+
+<patterns>
+<do>
+- Declare it in `dependencies`. The import survives into `dist/**/*.d.ts` and
+  `files: ["dist"]` publishes those, so consumers need it installed to typecheck.
+- Pin the exact version starknet pins, no caret. Same alias name + same exact
+  version is what collapses ours and starknet's into one `node_modules` entry.
+- Re-check the alias on every starknet bump, even a patch.
+</do>
+<dont>
+- Do not use `devDependencies` — consumers would hit the phantom-dependency
+  typecheck break that this declaration exists to fix.
+- Do not use `peerDependencies` — wrong ergonomics for a types-only artifact.
+- Do not use a caret range. `^0.10.3` lets a consumer resolve 0.10.4 while
+  starknet stays on 0.10.3, yielding two copies of the declarations and confusing
+  cross-package assignability errors.
+- Do not substitute `RPC.RPCSPEC09.*` to avoid the dependency (see `<context>`).
+</dont>
+</patterns>
+
+<verification>
+```bash
+# exactly one resolved copy, and both declarers agree
+node -e 'const l=require("./package-lock.json");Object.entries(l.packages).forEach(([k,v])=>{const d=v.dependencies&&v.dependencies["@starknet-io/starknet-types-0103"];if(d)console.log((k||"<root>"),"=>",d)})'
+```
+
+Expected: `<root>` and `node_modules/starknet` print the same `npm:` specifier.
+Divergence means a duplicate copy is about to appear.
+</verification>
+
+<troubleshooting>
+- `has no exported member 'PAYMASTER_API'` on `RPC`: expected — import from the
+  aliased spec package, not from `starknet`.
+- Consumer typecheck fails on a missing `@starknet-io/*` module: the package
+  slipped out of `dependencies`, or the alias name drifted from the import specifier.
+- Two `types-js` versions under `@starknet-io/`: our pin no longer matches
+  starknet's. Realign to starknet's exact version.
+</troubleshooting>

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,7 @@ coverage/
 *.pem
 wallets.json
 tasks/
-.claude/
+
+# Claude Code: shared skills/settings are versioned, per-machine settings are not
+**/.claude/settings.local.json
+examples/mobile/.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,4 +143,5 @@ DO NOT modify manually:
 - `skills/integration-testing.md`
 - `skills/presets-regeneration.md`
 - `skills/docs-export.md`
+- `skills/starknet-upgrade.md`
 </skills>

--- a/examples/mobile/package-lock.json
+++ b/examples/mobile/package-lock.json
@@ -12,6 +12,7 @@
         "@ethersproject/shims": "^5.8.0",
         "@expo/ui": "~57.0.2",
         "@expo/vector-icons": "^15.0.2",
+        "@fatsolutions/tongo-sdk": "^1.5.0",
         "@privy-io/expo": "^0.69.4",
         "@privy-io/expo-native-extensions": "^0.0.11",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -2002,6 +2003,109 @@
         "excpretty": "build/cli.js"
       }
     },
+    "node_modules/@fatsolutions/she": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@fatsolutions/she/-/she-0.4.0.tgz",
+      "integrity": "sha512-zPwERSMQ1w0QmoSyhSqCApAeyG8WLRkefsk/alHzx9OeZ503d8pGbNg7DDJBQ/UyfqCKevs6sjql6/k/cE/jaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.7.0",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.5",
+        "@scure/starknet": "1.1.0"
+      }
+    },
+    "node_modules/@fatsolutions/she/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fatsolutions/she/node_modules/@scure/base": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.5.tgz",
+      "integrity": "sha512-9rE6EOVeIQzt5TSu4v+K523F8u6DhBsoZWPGKlnCshhlDhy0kJzUX4V+tr2dWmzF1GdekvThABoEQBGBQI7xZw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fatsolutions/tongo-sdk": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@fatsolutions/tongo-sdk/-/tongo-sdk-1.5.0.tgz",
+      "integrity": "sha512-CCGU3XlgOVY7r2WI746dcA774YwNTEEJDw9qcZDE2xQBw4NZrqkOFlReFlyShQnb+iiZEMLzXthfsQgaDGbvmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fatsolutions/she": "0.4.0",
+        "@noble/ciphers": "1.3.0",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.5",
+        "@scure/starknet": "1.1.0",
+        "starknet": "9.4.2"
+      }
+    },
+    "node_modules/@fatsolutions/tongo-sdk/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fatsolutions/tongo-sdk/node_modules/@scure/base": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.5.tgz",
+      "integrity": "sha512-9rE6EOVeIQzt5TSu4v+K523F8u6DhBsoZWPGKlnCshhlDhy0kJzUX4V+tr2dWmzF1GdekvThABoEQBGBQI7xZw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fatsolutions/tongo-sdk/node_modules/starknet": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-9.4.2.tgz",
+      "integrity": "sha512-NFtg077DjddHUSh8sLZ5uB149LEF4NR90FuJ0oF7+zhce7l0oG9Ubqr3H4+jHm/ghHtV+yjlv1UhEoo4SBfILA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.7.0",
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1",
+        "@scure/starknet": "1.1.0",
+        "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
+        "@starknet-io/starknet-types-010": "npm:@starknet-io/types-js@0.10.0",
+        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.1",
+        "abi-wan-kanabi": "2.2.4",
+        "lossless-json": "^4.2.0",
+        "pako": "^2.0.4",
+        "ts-mixer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@fatsolutions/tongo-sdk/node_modules/starknet/node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -3777,6 +3881,13 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.3.tgz",
       "integrity": "sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/starknet-types-010": {
+      "name": "@starknet-io/types-js",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.0.tgz",
+      "integrity": "sha512-7ALSydz6pq3YIOpq5a7OkkxqwJciMc9Nlph0OGjhcC3xX0xH30XgizmziLyYVN10oO9+BJk8M9KbJjpzdbtRSw==",
       "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-0101": {
@@ -12951,6 +13062,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -15263,6 +15390,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",

--- a/examples/mobile/package-lock.json
+++ b/examples/mobile/package-lock.json
@@ -8,7 +8,7 @@
       "name": "starkzap",
       "version": "1.0.0",
       "dependencies": {
-        "@avnu/avnu-sdk": "^4.1.0-rc.0",
+        "@avnu/avnu-sdk": "4.2.0-next.2",
         "@ethersproject/shims": "^5.8.0",
         "@expo/ui": "~57.0.2",
         "@expo/vector-icons": "^15.0.2",
@@ -94,22 +94,22 @@
       "license": "MIT"
     },
     "node_modules/@avnu/avnu-sdk": {
-      "version": "4.1.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@avnu/avnu-sdk/-/avnu-sdk-4.1.0-rc.0.tgz",
-      "integrity": "sha512-f/y2898hzhjXpPk5e2mxcyHbbbBwqq9EdJLtjku04BlgkZwk9qfviMBgRPw2oKGTbGu9nd+WSKI+rNBfLUSVCg==",
+      "version": "4.2.0-next.2",
+      "resolved": "https://registry.npmjs.org/@avnu/avnu-sdk/-/avnu-sdk-4.2.0-next.2.tgz",
+      "integrity": "sha512-TBjJ1AL4PuYI/zf78I00eZkHZn2BBO+12VRvwzolmIZESFbVk2ijaJ5ZRncjLbQ55O/QyUEj9M7pkpaCgDRtrQ==",
       "license": "MIT",
       "dependencies": {
         "dayjs": "^1.11.19",
         "moment": "^2.30.1",
         "qs": "^6.14.1",
-        "zod": "^4.2.1"
+        "zod": "^4.3.6"
       },
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "ethers": "^6.15.0",
-        "starknet": "^8.9.1 || ^9.0.0"
+        "starknet": "^10.0.0"
       }
     },
     "node_modules/@avnu/avnu-sdk/node_modules/zod": {

--- a/examples/mobile/package-lock.json
+++ b/examples/mobile/package-lock.json
@@ -1226,9 +1226,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/examples/mobile/package-lock.json
+++ b/examples/mobile/package-lock.json
@@ -55,7 +55,7 @@
         "react-native-svg": "15.15.4",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.10.0",
-        "starknet": "^9.2.1",
+        "starknet": "^10.5.0",
         "starkzap-native": "file:../../packages/native",
         "zustand": "^5.0.14"
       },
@@ -3760,11 +3760,37 @@
         "ox": "^0.4.4"
       }
     },
-    "node_modules/@starknet-io/starknet-types-010": {
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6": {
+      "name": "@starknet-io/get-starknet-wallet-standard",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-6.0.2.tgz",
+      "integrity": "sha512-jCnLFNPw4IGgmkwDlHszKbnyEbQKu3pE7cZHyVMFwyvRG98IA9FZKykrTNH7Nq3BILf6EcOZ5SgYUQE/gtqraA==",
+      "license": "MIT",
+      "dependencies": {
+        "@starknet-io/types-js": "^0.10.3",
+        "@wallet-standard/base": "^1.1.1",
+        "@wallet-standard/features": "^1.1.1",
+        "ox": "^0.4.4"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6/node_modules/@starknet-io/types-js": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.3.tgz",
+      "integrity": "sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/starknet-types-0101": {
       "name": "@starknet-io/types-js",
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.0.tgz",
-      "integrity": "sha512-7ALSydz6pq3YIOpq5a7OkkxqwJciMc9Nlph0OGjhcC3xX0xH30XgizmziLyYVN10oO9+BJk8M9KbJjpzdbtRSw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.2.tgz",
+      "integrity": "sha512-AtUFPYdmo9DqVus++aBSoY9W13/2PZmillPr8/mXZjc+V0iYJ/QTmkTsbw+es2mnLeLhYWSymW9ivQzyyyKdog==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/starknet-types-0103": {
+      "name": "@starknet-io/types-js",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.3.tgz",
+      "integrity": "sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==",
       "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-09": {
@@ -12925,22 +12951,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pako": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
-      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -14811,9 +14821,9 @@
       "license": "MIT"
     },
     "node_modules/starknet": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/starknet/-/starknet-9.2.1.tgz",
-      "integrity": "sha512-bFJY2sMZ9tsLBhPCm719MWjoz+doabXIwPX/xtW56EHwAJMRAS6mICF6H2dCwOQHJmCMKpOSFBwW0SaiHzcioQ==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-10.5.0.tgz",
+      "integrity": "sha512-hHKW39sVFLCGPC8QKdQksbs8qo10Rjb6Zdpv3nKMYQUeXDtffvI1SOa62aX8+WcnpfG7Te4UBx5NTomz/X7ZpA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14822,12 +14832,12 @@
         "@scure/base": "~1.2.1",
         "@scure/starknet": "1.1.0",
         "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
-        "@starknet-io/starknet-types-010": "npm:@starknet-io/types-js@0.10.0",
-        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.1",
+        "@starknet-io/get-starknet-wallet-standard-v6": "npm:@starknet-io/get-starknet-wallet-standard@6.0.2",
+        "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
+        "@starknet-io/starknet-types-0103": "npm:@starknet-io/types-js@0.10.3",
+        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.2",
         "abi-wan-kanabi": "2.2.4",
-        "lossless-json": "^4.2.0",
-        "pako": "^2.0.4",
-        "ts-mixer": "^6.0.3"
+        "lossless-json": "^4.2.0"
       },
       "engines": {
         "node": ">=22"
@@ -15253,12 +15263,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/ts-mixer": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
-      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
-      "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",

--- a/examples/mobile/package.json
+++ b/examples/mobile/package.json
@@ -50,7 +50,7 @@
     "react-native-svg": "15.15.4",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.10.0",
-    "starknet": "^9.2.1",
+    "starknet": "^10.5.0",
     "starkzap-native": "file:../../packages/native",
     "zustand": "^5.0.14"
   },

--- a/examples/mobile/package.json
+++ b/examples/mobile/package.json
@@ -3,7 +3,7 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "dependencies": {
-    "@avnu/avnu-sdk": "^4.1.0-rc.0",
+    "@avnu/avnu-sdk": "4.2.0-next.2",
     "@ethersproject/shims": "^5.8.0",
     "@expo/ui": "~57.0.2",
     "@expo/vector-icons": "^15.0.2",

--- a/examples/mobile/package.json
+++ b/examples/mobile/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@avnu/avnu-sdk": "4.2.0-next.2",
     "@ethersproject/shims": "^5.8.0",
+    "@fatsolutions/tongo-sdk": "^1.5.0",
     "@expo/ui": "~57.0.2",
     "@expo/vector-icons": "^15.0.2",
     "@privy-io/expo": "^0.69.4",

--- a/examples/web/package-lock.json
+++ b/examples/web/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "@avnu/avnu-sdk": "4.2.0-next.2",
         "@cartridge/controller": "^0.13.13",
+        "@fatsolutions/tongo-sdk": "^1.5.0",
         "@hyperlane-xyz/registry": "^19.4.0",
         "@hyperlane-xyz/sdk": "^14.4.0",
         "@hyperlane-xyz/utils": "^14.4.0",
@@ -53,7 +54,7 @@
         "@avnu/avnu-sdk": "4.2.0-next.2",
         "@cartridge/controller": "^0.13.13",
         "@eslint/js": "^9.39.2",
-        "@fatsolutions/tongo-sdk": "^1.3.2",
+        "@fatsolutions/tongo-sdk": "^1.5.0",
         "@hyperlane-xyz/registry": "^19.4.0",
         "@hyperlane-xyz/sdk": "^14.4.0",
         "@hyperlane-xyz/utils": "^14.4.0",
@@ -80,7 +81,7 @@
       "peerDependencies": {
         "@avnu/avnu-sdk": "^4.2.0-next.2",
         "@cartridge/controller": "^0.13.13",
-        "@fatsolutions/tongo-sdk": "^1.3.2",
+        "@fatsolutions/tongo-sdk": "^1.5.0",
         "@hyperlane-xyz/registry": "^19.4.0",
         "@hyperlane-xyz/sdk": "^14.4.0",
         "@hyperlane-xyz/utils": "^14.4.0",
@@ -3706,6 +3707,139 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@fatsolutions/she": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@fatsolutions/she/-/she-0.4.0.tgz",
+      "integrity": "sha512-zPwERSMQ1w0QmoSyhSqCApAeyG8WLRkefsk/alHzx9OeZ503d8pGbNg7DDJBQ/UyfqCKevs6sjql6/k/cE/jaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.7.0",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.5",
+        "@scure/starknet": "1.1.0"
+      }
+    },
+    "node_modules/@fatsolutions/she/node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fatsolutions/she/node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fatsolutions/she/node_modules/@scure/base": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.5.tgz",
+      "integrity": "sha512-9rE6EOVeIQzt5TSu4v+K523F8u6DhBsoZWPGKlnCshhlDhy0kJzUX4V+tr2dWmzF1GdekvThABoEQBGBQI7xZw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fatsolutions/tongo-sdk": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@fatsolutions/tongo-sdk/-/tongo-sdk-1.5.0.tgz",
+      "integrity": "sha512-CCGU3XlgOVY7r2WI746dcA774YwNTEEJDw9qcZDE2xQBw4NZrqkOFlReFlyShQnb+iiZEMLzXthfsQgaDGbvmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fatsolutions/she": "0.4.0",
+        "@noble/ciphers": "1.3.0",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.5",
+        "@scure/starknet": "1.1.0",
+        "starknet": "9.4.2"
+      }
+    },
+    "node_modules/@fatsolutions/tongo-sdk/node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fatsolutions/tongo-sdk/node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fatsolutions/tongo-sdk/node_modules/@scure/base": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.5.tgz",
+      "integrity": "sha512-9rE6EOVeIQzt5TSu4v+K523F8u6DhBsoZWPGKlnCshhlDhy0kJzUX4V+tr2dWmzF1GdekvThABoEQBGBQI7xZw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fatsolutions/tongo-sdk/node_modules/starknet": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-9.4.2.tgz",
+      "integrity": "sha512-NFtg077DjddHUSh8sLZ5uB149LEF4NR90FuJ0oF7+zhce7l0oG9Ubqr3H4+jHm/ghHtV+yjlv1UhEoo4SBfILA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.7.0",
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1",
+        "@scure/starknet": "1.1.0",
+        "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
+        "@starknet-io/starknet-types-010": "npm:@starknet-io/types-js@0.10.0",
+        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.1",
+        "abi-wan-kanabi": "2.2.4",
+        "lossless-json": "^4.2.0",
+        "pako": "^2.0.4",
+        "ts-mixer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@fatsolutions/tongo-sdk/node_modules/starknet/node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -9680,6 +9814,13 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallets/-/get-starknet-wallets-5.0.0.tgz",
       "integrity": "sha512-fuywFgoal4Al2KdFQCNTYgioK0ubu3cP+mM6OxE8ti78Nmd9ySlh78LwdKNXIp2Alq4kaQ5XMf6HMgkStCWhkw==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/starknet-types-010": {
+      "name": "@starknet-io/types-js",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.0.tgz",
+      "integrity": "sha512-7ALSydz6pq3YIOpq5a7OkkxqwJciMc9Nlph0OGjhcC3xX0xH30XgizmziLyYVN10oO9+BJk8M9KbJjpzdbtRSw==",
       "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-0101": {

--- a/examples/web/package-lock.json
+++ b/examples/web/package-lock.json
@@ -18,6 +18,7 @@
         "@reown/appkit-adapter-solana": "1.8.19",
         "@solana/web3.js": "^1.98.4",
         "ethers": "^6.16.0",
+        "starknet": "^10.5.0",
         "starkzap": "file:../.."
       },
       "devDependencies": {
@@ -45,7 +46,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "starknet": "^9.2.1"
+        "starknet": "^10.5.0"
       },
       "devDependencies": {
         "@0no-co/graphql.web": "^1.2.0",
@@ -65,7 +66,7 @@
         "ethers": "^6.16.0",
         "husky": "^9.1.7",
         "prettier": "3.8.1",
-        "starknet-devnet": "^0.7.2",
+        "starknet-devnet": "^0.8.2",
         "tsc-alias": "^1.8.16",
         "tsx": "^4.21.0",
         "typedoc": "^0.28.16",
@@ -1409,6 +1410,66 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/@cartridge/controller-wasm/-/controller-wasm-0.9.4.tgz",
       "integrity": "sha512-hkvXPhAnjY57MhdJfUWK5htCFeOv06ChwYtrsx3AKJRnNW9HU25dfWHqWPdy875/2KmqIBDVTdoxddhoHgmrBw=="
+    },
+    "node_modules/@cartridge/controller/node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@cartridge/controller/node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@cartridge/controller/node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@cartridge/controller/node_modules/starknet": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-8.9.2.tgz",
+      "integrity": "sha512-+dp+o2w67fV6JyVOVkYeM1Ec71aORHc/JrF4VHLlfeGee0nLilooCQLE2u6hUcSGQG2x2/fvzkxYpIN+k1JBvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.7.0",
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1",
+        "@scure/starknet": "1.1.0",
+        "@starknet-io/starknet-types-08": "npm:@starknet-io/types-js@~0.8.4",
+        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.1",
+        "abi-wan-kanabi": "2.2.4",
+        "lossless-json": "^4.2.0",
+        "pako": "^2.0.4",
+        "ts-mixer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@cartridge/penpal": {
       "version": "6.2.4",
@@ -9171,6 +9232,75 @@
         "ox": "^0.4.4"
       }
     },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6": {
+      "name": "@starknet-io/get-starknet-wallet-standard",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-6.0.2.tgz",
+      "integrity": "sha512-jCnLFNPw4IGgmkwDlHszKbnyEbQKu3pE7cZHyVMFwyvRG98IA9FZKykrTNH7Nq3BILf6EcOZ5SgYUQE/gtqraA==",
+      "license": "MIT",
+      "dependencies": {
+        "@starknet-io/types-js": "^0.10.3",
+        "@wallet-standard/base": "^1.1.1",
+        "@wallet-standard/features": "^1.1.1",
+        "ox": "^0.4.4"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6/node_modules/@starknet-io/types-js": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.3.tgz",
+      "integrity": "sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6/node_modules/@wallet-standard/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6/node_modules/@wallet-standard/features": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.1.tgz",
+      "integrity": "sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6/node_modules/ox": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.4.4.tgz",
+      "integrity": "sha512-oJPEeCDs9iNiPs6J0rTx+Y0KGeCGyCAA3zo94yZhm8G5WpOxrwUtn2Ie/Y8IyARSqqY/j9JTKA3Fc1xs1DvFnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@starknet-io/get-starknet-wallet-standard/node_modules/@starknet-io/types-js": {
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
@@ -9205,6 +9335,20 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@starknet-io/starknet-types-0101": {
+      "name": "@starknet-io/types-js",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.2.tgz",
+      "integrity": "sha512-AtUFPYdmo9DqVus++aBSoY9W13/2PZmillPr8/mXZjc+V0iYJ/QTmkTsbw+es2mnLeLhYWSymW9ivQzyyyKdog==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/starknet-types-0103": {
+      "name": "@starknet-io/types-js",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.3.tgz",
+      "integrity": "sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==",
+      "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-07": {
       "name": "@starknet-io/types-js",
@@ -19775,9 +19919,9 @@
       }
     },
     "node_modules/starknet": {
-      "version": "8.9.2",
-      "resolved": "https://registry.npmjs.org/starknet/-/starknet-8.9.2.tgz",
-      "integrity": "sha512-+dp+o2w67fV6JyVOVkYeM1Ec71aORHc/JrF4VHLlfeGee0nLilooCQLE2u6hUcSGQG2x2/fvzkxYpIN+k1JBvA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-10.5.0.tgz",
+      "integrity": "sha512-hHKW39sVFLCGPC8QKdQksbs8qo10Rjb6Zdpv3nKMYQUeXDtffvI1SOa62aX8+WcnpfG7Te4UBx5NTomz/X7ZpA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19785,12 +19929,13 @@
         "@noble/hashes": "~1.6.0",
         "@scure/base": "~1.2.1",
         "@scure/starknet": "1.1.0",
-        "@starknet-io/starknet-types-08": "npm:@starknet-io/types-js@~0.8.4",
-        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.1",
+        "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
+        "@starknet-io/get-starknet-wallet-standard-v6": "npm:@starknet-io/get-starknet-wallet-standard@6.0.2",
+        "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
+        "@starknet-io/starknet-types-0103": "npm:@starknet-io/types-js@0.10.3",
+        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.2",
         "abi-wan-kanabi": "2.2.4",
-        "lossless-json": "^4.2.0",
-        "pako": "^2.0.4",
-        "ts-mixer": "^6.0.3"
+        "lossless-json": "^4.2.0"
       },
       "engines": {
         "node": ">=22"
@@ -19833,6 +19978,53 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/starknet/node_modules/@starknet-io/get-starknet-wallet-standard": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0.tgz",
+      "integrity": "sha512-isDNGDlp16W24HE4IuweYXLDRZN0JbsDnazAieeKXE87Mn+jqhsjgTsMxcwWTjX7v906Bjz39FiDjGUddnr36g==",
+      "license": "MIT",
+      "dependencies": {
+        "@starknet-io/types-js": "^0.7.10",
+        "@wallet-standard/base": "^1.1.0",
+        "@wallet-standard/features": "^1.1.0",
+        "ox": "^0.4.4"
+      }
+    },
+    "node_modules/starknet/node_modules/@starknet-io/types-js": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
+      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
+      "license": "MIT"
+    },
+    "node_modules/starknet/node_modules/ox": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.4.4.tgz",
+      "integrity": "sha512-oJPEeCDs9iNiPs6J0rTx+Y0KGeCGyCAA3zo94yZhm8G5WpOxrwUtn2Ie/Y8IyARSqqY/j9JTKA3Fc1xs1DvFnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/starkzap": {

--- a/examples/web/package-lock.json
+++ b/examples/web/package-lock.json
@@ -7,8 +7,8 @@
       "name": "starkzap-examples",
       "hasInstallScript": true,
       "dependencies": {
-        "@avnu/avnu-sdk": "^4.1.0-rc.0",
-        "@cartridge/controller": "^0.13.9",
+        "@avnu/avnu-sdk": "4.2.0-next.2",
+        "@cartridge/controller": "^0.13.13",
         "@hyperlane-xyz/registry": "^19.4.0",
         "@hyperlane-xyz/sdk": "^14.4.0",
         "@hyperlane-xyz/utils": "^14.4.0",
@@ -50,8 +50,8 @@
       },
       "devDependencies": {
         "@0no-co/graphql.web": "^1.2.0",
-        "@avnu/avnu-sdk": "^4.1.0-rc.0",
-        "@cartridge/controller": "^0.13.9",
+        "@avnu/avnu-sdk": "4.2.0-next.2",
+        "@cartridge/controller": "^0.13.13",
         "@eslint/js": "^9.39.2",
         "@fatsolutions/tongo-sdk": "^1.3.2",
         "@hyperlane-xyz/registry": "^19.4.0",
@@ -78,8 +78,8 @@
         "vitest": "^4.0.17"
       },
       "peerDependencies": {
-        "@avnu/avnu-sdk": "^4.1.0-rc.0",
-        "@cartridge/controller": "^0.13.9",
+        "@avnu/avnu-sdk": "^4.2.0-next.2",
+        "@cartridge/controller": "^0.13.13",
         "@fatsolutions/tongo-sdk": "^1.3.2",
         "@hyperlane-xyz/registry": "^19.4.0",
         "@hyperlane-xyz/sdk": "^14.4.0",
@@ -221,22 +221,22 @@
       }
     },
     "node_modules/@avnu/avnu-sdk": {
-      "version": "4.1.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@avnu/avnu-sdk/-/avnu-sdk-4.1.0-rc.0.tgz",
-      "integrity": "sha512-f/y2898hzhjXpPk5e2mxcyHbbbBwqq9EdJLtjku04BlgkZwk9qfviMBgRPw2oKGTbGu9nd+WSKI+rNBfLUSVCg==",
+      "version": "4.2.0-next.2",
+      "resolved": "https://registry.npmjs.org/@avnu/avnu-sdk/-/avnu-sdk-4.2.0-next.2.tgz",
+      "integrity": "sha512-TBjJ1AL4PuYI/zf78I00eZkHZn2BBO+12VRvwzolmIZESFbVk2ijaJ5ZRncjLbQ55O/QyUEj9M7pkpaCgDRtrQ==",
       "license": "MIT",
       "dependencies": {
         "dayjs": "^1.11.19",
         "moment": "^2.30.1",
         "qs": "^6.14.1",
-        "zod": "^4.2.1"
+        "zod": "^4.3.6"
       },
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "ethers": "^6.15.0",
-        "starknet": "^8.9.1 || ^9.0.0"
+        "starknet": "^10.0.0"
       }
     },
     "node_modules/@avnu/avnu-sdk/node_modules/dayjs": {
@@ -1386,16 +1386,16 @@
       }
     },
     "node_modules/@cartridge/controller": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/@cartridge/controller/-/controller-0.13.9.tgz",
-      "integrity": "sha512-LVjoBN8/Fa2Hv5bjOUBWcaJSxFthqr5JikUPZo3NERnLloUHOtGQs6HnIFOwP4N5i0A+GyTJVLa+fmk49ZJERg==",
+      "version": "0.13.13",
+      "resolved": "https://registry.npmjs.org/@cartridge/controller/-/controller-0.13.13.tgz",
+      "integrity": "sha512-/r8vgHzKPYkjb6Z4SAbTOM3S1MT/ZzflgZ/dfD2OqHBcQtqLz18YtMOoLcvhfljrxgr/MRkR8u3gRN4GKp72mg==",
       "dependencies": {
-        "@cartridge/controller-wasm": "0.9.4",
+        "@cartridge/controller-wasm": "0.10.1",
         "@cartridge/penpal": "^6.2.4",
-        "@starknet-io/get-starknet-wallet-standard": "5.0.0-beta.0",
+        "@starknet-io/get-starknet-core": "5.0.0",
         "@starknet-io/types-js": "0.9.1",
-        "@telegram-apps/sdk": "^2.4.0",
-        "@turnkey/sdk-browser": "^4.0.0",
+        "@turnkey/sdk-browser": "^5.15.2",
+        "@wallet-standard/wallet": "^1.1.0",
         "@walletconnect/ethereum-provider": "^2.20.0",
         "bs58": "^6.0.0",
         "cbor-x": "^1.5.0",
@@ -1404,12 +1404,24 @@
         "mipd": "^0.0.7",
         "open": "^10.1.0",
         "starknet": "^8.5.2"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@cartridge/controller-wasm": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@cartridge/controller-wasm/-/controller-wasm-0.9.4.tgz",
-      "integrity": "sha512-hkvXPhAnjY57MhdJfUWK5htCFeOv06ChwYtrsx3AKJRnNW9HU25dfWHqWPdy875/2KmqIBDVTdoxddhoHgmrBw=="
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@cartridge/controller-wasm/-/controller-wasm-0.10.1.tgz",
+      "integrity": "sha512-NweHJ98lFrV103sT+ud0WOUT+j92bBdaTdT+cFRwPA+XmRB39UekMu35iWlFcBhlnxQF+GdX4G/IrQtfoXf9+A=="
     },
     "node_modules/@cartridge/controller/node_modules/@noble/curves": {
       "version": "1.7.0",
@@ -4955,6 +4967,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/@module-federation/error-codes": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.12.0.tgz",
+      "integrity": "sha512-DEXQjopcBuGzp/NA9OVtASO0uZ6grVK5TIe0PjrbDRyZDxVaYQXKrISxBLOE+3nSIELE98tYpfxptm8WC9A8zA==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/runtime": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.12.0.tgz",
+      "integrity": "sha512-Cz9/7+gSvrdencwA8LXUMKnZdu0/flyN+yk6t3pkxfhvPJi3W65ZcalAKyOgyk2x8rEYrRSyEXu+/2DIFgrzmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.12.0",
+        "@module-federation/runtime-core": "0.12.0",
+        "@module-federation/sdk": "0.12.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.12.0.tgz",
+      "integrity": "sha512-373zBM54196KHURs/O8lry9trCAM3PPidvsF4YdrtahNc8YaQynml0mE3zdZeBnqP6H0/4OpPqMMjACI80Ht8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.12.0",
+        "@module-federation/sdk": "0.12.0"
+      }
+    },
+    "node_modules/@module-federation/sdk": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.12.0.tgz",
+      "integrity": "sha512-vh3GcG90fxjbkMghK7iSWcMayi/y8U5DxI6mhEFuz11St3y1UgQO2TZYephL8nISFBld7DdiqAkimx+6Hb3hjQ==",
+      "license": "MIT"
+    },
     "node_modules/@msgpack/msgpack": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
@@ -4965,10 +5010,13 @@
       }
     },
     "node_modules/@noble/ciphers": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.5.3.tgz",
-      "integrity": "sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -5599,6 +5647,232 @@
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.6.tgz",
       "integrity": "sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==",
       "license": "MIT"
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-rsa": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pfx": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-x509/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.12.3.tgz",
+      "integrity": "sha512-+Mzq+W7cNEKfkNZzyLl6A6ffqc3r21HGZUezgfKxpZrkORfOqgRXnS80Zu0IV6a9Ue9QBJeKD7kN0iWfc3bhRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.3.13",
+        "@peculiar/asn1-csr": "^2.3.13",
+        "@peculiar/asn1-ecc": "^2.3.14",
+        "@peculiar/asn1-pkcs9": "^2.3.13",
+        "@peculiar/asn1-rsa": "^2.3.13",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-x509": "^2.3.13",
+        "pvtsutils": "^1.3.5",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.7.0",
+        "tsyringe": "^4.8.0"
+      }
+    },
+    "node_modules/@peculiar/x509/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@phosphor-icons/webcomponents": {
       "version": "2.1.5",
@@ -9220,10 +9494,76 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@starknet-io/get-starknet-core": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-core/-/get-starknet-core-5.0.0.tgz",
+      "integrity": "sha512-FVKYeNGHWG978482ZdCf7VQMoMn0xxHS0mWYbNB6zwkpo2yForHJwN4/EIHQkd2xp2mfAD1VcIHSZ4SLWGV1zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@starknet-io/get-starknet-discovery": "^5.0.0",
+        "@starknet-io/get-starknet-virtual-wallet": "^5.0.0",
+        "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
+        "@starknet-io/get-starknet-wallets": "^5.0.0"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-discovery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-discovery/-/get-starknet-discovery-5.0.0.tgz",
+      "integrity": "sha512-b40ZfhbisiEonxWLe/naOraZvNc1hfhy4TEs0TP/cYppfECDhBKncvvFTGu++/rm+xV3SjmSzwNQGQmIn5DMLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@starknet-io/get-starknet-virtual-wallet": "^5.0.0",
+        "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
+        "@starknet-io/types-js": "^0.7.10",
+        "@wallet-standard/base": "^1.1.0"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-discovery/node_modules/@starknet-io/types-js": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
+      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/get-starknet-virtual-wallet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-virtual-wallet/-/get-starknet-virtual-wallet-5.0.0.tgz",
+      "integrity": "sha512-ne9Svr0tHj7a5OJOvC82ewth/GJTa78Gal/iiiRzQmvIDpZcu+nzrPAi350RKEtErxjG5rZSPv2DLz7VBClN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "^0.12.0",
+        "@starknet-io/get-starknet-wallet-standard": "5.0.0",
+        "@starknet-io/types-js": "^0.7.10",
+        "@wallet-standard/base": "^1.1.0",
+        "@wallet-standard/features": "^1.1.0",
+        "async-mutex": "^0.5.0",
+        "viem": "^2.27.2"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-virtual-wallet/node_modules/@starknet-io/types-js": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
+      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/get-starknet-virtual-wallet/node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-virtual-wallet/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@starknet-io/get-starknet-wallet-standard": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0-beta.0.tgz",
-      "integrity": "sha512-1QBmWnd76KzKwnVlRXLh58wtd1e0P5fyOhs0bCCjivTpGJ2nUPRvTgmzVJStNBcuQ7617UfB5qIyBnkig31TmQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0.tgz",
+      "integrity": "sha512-isDNGDlp16W24HE4IuweYXLDRZN0JbsDnazAieeKXE87Mn+jqhsjgTsMxcwWTjX7v906Bjz39FiDjGUddnr36g==",
       "license": "MIT",
       "dependencies": {
         "@starknet-io/types-js": "^0.7.10",
@@ -9335,6 +9675,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@starknet-io/get-starknet-wallets": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallets/-/get-starknet-wallets-5.0.0.tgz",
+      "integrity": "sha512-fuywFgoal4Al2KdFQCNTYgioK0ubu3cP+mM6OxE8ti78Nmd9ySlh78LwdKNXIp2Alq4kaQ5XMf6HMgkStCWhkw==",
+      "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-0101": {
       "name": "@starknet-io/types-js",
@@ -9464,68 +9810,6 @@
         "node": ">=14.16"
       }
     },
-    "node_modules/@telegram-apps/bridge": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/bridge/-/bridge-1.9.2.tgz",
-      "integrity": "sha512-SJLcNWLXhbbZr9MiqFH/g2ceuitSJKMxUIZysK4zUNyTUNuonrQG80Q/yrO+XiNbKUj8WdDNM86NBARhuyyinQ==",
-      "deprecated": "This package is not supported anymore. Use @tma.js/bridge instead",
-      "license": "MIT",
-      "dependencies": {
-        "@telegram-apps/signals": "^1.1.1",
-        "@telegram-apps/toolkit": "^1.1.1",
-        "@telegram-apps/transformers": "^1.2.2",
-        "@telegram-apps/types": "^1.2.1"
-      }
-    },
-    "node_modules/@telegram-apps/navigation": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/navigation/-/navigation-1.0.14.tgz",
-      "integrity": "sha512-bqNgF/J8Po7ZtsELm3E1a6aPr7awwxO3sIqD8J6u12urOlGoW5+1KxKKbkPa58mgXuQdsltd8apI+OVy0IYiUA==",
-      "license": "MIT"
-    },
-    "node_modules/@telegram-apps/sdk": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/sdk/-/sdk-2.11.3.tgz",
-      "integrity": "sha512-KdULzgRe1gcR8B3Z/t3hQrEaDmLGrfsL2IePtPP6ehtMn5tT0uPfnjtDLjDNQMyI7D4Tv2ZOzvDx45wOhhreXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@telegram-apps/bridge": "^1.9.2",
-        "@telegram-apps/navigation": "^1.0.13",
-        "@telegram-apps/signals": "^1.1.1",
-        "@telegram-apps/toolkit": "^1.1.1",
-        "@telegram-apps/transformers": "^1.2.2"
-      }
-    },
-    "node_modules/@telegram-apps/signals": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/signals/-/signals-1.1.2.tgz",
-      "integrity": "sha512-1P1kdCLX7MfETGPxH7f3UZKIsdE7Tz5S7QmN4Km1sbYQMakD5Bi1NecSMR7/wnHp50gWMI1JzENcMtCEmouhSg==",
-      "license": "MIT"
-    },
-    "node_modules/@telegram-apps/toolkit": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/toolkit/-/toolkit-1.1.1.tgz",
-      "integrity": "sha512-+vhKx6ngfvjyTE6Xagl3z1TPVbfx5s7xAkcYzCdHYUo6T60jLIqLgyZMcI1UPoIAMuMu1pHoO+p8QNCj/+tFmw==",
-      "license": "MIT"
-    },
-    "node_modules/@telegram-apps/transformers": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/transformers/-/transformers-1.2.2.tgz",
-      "integrity": "sha512-vvMwXckd1D7Ozc0h66PSUwF5QLrRV9HlGJFFeBuUex8QEk5mSPtsJkLiqB8aBbwuFDa91+TUSM/CxqPZO/e9YQ==",
-      "deprecated": "This package is not supported anymore. Use @tma.js/transfomers instead",
-      "license": "MIT",
-      "dependencies": {
-        "@telegram-apps/toolkit": "^1.1.1",
-        "@telegram-apps/types": "^1.2.1"
-      }
-    },
-    "node_modules/@telegram-apps/types": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/types/-/types-1.2.1.tgz",
-      "integrity": "sha512-so4HLh7clur0YyMthi9KVIgWoGpZdXlFOuQjk3+Q5NAvJZ11nAheBSwPlGw/Ko92+zwvrSBE/lQyN2+p17RP+w==",
-      "deprecated": "This package is not supported anymore. Use @tma.js/types instead",
-      "license": "MIT"
-    },
     "node_modules/@tsconfig/svelte": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
@@ -9534,13 +9818,14 @@
       "license": "MIT"
     },
     "node_modules/@turnkey/api-key-stamper": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@turnkey/api-key-stamper/-/api-key-stamper-0.4.5.tgz",
-      "integrity": "sha512-8UeYt/2WtMrK2uSFzjiRXdCVc9SmKlMVuA4f1Z+SlxcsW0wlEpNM/7bd8N4VVVAjoE8Yy50Vhk3ylfQFtlaKsQ==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@turnkey/api-key-stamper/-/api-key-stamper-0.6.5.tgz",
+      "integrity": "sha512-dSINHLIzYVw+ZNLwjM1wnEYFkYHPjQDSi43opCUhvow/ws6Fsn6gWkYpzbH+6Ej3rvSJTuaTwsld+dsTG/3HnA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.3.0",
-        "@turnkey/encoding": "0.4.0",
+        "@turnkey/crypto": "2.8.14",
+        "@turnkey/encoding": "0.6.0",
         "sha256-uint8array": "^0.10.7"
       },
       "engines": {
@@ -9548,133 +9833,144 @@
       }
     },
     "node_modules/@turnkey/crypto": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@turnkey/crypto/-/crypto-2.3.1.tgz",
-      "integrity": "sha512-fHKCw0inuThEKIpZnC8pvz16egZHf08wES0LdSkM9XrGDcI7p0eqF7nAHgfAMW/0qNVZD8AKW+g/5O97HBwZ4w==",
+      "version": "2.8.14",
+      "resolved": "https://registry.npmjs.org/@turnkey/crypto/-/crypto-2.8.14.tgz",
+      "integrity": "sha512-UZU+DEwhSUyyMHC9VZbp5av8NY/IJsfJ+g1E4dndQjMSAJd5NPKGS7sItlBy1ifN6wBb9JP5AcvmcfCdCfj9bw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/ciphers": "0.5.3",
-        "@noble/curves": "1.4.0",
-        "@noble/hashes": "1.4.0",
-        "@turnkey/encoding": "0.4.0",
-        "bs58": "^5.0.0",
-        "bs58check": "3.0.1"
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.0",
+        "@noble/hashes": "1.8.0",
+        "@peculiar/x509": "1.12.3",
+        "@turnkey/encoding": "0.6.0",
+        "@turnkey/sdk-types": "0.14.0",
+        "borsh": "2.0.0",
+        "cbor-js": "0.1.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@turnkey/crypto/node_modules/@noble/curves": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.0.tgz",
+      "integrity": "sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.8.0"
       },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@turnkey/crypto/node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@turnkey/crypto/node_modules/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
-      "license": "MIT"
-    },
-    "node_modules/@turnkey/crypto/node_modules/bs58": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^4.0.0"
-      }
+    "node_modules/@turnkey/crypto/node_modules/borsh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-2.0.0.tgz",
+      "integrity": "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@turnkey/encoding": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@turnkey/encoding/-/encoding-0.4.0.tgz",
-      "integrity": "sha512-ptLgcpWVt34KTPx0omF2QLJrosW6I//clCJ4G2+yngYFCzrdR0yBchV/BOcfME67mK1v3MmauyXl9AAnQTmB4Q==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@turnkey/encoding/-/encoding-0.6.0.tgz",
+      "integrity": "sha512-IC8qXvy36+iGAeiaVIuJvB35uU2Ld/RAWI/DRTKS+ttBej0GXhOn48Ouu5mlca4jt8ZEuwXmDVv74A8uBQclsA==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "bs58": "6.0.0",
+        "bs58check": "4.0.0"
+      },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@turnkey/http": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@turnkey/http/-/http-3.3.0.tgz",
-      "integrity": "sha512-m1fP8aqQcI0U4j7Gw89UbavavWP7AWGmEwoJl5nBhQz88mtep6AaZTsUoDDU4HXg0ch+aQ2/lfl0KFPp8s2u5Q==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@turnkey/http/-/http-3.18.1.tgz",
+      "integrity": "sha512-KXhDAtohx3PPRigdU0qjdgSTuomD0xl3mONly5hn8/jgrp0Gs7BKXv0OGiw/3Sj02IPmlza3SRWBKGtWyGwNmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@turnkey/api-key-stamper": "0.4.5",
-        "@turnkey/encoding": "0.4.0",
-        "@turnkey/webauthn-stamper": "0.5.0",
+        "@turnkey/api-key-stamper": "0.6.5",
+        "@turnkey/encoding": "0.6.0",
+        "@turnkey/webauthn-stamper": "0.6.0",
         "cross-fetch": "^3.1.5"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@turnkey/iframe-stamper": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@turnkey/iframe-stamper/-/iframe-stamper-2.5.0.tgz",
-      "integrity": "sha512-XjntbA5CNjxGRH+loceAlVLL9PG9Q4Y7p5zjBm4DeKclhD6lpUl9h8INArMEXIFbfLwLjjS6Q+SmQG4BHvNY6A==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@turnkey/iframe-stamper/-/iframe-stamper-2.11.0.tgz",
+      "integrity": "sha512-Iyf4W4S4Hx/RVsXl07PkRTh3g5Ca+vpN6SdUbRy8lt9IQZAJel/vxAk9XMyB7utX9TJx+icSjNYHvC0XGqJ47A==",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@turnkey/indexed-db-stamper": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@turnkey/indexed-db-stamper/-/indexed-db-stamper-1.2.6.tgz",
+      "integrity": "sha512-RSlCpH96e46PYgc029/TK3nE/HOW4QgKo9bXIYjoUR8J7+xkq+0Z0wjHrp27Yn3PbW8743hEppqK9jxsYc8ptA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@turnkey/api-key-stamper": "0.6.5",
+        "@turnkey/encoding": "0.6.0"
+      },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@turnkey/sdk-browser": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@turnkey/sdk-browser/-/sdk-browser-4.3.0.tgz",
-      "integrity": "sha512-TBAWpA28PnqFOeD45Ljzq5RfAabj4Qlnvo1toekt+yf6Hk13Nsm6R5FEiivHUMSNcvKBAwf5uQg+MPbBndymlQ==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/@turnkey/sdk-browser/-/sdk-browser-5.16.1.tgz",
+      "integrity": "sha512-AXBUJVW83nZKnSVNUH235dbsu4S+a4F0Swo25Fm/gHWKPVh4nvpT/Pr2cr6PVh3UR15p787AVUkxO9ZgtNclPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@turnkey/api-key-stamper": "0.4.5",
-        "@turnkey/crypto": "2.3.1",
-        "@turnkey/encoding": "0.4.0",
-        "@turnkey/http": "3.3.0",
-        "@turnkey/iframe-stamper": "2.5.0",
-        "@turnkey/wallet-stamper": "1.0.3",
-        "@turnkey/webauthn-stamper": "0.5.0",
-        "bs58check": "^3.0.1",
+        "@turnkey/api-key-stamper": "0.6.5",
+        "@turnkey/crypto": "2.8.14",
+        "@turnkey/encoding": "0.6.0",
+        "@turnkey/http": "3.18.1",
+        "@turnkey/iframe-stamper": "2.11.0",
+        "@turnkey/indexed-db-stamper": "1.2.6",
+        "@turnkey/sdk-types": "0.14.0",
+        "@turnkey/wallet-stamper": "1.1.16",
+        "@turnkey/webauthn-stamper": "0.6.0",
         "buffer": "^6.0.3",
         "cross-fetch": "^3.1.5",
-        "hpke-js": "^1.2.7"
+        "hpke-js": "^1.6.5"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@turnkey/sdk-types": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@turnkey/sdk-types/-/sdk-types-0.14.0.tgz",
+      "integrity": "sha512-FLN4p3Jc3rBMvM17tgFrO4VpqkQN0RgWtLknqcqpLuNgTJ7oqgvzm42YIrzvBlW6DPsnFjVZMzc4yCfaRN7Lmg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@turnkey/wallet-stamper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@turnkey/wallet-stamper/-/wallet-stamper-1.0.3.tgz",
-      "integrity": "sha512-8DMuVPo/u8oIzQ9Snsa24ZQO3nXVMfpd8VnlPLfZiW2jjZHPFyBGCJOYSArfp+W2xoudpYVu//JElBAVxk/u/g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@turnkey/wallet-stamper/-/wallet-stamper-1.1.16.tgz",
+      "integrity": "sha512-IdgoIRQr5RoiHAPnVag2QyaYg6cmmkZQs1rOig57/tQ/fXdPsC1+2660RisIAvv69ZFrArG8Z8wHaGSQMkStlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@turnkey/crypto": "2.3.1",
-        "@turnkey/encoding": "0.4.0"
+        "@turnkey/crypto": "2.8.14",
+        "@turnkey/encoding": "0.6.0"
       },
       "optionalDependencies": {
         "viem": "^2.21.35"
       }
     },
     "node_modules/@turnkey/webauthn-stamper": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@turnkey/webauthn-stamper/-/webauthn-stamper-0.5.0.tgz",
-      "integrity": "sha512-iUbTUwD4f4ibdLy5PWWb7ITEz4S4VAP9/mNjFhoRY3cKVVTDfmykrVTKjPOIHWzDgAmLtgrLvySIIC9ZBVENBw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@turnkey/webauthn-stamper/-/webauthn-stamper-0.6.0.tgz",
+      "integrity": "sha512-jdN17QEnn7RBykEOhtKIialWmDjnDAH8DzbyITwn8jsKcwT1TBNYge89hTUTjbdsDLBAqQw8cHujPdy0RaAqvw==",
       "license": "Apache-2.0",
       "dependencies": {
         "sha256-uint8array": "^0.10.7"
@@ -10064,18 +10360,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/@walletconnect/ethereum-provider/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit": {
@@ -10937,18 +11221,6 @@
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
     },
-    "node_modules/@walletconnect/universal-provider/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/core": {
       "version": "2.23.7",
       "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
@@ -11119,18 +11391,6 @@
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
-    },
-    "node_modules/@walletconnect/utils/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
     },
     "node_modules/@walletconnect/utils/node_modules/@walletconnect/types": {
       "version": "2.23.8",
@@ -11568,6 +11828,26 @@
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/asn1js/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/assert": {
       "version": "2.1.0",
@@ -12214,28 +12494,13 @@
       }
     },
     "node_modules/bs58check": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
-      "integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
-        "bs58": "^5.0.0"
-      }
-    },
-    "node_modules/bs58check/node_modules/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
-      "license": "MIT"
-    },
-    "node_modules/bs58check/node_modules/bs58": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^4.0.0"
+        "bs58": "^6.0.0"
       }
     },
     "node_modules/buffer": {
@@ -12542,6 +12807,12 @@
         "@cbor-extract/cbor-extract-linux-x64": "2.2.2",
         "@cbor-extract/cbor-extract-win32-x64": "2.2.2"
       }
+    },
+    "node_modules/cbor-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cbor-js/-/cbor-js-0.1.0.tgz",
+      "integrity": "sha512-7sQ/TvDZPl7csT1Sif9G0+MA0I0JOVah8+wWlJVQdVEgIbCzlN/ab3x+uvMNsc34TUvO6osQTAmB2ls80JX6tw==",
+      "license": "MIT"
     },
     "node_modules/cbor-x": {
       "version": "1.6.4",
@@ -18392,6 +18663,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvtsutils/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/qrcode": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
@@ -18757,6 +19052,12 @@
       "dependencies": {
         "esprima": "~4.0.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/request": {
       "version": "2.88.2",
@@ -19980,53 +20281,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/starknet/node_modules/@starknet-io/get-starknet-wallet-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0.tgz",
-      "integrity": "sha512-isDNGDlp16W24HE4IuweYXLDRZN0JbsDnazAieeKXE87Mn+jqhsjgTsMxcwWTjX7v906Bjz39FiDjGUddnr36g==",
-      "license": "MIT",
-      "dependencies": {
-        "@starknet-io/types-js": "^0.7.10",
-        "@wallet-standard/base": "^1.1.0",
-        "@wallet-standard/features": "^1.1.0",
-        "ox": "^0.4.4"
-      }
-    },
-    "node_modules/starknet/node_modules/@starknet-io/types-js": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
-      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
-      "license": "MIT"
-    },
-    "node_modules/starknet/node_modules/ox": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.4.4.tgz",
-      "integrity": "sha512-oJPEeCDs9iNiPs6J0rTx+Y0KGeCGyCAA3zo94yZhm8G5WpOxrwUtn2Ie/Y8IyARSqqY/j9JTKA3Fc1xs1DvFnw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.10.1",
-        "@noble/curves": "^1.6.0",
-        "@noble/hashes": "^1.5.0",
-        "@scure/bip32": "^1.5.0",
-        "@scure/bip39": "^1.4.0",
-        "abitype": "^1.0.6",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/starkzap": {
       "resolved": "../..",
       "link": true
@@ -20822,6 +21076,18 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/tty-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
@@ -21263,18 +21529,6 @@
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
-    },
-    "node_modules/viem/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
     },
     "node_modules/viem/node_modules/@noble/curves": {
       "version": "1.9.1",

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -22,6 +22,7 @@
     "@reown/appkit-adapter-ethers": "1.8.19",
     "@reown/appkit-adapter-solana": "1.8.19",
     "@solana/web3.js": "^1.98.4",
+    "@fatsolutions/tongo-sdk": "^1.5.0",
     "ethers": "^6.16.0",
     "starknet": "^10.5.0",
     "starkzap": "file:../.."

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -12,9 +12,9 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
-    "@avnu/avnu-sdk": "^4.1.0-rc.0",
+    "@avnu/avnu-sdk": "4.2.0-next.2",
     "@privy-io/js-sdk-core": "^0.68.0",
-    "@cartridge/controller": "^0.13.9",
+    "@cartridge/controller": "^0.13.13",
     "@hyperlane-xyz/registry": "^19.4.0",
     "@hyperlane-xyz/sdk": "^14.4.0",
     "@hyperlane-xyz/utils": "^14.4.0",

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -23,6 +23,7 @@
     "@reown/appkit-adapter-solana": "1.8.19",
     "@solana/web3.js": "^1.98.4",
     "ethers": "^6.16.0",
+    "starknet": "^10.5.0",
     "starkzap": "file:../.."
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11551,13 +11551,13 @@
       }
     },
     "node_modules/@react-navigation/core": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.21.5.tgz",
-      "integrity": "sha512-3hpV7uR41LBW+GHDoLhztZCb/i5ySRJISZ/rez4d7DCHSZo6ej4gNxYclaS6LRguoLiKG7SOCNa6O390AQklZQ==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.21.11.tgz",
+      "integrity": "sha512-bCW1PsLA/eOXDOukcJFEzlcL3Zpy8DJuDCfkDDwAQlAgoSZ/J9+ZeDRUMmCUi6xbnFgvFEEIMertaLeErOFP0Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@react-navigation/routers": "^7.6.0",
+        "@react-navigation/routers": "^7.6.4",
         "escape-string-regexp": "^4.0.0",
         "fast-deep-equal": "^3.1.3",
         "nanoid": "^3.3.11",
@@ -11615,9 +11615,9 @@
       }
     },
     "node_modules/@react-navigation/routers": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.6.0.tgz",
-      "integrity": "sha512-lblhDXfS75jLc7G2K7BZGM+7cjqQXk13X/MA4fq/12r62zM+fBhhreLzYflSitrDDXFRJpSvJXy0ziiGU04Xow==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.6.4.tgz",
+      "integrity": "sha512-GI7eJm8/KsZUQaYcXvEExikKurRZRgEsSzyZ7faENfi65yqJBCXjDMwyN1pF6pNW1MoLH1ErDwDivFxY6BzD3w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -31798,11 +31798,14 @@
       }
     },
     "node_modules/standard-navigation": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/standard-navigation/-/standard-navigation-0.0.7.tgz",
-      "integrity": "sha512-NCGLCNyuXrFOkGHxdNZFnpsehGtiq1oXbPhKl7ZuxFO5J//H2evqqOchmD4YwEUJnkjO4kH9Xp4hQX6hdAYCKQ==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/standard-navigation/-/standard-navigation-0.0.8.tgz",
+      "integrity": "sha512-TyVbo7INUDWtsUWDFn8RR7kwR87U0S4xHfLfbbnyeC581TmmyqQ+eM+nPw8rQTSD8QitRVcYfPaSHr/QJiUy1g==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/starknet": {
       "version": "10.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "starknet": "^9.2.1"
+        "starknet": "^10.5.0"
       },
       "devDependencies": {
         "@0no-co/graphql.web": "^1.2.0",
@@ -32,7 +32,7 @@
         "ethers": "^6.16.0",
         "husky": "^9.1.7",
         "prettier": "3.8.1",
-        "starknet-devnet": "^0.7.2",
+        "starknet-devnet": "^0.8.2",
         "tsc-alias": "^1.8.16",
         "tsx": "^4.21.0",
         "typedoc": "^0.28.16",
@@ -1794,9 +1794,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2145,12 +2145,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
-      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2903,13 +2903,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
-      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
+      "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -5826,9 +5826,9 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "54.0.23",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.23.tgz",
-      "integrity": "sha512-km0h72SFfQCmVycH/JtPFTVy69w6Lx1cHNDmfLfQqgKFYeeHTjx7LVDP4POHCtNxFP2UeRazrygJhlh4zz498g==",
+      "version": "54.0.25",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.25.tgz",
+      "integrity": "sha512-WnUqIb8oMBhtwSfIqdCHCzcaDIpLNXItRVd5miuvWi4GO0SGo89PSsAkbVJ+LJgcaY+v5rbgMELJS9I/CqOulA==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
@@ -5838,12 +5838,12 @@
         "@expo/devcert": "^1.2.1",
         "@expo/env": "~2.0.8",
         "@expo/image-utils": "^0.8.8",
-        "@expo/json-file": "^10.0.8",
+        "@expo/json-file": "^10.0.16",
         "@expo/metro": "~54.2.0",
-        "@expo/metro-config": "~54.0.14",
+        "@expo/metro-config": "~54.0.16",
         "@expo/osascript": "^2.3.8",
         "@expo/package-manager": "^1.9.10",
-        "@expo/plist": "^0.4.8",
+        "@expo/plist": "^0.4.9",
         "@expo/prebuild-config": "^54.0.8",
         "@expo/schema-utils": "^0.1.8",
         "@expo/spawn-async": "^1.7.2",
@@ -5863,16 +5863,16 @@
         "connect": "^3.7.0",
         "debug": "^4.3.4",
         "env-editor": "^0.4.1",
-        "expo-server": "^1.0.5",
+        "expo-server": "^1.0.7",
         "freeport-async": "^2.0.0",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
-        "lan-network": "^0.1.6",
+        "lan-network": "^0.2.1",
         "minimatch": "^9.0.0",
         "node-forge": "^1.3.3",
         "npm-package-arg": "^11.0.0",
         "ora": "^3.4.0",
-        "picomatch": "^3.0.1",
+        "picomatch": "^4.0.3",
         "pretty-bytes": "^5.6.0",
         "pretty-format": "^29.7.0",
         "progress": "^2.0.3",
@@ -5910,15 +5910,6 @@
         "react-native": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@expo/cli/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
       }
     },
     "node_modules/@expo/cli/node_modules/@expo/config": {
@@ -5964,11 +5955,39 @@
         "xml2js": "0.6.0"
       }
     },
+    "node_modules/@expo/cli/node_modules/@expo/config-plugins/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/@expo/config-plugins/node_modules/@expo/json-file": {
+      "version": "10.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.16.tgz",
+      "integrity": "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3"
+      }
+    },
     "node_modules/@expo/cli/node_modules/@expo/config-types": {
       "version": "54.0.10",
       "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.10.tgz",
       "integrity": "sha512-/J16SC2an1LdtCZ67xhSkGXpALYUVUNyZws7v+PVsFZxClYehDSoKLqyRaGkpHlYrCc08bS0RF5E0JV6g50psA==",
       "license": "MIT"
+    },
+    "node_modules/@expo/cli/node_modules/@expo/config/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
     },
     "node_modules/@expo/cli/node_modules/@expo/env": {
       "version": "2.0.11",
@@ -5983,10 +6002,20 @@
         "getenv": "^2.0.0"
       }
     },
+    "node_modules/@expo/cli/node_modules/@expo/json-file": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
+      "integrity": "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "json5": "^2.2.3"
+      }
+    },
     "node_modules/@expo/cli/node_modules/@expo/plist": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
-      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.9.tgz",
+      "integrity": "sha512-MPVpmKGfnQEnrCzgxuXcmPP/y/t6AVm+DcSb2Myp21LKWv1N3l8uFxMggesfF4ixAxkRlGmMMx9GyDC9M+XklQ==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -6016,9 +6045,9 @@
       }
     },
     "node_modules/@expo/cli/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6053,9 +6082,9 @@
       }
     },
     "node_modules/@expo/cli/node_modules/expo-server": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.5.tgz",
-      "integrity": "sha512-IGR++flYH70rhLyeXF0Phle56/k4cee87WeQ4mamS+MkVAVP+dDlOHf2nN06Z9Y2KhU0Gp1k+y61KkghF7HdhA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.7.tgz",
+      "integrity": "sha512-mcmyML3oXcqFUXUxtdtCL1O00ztNI2v76d+MdniXRUgHNxIcHZ05zo+DqBaOOT6LQnPk4vA4YHqQl7iGUfRb3g==",
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
@@ -6088,9 +6117,9 @@
       }
     },
     "node_modules/@expo/cli/node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6114,15 +6143,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@expo/cli/node_modules/lan-network": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.1.7.tgz",
-      "integrity": "sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ==",
-      "license": "MIT",
-      "bin": {
-        "lan-network": "dist/lan-network-cli.js"
-      }
-    },
     "node_modules/@expo/cli/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -6136,18 +6156,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@expo/cli/node_modules/picomatch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.2.tgz",
-      "integrity": "sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@expo/code-signing-certificates": {
@@ -6414,9 +6422,9 @@
       }
     },
     "node_modules/@expo/dom-webview": {
-      "version": "55.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/dom-webview/-/dom-webview-55.0.5.tgz",
-      "integrity": "sha512-lt3uxYOCk3wmWvtOOvsC35CKGbDAOx5C2EaY8SH1JVSfBzqmF8Cs0Xp1MPxncDPMyxpMiWx5SvvV/iLF1rJU4A==",
+      "version": "55.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/dom-webview/-/dom-webview-55.0.6.tgz",
+      "integrity": "sha512-ZNm8tiNEZysxrr36J0x4mOCGyJDcaIvL/3tMxBz0VJIJDcV19xjuJAhJQxHovu+jKx6s9tRyEAINa1mdrzV39g==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -6622,13 +6630,22 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "10.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.12.tgz",
-      "integrity": "sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==",
+      "version": "10.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.16.tgz",
+      "integrity": "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.20.0",
+        "@babel/code-frame": "~7.10.4",
         "json5": "^2.2.3"
+      }
+    },
+    "node_modules/@expo/json-file/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
       }
     },
     "node_modules/@expo/local-build-cache-provider": {
@@ -6695,9 +6712,9 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "54.0.14",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.14.tgz",
-      "integrity": "sha512-hxpLyDfOR4L23tJ9W1IbJJsG7k4lv2sotohBm/kTYyiG+pe1SYCAWsRmgk+H42o/wWf/HQjE5k45S5TomGLxNA==",
+      "version": "54.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.16.tgz",
+      "integrity": "sha512-3LLb9ZQl0VlqSlsalJ7+CYjfz60PBoSDHvpE1UF71aTM1Nx0Vb4LhXo7bCCC+PYP9q/GPB58LLbIROQ8PjKX2w==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -6705,7 +6722,7 @@
         "@babel/generator": "^7.20.5",
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8",
-        "@expo/json-file": "~10.0.8",
+        "@expo/json-file": "~10.0.16",
         "@expo/metro": "~54.2.0",
         "@expo/spawn-async": "^1.7.2",
         "browserslist": "^4.25.0",
@@ -6718,7 +6735,7 @@
         "hermes-parser": "^0.29.1",
         "jsc-safe-url": "^0.2.4",
         "lightningcss": "^1.30.1",
-        "minimatch": "^9.0.0",
+        "picomatch": "^4.0.3",
         "postcss": "~8.4.32",
         "resolve-from": "^5.0.0"
       },
@@ -6803,9 +6820,9 @@
       }
     },
     "node_modules/@expo/metro-config/node_modules/@expo/plist": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
-      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.9.tgz",
+      "integrity": "sha512-MPVpmKGfnQEnrCzgxuXcmPP/y/t6AVm+DcSb2Myp21LKWv1N3l8uFxMggesfF4ixAxkRlGmMMx9GyDC9M+XklQ==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -6828,13 +6845,25 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/@expo/metro-config/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@expo/metro-config/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@expo/metro-config/node_modules/chalk": {
@@ -6882,28 +6911,7 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@expo/metro-config/node_modules/glob/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/glob/node_modules/minimatch": {
+    "node_modules/@expo/metro-config/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
@@ -6913,21 +6921,6 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -7105,9 +7098,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/prebuild-config/node_modules/@expo/plist": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
-      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.9.tgz",
+      "integrity": "sha512-MPVpmKGfnQEnrCzgxuXcmPP/y/t6AVm+DcSb2Myp21LKWv1N3l8uFxMggesfF4ixAxkRlGmMMx9GyDC9M+XklQ==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -7140,9 +7133,9 @@
       }
     },
     "node_modules/@expo/prebuild-config/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -8688,9 +8681,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -8740,9 +8733,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10294,23 +10287,23 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/primitive": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
-      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.5.tgz",
+      "integrity": "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/@radix-ui/react-collection": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
-      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.12.tgz",
+      "integrity": "sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10327,14 +10320,30 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-compose-refs": "1.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10363,9 +10372,9 @@
       }
     },
     "node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
       "license": "MIT",
       "optional": true,
       "peerDependencies": {
@@ -10379,26 +10388,26 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
-      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.19.tgz",
+      "integrity": "sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.12",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10415,14 +10424,30 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-compose-refs": "1.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10435,9 +10460,9 @@
       }
     },
     "node_modules/@radix-ui/react-direction": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
-      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
       "license": "MIT",
       "optional": true,
       "peerDependencies": {
@@ -10451,17 +10476,17 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.15.tgz",
+      "integrity": "sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-escape-keydown": "1.1.1"
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-effect-event": "0.0.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10478,10 +10503,26 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-focus-guards": {
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
-      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
       "license": "MIT",
       "optional": true,
       "peerDependencies": {
@@ -10495,15 +10536,15 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
-      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.12.tgz",
+      "integrity": "sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1"
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10520,14 +10561,30 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-id": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
-      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10540,14 +10597,14 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.13.tgz",
+      "integrity": "sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10565,14 +10622,13 @@
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
-      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.7.tgz",
+      "integrity": "sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10590,13 +10646,13 @@
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/react-slot": "1.3.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10613,14 +10669,30 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-compose-refs": "1.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10633,21 +10705,23 @@
       }
     },
     "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
-      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.15.tgz",
+      "integrity": "sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10660,6 +10734,22 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -10684,20 +10774,20 @@
       }
     },
     "node_modules/@radix-ui/react-tabs": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
-      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.17.tgz",
+      "integrity": "sha512-nRyXnrAVCwjeXcHbvEbLS6ndbTeKHG1RqCP4A8Gw5L4cemDzPXdD8rAmr6wet0v57R69wGvuIIsFjHSVkZiMzQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.15",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10715,9 +10805,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
-      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
       "license": "MIT",
       "optional": true,
       "peerDependencies": {
@@ -10731,14 +10821,14 @@
       }
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
-      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10751,13 +10841,13 @@
       }
     },
     "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
-      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10769,15 +10859,12 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
-      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.1.tgz",
+      "integrity": "sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==",
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "@radix-ui/react-use-callback-ref": "1.1.1"
-      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -10789,9 +10876,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
       "license": "MIT",
       "optional": true,
       "peerDependencies": {
@@ -11046,9 +11133,9 @@
       }
     },
     "node_modules/@react-native/codegen/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -11163,9 +11250,9 @@
       }
     },
     "node_modules/@react-native/dev-middleware/node_modules/ws": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.4.tgz",
+      "integrity": "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==",
       "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"
@@ -11195,42 +11282,19 @@
       "integrity": "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g==",
       "license": "MIT"
     },
-    "node_modules/@react-native/virtualized-lists": {
-      "version": "0.81.5",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.81.5.tgz",
-      "integrity": "sha512-UVXgV/db25OPIvwZySeToXD/9sKKhOdkcWmmf4Jh8iBZuyfML+/5CasaZ1E7Lqg6g3uqVQq75NqIwkYmORJMPw==",
-      "license": "MIT",
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 20.19.4"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.1.0",
-        "react": "*",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@react-navigation/bottom-tabs": {
-      "version": "7.15.9",
-      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.15.9.tgz",
-      "integrity": "sha512-Ou28A1aZLj5wiFQ3F93aIsrI4NCwn3IJzkkjNo9KLFXsc0Yks+UqrVaFlffHFLsrbajuGRG/OQpnMA1ljayY5Q==",
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.18.8.tgz",
+      "integrity": "sha512-7KCsBtwCRwQQSTEw9SLglZCEkxWc+EqgdRKyUOgII+6+xEnemOyg8aDlnLIM2yk9ip6uE+Oxvm0jdpQU2vsu2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@react-navigation/elements": "^2.9.14",
+        "@react-navigation/elements": "^2.9.30",
         "color": "^4.2.3",
         "sf-symbols-typescript": "^2.1.0"
       },
       "peerDependencies": {
-        "@react-navigation/native": "^7.2.2",
+        "@react-navigation/native": "^7.3.8",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0",
@@ -11258,9 +11322,9 @@
       }
     },
     "node_modules/@react-navigation/elements": {
-      "version": "2.9.14",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.14.tgz",
-      "integrity": "sha512-lKqzu+su2pI/YIZmR7L7xdOs4UL+rVXKJAMpRMBrwInEy96SjIFst6QDGpE89Dunnu3VjVpjWfByo9f2GWBHDQ==",
+      "version": "2.9.30",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.30.tgz",
+      "integrity": "sha512-2isleieiRMmP4WNMV2Q1u3qP1M47ZqsJ2hJ/Og11FeKXK8YmUTHya7PW7ecsgAh2CXKTxAcbfJDFTSvq2D++Tw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11270,7 +11334,7 @@
       },
       "peerDependencies": {
         "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.2.2",
+        "@react-navigation/native": "^7.3.8",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0"
@@ -11282,19 +11346,19 @@
       }
     },
     "node_modules/@react-navigation/native-stack": {
-      "version": "7.14.11",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.14.11.tgz",
-      "integrity": "sha512-1ufBtJ7KbVFlQhXsYSYHqjgkmP30AzJSgW48YjWMQZ3NZGAyYe34w9Wd4KpdebQCfDClPe9maU+8crA/awa6lQ==",
+      "version": "7.17.10",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.17.10.tgz",
+      "integrity": "sha512-m1BWVEaOPX9k30DbmhsD7IlrUdl4J7Ogmo71rcNlbZQPMNB126av/nfwqB+qN7DIsiwTAnORnT+SwzD56qqD0Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@react-navigation/elements": "^2.9.14",
+        "@react-navigation/elements": "^2.9.30",
         "color": "^4.2.3",
         "sf-symbols-typescript": "^2.1.0",
         "warn-once": "^0.1.1"
       },
       "peerDependencies": {
-        "@react-navigation/native": "^7.2.2",
+        "@react-navigation/native": "^7.3.8",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0",
@@ -15554,6 +15618,25 @@
         "ox": "^0.4.4"
       }
     },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6": {
+      "name": "@starknet-io/get-starknet-wallet-standard",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-6.0.2.tgz",
+      "integrity": "sha512-jCnLFNPw4IGgmkwDlHszKbnyEbQKu3pE7cZHyVMFwyvRG98IA9FZKykrTNH7Nq3BILf6EcOZ5SgYUQE/gtqraA==",
+      "license": "MIT",
+      "dependencies": {
+        "@starknet-io/types-js": "^0.10.3",
+        "@wallet-standard/base": "^1.1.1",
+        "@wallet-standard/features": "^1.1.1",
+        "ox": "^0.4.4"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6/node_modules/@starknet-io/types-js": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.3.tgz",
+      "integrity": "sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==",
+      "license": "MIT"
+    },
     "node_modules/@starknet-io/get-starknet-wallet-standard/node_modules/@starknet-io/types-js": {
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
@@ -15561,11 +15644,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@starknet-io/starknet-types-010": {
+    "node_modules/@starknet-io/starknet-types-0101": {
       "name": "@starknet-io/types-js",
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.0.tgz",
-      "integrity": "sha512-7ALSydz6pq3YIOpq5a7OkkxqwJciMc9Nlph0OGjhcC3xX0xH30XgizmziLyYVN10oO9+BJk8M9KbJjpzdbtRSw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.2.tgz",
+      "integrity": "sha512-AtUFPYdmo9DqVus++aBSoY9W13/2PZmillPr8/mXZjc+V0iYJ/QTmkTsbw+es2mnLeLhYWSymW9ivQzyyyKdog==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/starknet-types-0103": {
+      "name": "@starknet-io/types-js",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.3.tgz",
+      "integrity": "sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==",
       "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-07": {
@@ -16085,9 +16175,9 @@
       }
     },
     "node_modules/@types/sinon": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.0.tgz",
-      "integrity": "sha512-+oHKZ0lTI+WVLxx1IbJDNmReQaIsQJjN2e7UUrJHEeByG7bFeKJYsv1E75JxTQ9QKJDp21bAa/0W2Xo4srsDnw==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-22.0.0.tgz",
+      "integrity": "sha512-TDbVpbccc2HfiqHR09Argj3mHV1KMW7sCCKj52fsl8lbRLkEn7fB1966EWhOKWUBcqfBueZuPoA7/OK1CKiy3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16633,24 +16723,24 @@
       }
     },
     "node_modules/@wallet-standard/base": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
-      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@wallet-standard/features": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
-      "integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.1.tgz",
+      "integrity": "sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wallet-standard/base": "^1.1.0"
+        "@wallet-standard/base": "^1.1.1"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@wallet-standard/wallet": {
@@ -18033,121 +18123,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0 || ^8.0.0-0"
-      }
-    },
-    "node_modules/babel-preset-expo": {
-      "version": "54.0.10",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.10.tgz",
-      "integrity": "sha512-wTt7POavLFypLcPW/uC5v8y+mtQKDJiyGLzYCjqr9tx0Qc3vCXcDKk1iCFIj/++Iy5CWhhTflEa7VvVPNWeCfw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/plugin-proposal-decorators": "^7.12.9",
-        "@babel/plugin-proposal-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-export-default-from": "^7.24.7",
-        "@babel/plugin-transform-class-static-block": "^7.27.1",
-        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
-        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
-        "@babel/plugin-transform-parameters": "^7.24.7",
-        "@babel/plugin-transform-private-methods": "^7.24.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-        "@babel/plugin-transform-runtime": "^7.24.7",
-        "@babel/preset-react": "^7.22.15",
-        "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "0.81.5",
-        "babel-plugin-react-compiler": "^1.0.0",
-        "babel-plugin-react-native-web": "~0.21.0",
-        "babel-plugin-syntax-hermes-parser": "^0.29.1",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "debug": "^4.3.4",
-        "resolve-from": "^5.0.0"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.20.0",
-        "expo": "*",
-        "react-refresh": ">=0.14.0 <1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/runtime": {
-          "optional": true
-        },
-        "expo": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/babel-preset-expo/node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.81.5",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.5.tgz",
-      "integrity": "sha512-oF71cIH6je3fSLi6VPjjC3Sgyyn57JLHXs+mHWc9MoCiJJcM4nqsS5J38zv1XQ8d3zOW2JtHro+LF0tagj2bfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.25.3",
-        "@react-native/codegen": "0.81.5"
-      },
-      "engines": {
-        "node": ">= 20.19.4"
-      }
-    },
-    "node_modules/babel-preset-expo/node_modules/@react-native/babel-preset": {
-      "version": "0.81.5",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.81.5.tgz",
-      "integrity": "sha512-UoI/x/5tCmi+pZ3c1+Ypr1DaRMDLI3y+Q70pVLLVgrnC3DHsHRIbHcCHIeG/IJvoeFqFM2sTdhSOLJrf8lOPrA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/plugin-proposal-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-syntax-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-transform-arrow-functions": "^7.24.7",
-        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
-        "@babel/plugin-transform-async-to-generator": "^7.24.7",
-        "@babel/plugin-transform-block-scoping": "^7.25.0",
-        "@babel/plugin-transform-class-properties": "^7.25.4",
-        "@babel/plugin-transform-classes": "^7.25.4",
-        "@babel/plugin-transform-computed-properties": "^7.24.7",
-        "@babel/plugin-transform-destructuring": "^7.24.8",
-        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-        "@babel/plugin-transform-for-of": "^7.24.7",
-        "@babel/plugin-transform-function-name": "^7.25.1",
-        "@babel/plugin-transform-literals": "^7.25.2",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
-        "@babel/plugin-transform-numeric-separator": "^7.24.7",
-        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
-        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
-        "@babel/plugin-transform-optional-chaining": "^7.24.8",
-        "@babel/plugin-transform-parameters": "^7.24.7",
-        "@babel/plugin-transform-private-methods": "^7.24.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-        "@babel/plugin-transform-react-display-name": "^7.24.7",
-        "@babel/plugin-transform-react-jsx": "^7.25.2",
-        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
-        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
-        "@babel/plugin-transform-regenerator": "^7.24.7",
-        "@babel/plugin-transform-runtime": "^7.24.7",
-        "@babel/plugin-transform-shorthand-properties": "^7.24.7",
-        "@babel/plugin-transform-spread": "^7.24.7",
-        "@babel/plugin-transform-sticky-regex": "^7.24.7",
-        "@babel/plugin-transform-typescript": "^7.25.2",
-        "@babel/plugin-transform-unicode-regex": "^7.24.7",
-        "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.81.5",
-        "babel-plugin-syntax-hermes-parser": "0.29.1",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "react-refresh": "^0.14.0"
-      },
-      "engines": {
-        "node": ">= 20.19.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
       }
     },
     "node_modules/babel-preset-jest": {
@@ -21603,29 +21578,29 @@
       }
     },
     "node_modules/expo": {
-      "version": "54.0.33",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
-      "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
+      "version": "54.0.35",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.35.tgz",
+      "integrity": "sha512-E+tXpQwjGm5fK/uwa55p0Xx/kuo5dXDKfVJ95IargTNa5KiFt26lSTXXa9KnHbI4EDLwFD38/xTKZvzPTlGTdg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "54.0.23",
+        "@expo/cli": "54.0.25",
         "@expo/config": "~12.0.13",
         "@expo/config-plugins": "~54.0.4",
         "@expo/devtools": "0.1.8",
-        "@expo/fingerprint": "0.15.4",
+        "@expo/fingerprint": "0.15.5",
         "@expo/metro": "~54.2.0",
-        "@expo/metro-config": "54.0.14",
+        "@expo/metro-config": "54.0.16",
         "@expo/vector-icons": "^15.0.3",
         "@ungap/structured-clone": "^1.3.0",
-        "babel-preset-expo": "~54.0.10",
-        "expo-asset": "~12.0.12",
+        "babel-preset-expo": "~54.0.11",
+        "expo-asset": "~12.0.13",
         "expo-constants": "~18.0.13",
-        "expo-file-system": "~19.0.21",
-        "expo-font": "~14.0.11",
+        "expo-file-system": "~19.0.23",
+        "expo-font": "~14.0.12",
         "expo-keep-awake": "~15.0.8",
-        "expo-modules-autolinking": "3.0.24",
-        "expo-modules-core": "3.0.29",
+        "expo-modules-autolinking": "3.0.26",
+        "expo-modules-core": "3.0.30",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-without-unicode": "8.0.0-3"
@@ -21652,21 +21627,6 @@
         "react-native-webview": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo-asset": {
-      "version": "12.0.12",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.12.tgz",
-      "integrity": "sha512-CsXFCQbx2fElSMn0lyTdRIyKlSXOal6ilLJd+yeZ6xaC7I9AICQgscY5nj0QcwgA+KYYCCEQEBndMsmj7drOWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/image-utils": "^0.8.8",
-        "expo-constants": "~18.0.12"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo-constants": {
@@ -21756,9 +21716,9 @@
       }
     },
     "node_modules/expo-constants/node_modules/@expo/plist": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
-      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.9.tgz",
+      "integrity": "sha512-MPVpmKGfnQEnrCzgxuXcmPP/y/t6AVm+DcSb2Myp21LKWv1N3l8uFxMggesfF4ixAxkRlGmMMx9GyDC9M+XklQ==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -21791,9 +21751,9 @@
       }
     },
     "node_modules/expo-constants/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -21862,20 +21822,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/expo-file-system": {
-      "version": "19.0.21",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
-      "integrity": "sha512-s3DlrDdiscBHtab/6W1osrjGL+C2bvoInPJD7sOwmxfJ5Woynv2oc+Fz1/xVXaE/V7HE/+xrHC/H45tu6lZzzg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo-font": {
-      "version": "14.0.11",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
-      "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
+      "version": "14.0.12",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.12.tgz",
+      "integrity": "sha512-QQzunE2Mxk45AsCWm3tK7OpVljbtVnKD58q4/qliev+cbye1IOduUnRIdD+P7DyButw17G9MTX795kgaQiz5hQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -21885,16 +21835,6 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/expo-keep-awake": {
-      "version": "15.0.8",
-      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-15.0.8.tgz",
-      "integrity": "sha512-YK9M1VrnoH1vLJiQzChZgzDvVimVoriibiDIFLbQMpjYBnvyfUeHJcin/Gx1a+XgupNXy92EQJLgI/9ZuXajYQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -22055,9 +21995,9 @@
       }
     },
     "node_modules/expo/node_modules/@expo/fingerprint": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.4.tgz",
-      "integrity": "sha512-eYlxcrGdR2/j2M6pEDXo9zU9KXXF1vhP+V+Tl+lyY+bU8lnzrN6c637mz6Ye3em2ANy8hhUR03Raf8VsT9Ogng==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.5.tgz",
+      "integrity": "sha512-mdVoAMcux1WlM6kd1RoWiHRNqKqS+J6mKmWQ/BKgeh937S/fcW58EE68O6nc4KDXtWi3PBeNHskOFcgyIuD4hw==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -22067,7 +22007,7 @@
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
         "ignore": "^5.3.1",
-        "minimatch": "^9.0.0",
+        "minimatch": "^10.2.2",
         "p-limit": "^3.1.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
@@ -22077,14 +22017,86 @@
       }
     },
     "node_modules/expo/node_modules/@expo/plist": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
-      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.9.tgz",
+      "integrity": "sha512-MPVpmKGfnQEnrCzgxuXcmPP/y/t6AVm+DcSb2Myp21LKWv1N3l8uFxMggesfF4ixAxkRlGmMMx9GyDC9M+XklQ==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.2.3",
         "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/expo/node_modules/@react-native/babel-plugin-codegen": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.5.tgz",
+      "integrity": "sha512-oF71cIH6je3fSLi6VPjjC3Sgyyn57JLHXs+mHWc9MoCiJJcM4nqsS5J38zv1XQ8d3zOW2JtHro+LF0tagj2bfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.25.3",
+        "@react-native/codegen": "0.81.5"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      }
+    },
+    "node_modules/expo/node_modules/@react-native/babel-preset": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.81.5.tgz",
+      "integrity": "sha512-UoI/x/5tCmi+pZ3c1+Ypr1DaRMDLI3y+Q70pVLLVgrnC3DHsHRIbHcCHIeG/IJvoeFqFM2sTdhSOLJrf8lOPrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-proposal-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-transform-arrow-functions": "^7.24.7",
+        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
+        "@babel/plugin-transform-async-to-generator": "^7.24.7",
+        "@babel/plugin-transform-block-scoping": "^7.25.0",
+        "@babel/plugin-transform-class-properties": "^7.25.4",
+        "@babel/plugin-transform-classes": "^7.25.4",
+        "@babel/plugin-transform-computed-properties": "^7.24.7",
+        "@babel/plugin-transform-destructuring": "^7.24.8",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+        "@babel/plugin-transform-for-of": "^7.24.7",
+        "@babel/plugin-transform-function-name": "^7.25.1",
+        "@babel/plugin-transform-literals": "^7.25.2",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+        "@babel/plugin-transform-numeric-separator": "^7.24.7",
+        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.8",
+        "@babel/plugin-transform-parameters": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+        "@babel/plugin-transform-react-display-name": "^7.24.7",
+        "@babel/plugin-transform-react-jsx": "^7.25.2",
+        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
+        "@babel/plugin-transform-regenerator": "^7.24.7",
+        "@babel/plugin-transform-runtime": "^7.24.7",
+        "@babel/plugin-transform-shorthand-properties": "^7.24.7",
+        "@babel/plugin-transform-spread": "^7.24.7",
+        "@babel/plugin-transform-sticky-regex": "^7.24.7",
+        "@babel/plugin-transform-typescript": "^7.25.2",
+        "@babel/plugin-transform-unicode-regex": "^7.24.7",
+        "@babel/template": "^7.25.0",
+        "@react-native/babel-plugin-codegen": "0.81.5",
+        "babel-plugin-syntax-hermes-parser": "0.29.1",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
+        "react-refresh": "^0.14.0"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
       }
     },
     "node_modules/expo/node_modules/ansi-styles": {
@@ -22102,13 +22114,68 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/expo/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+    "node_modules/expo/node_modules/babel-preset-expo": {
+      "version": "54.0.11",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.11.tgz",
+      "integrity": "sha512-dEpeFDtYEFzmWtWVwvt7sUCZH0fxXPfbJlgXd7XNZSQDa/Ki/hTOj9exMTzqR2oyPHDNcE9VxYCJ4oS6xw4Pjg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/plugin-proposal-decorators": "^7.12.9",
+        "@babel/plugin-proposal-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-export-default-from": "^7.24.7",
+        "@babel/plugin-transform-class-static-block": "^7.27.1",
+        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
+        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+        "@babel/plugin-transform-parameters": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+        "@babel/plugin-transform-runtime": "^7.24.7",
+        "@babel/preset-react": "^7.22.15",
+        "@babel/preset-typescript": "^7.23.0",
+        "@react-native/babel-preset": "0.81.5",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "babel-plugin-react-native-web": "~0.21.0",
+        "babel-plugin-syntax-hermes-parser": "^0.29.1",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
+        "debug": "^4.3.4",
+        "resolve-from": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.20.0",
+        "expo": "*",
+        "react-refresh": ">=0.14.0 <1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/runtime": {
+          "optional": true
+        },
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/expo/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/expo/node_modules/chalk": {
@@ -22136,10 +22203,45 @@
         "node": ">= 10"
       }
     },
+    "node_modules/expo/node_modules/expo-asset": {
+      "version": "12.0.13",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.13.tgz",
+      "integrity": "sha512-x/p7WvQUnkn6K43b9eL6SPeq5Vnf1E8BDe9bDrWrvMqzyUvJnUFvl+ctg3034s/+UHe7Ne2pAmc0+yzbl8CrDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.8",
+        "expo-constants": "~18.0.13"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo/node_modules/expo-file-system": {
+      "version": "19.0.23",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.23.tgz",
+      "integrity": "sha512-MeGkid9OeNILfT/qonaXHp4f2c15xaB28U/bcN7pqZej0Kx0+6+V7e9ZIXpPHm07zVatxA+QkMTPQEGfmvVOxA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo/node_modules/expo-keep-awake": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-15.0.8.tgz",
+      "integrity": "sha512-YK9M1VrnoH1vLJiQzChZgzDvVimVoriibiDIFLbQMpjYBnvyfUeHJcin/Gx1a+XgupNXy92EQJLgI/9ZuXajYQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "node_modules/expo/node_modules/expo-modules-autolinking": {
-      "version": "3.0.24",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz",
-      "integrity": "sha512-TP+6HTwhL7orDvsz2VzauyQlXJcAWyU3ANsZ7JGL4DQu8XaZv/A41ZchbtAYLfozNA2Ya1Hzmhx65hXryBMjaQ==",
+      "version": "3.0.26",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.26.tgz",
+      "integrity": "sha512-WOaud6UKg16ciCOj8raKcMOoKFMHLXKI29U29yhgu1lf+Y7VxJyCktUcYo6AM+ccZ7zLD1uWZdMtgnpf+95OXA==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -22153,9 +22255,9 @@
       }
     },
     "node_modules/expo/node_modules/expo-modules-core": {
-      "version": "3.0.29",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.29.tgz",
-      "integrity": "sha512-LzipcjGqk8gvkrOUf7O2mejNWugPkf3lmd9GkqL9WuNyeN2fRwU0Dn77e3ZUKI3k6sI+DNwjkq4Nu9fNN9WS7Q==",
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.30.tgz",
+      "integrity": "sha512-a6IrpAn/Jbmwxi9L+hMmXKpNqnkUpoF7WHOpn02rVLyax2J0gB1vvCVE5rNydplEnt41Q6WxQwvcOjZaIkcSUg==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
@@ -22182,28 +22284,7 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/expo/node_modules/glob/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/expo/node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/expo/node_modules/glob/node_modules/minimatch": {
+    "node_modules/expo/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
@@ -22213,21 +22294,6 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/expo/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -23763,6 +23829,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -23770,9 +23837,9 @@
       }
     },
     "node_modules/hardhat/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -24257,9 +24324,9 @@
       "license": "MIT"
     },
     "node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -25294,9 +25361,9 @@
       "license": "MIT"
     },
     "node_modules/json-stream-stringify": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.6.tgz",
-      "integrity": "sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.7.tgz",
+      "integrity": "sha512-F4MWetLtY42YMaAKw5cV4e47zMD5aOT+tjjQWjX18ACtdkQ5Y/vrcfbcQ107Rh+MXjOCIx4KhW0wPmOvG8iQ5w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -25497,9 +25564,9 @@
       }
     },
     "node_modules/lan-network": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.2.0.tgz",
-      "integrity": "sha512-EZgbsXMrGS+oK+Ta12mCjzBFse+SIewGdwrSTr5g+MSymnjpox2x05ceI20PQejJOFvOgzcXrfDk/SdY7dSCtw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.2.1.tgz",
+      "integrity": "sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A==",
       "license": "MIT",
       "bin": {
         "lan-network": "dist/lan-network-cli.js"
@@ -25972,9 +26039,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -27177,9 +27244,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -28165,6 +28232,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "dev": true,
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
@@ -29457,9 +29525,9 @@
       }
     },
     "node_modules/react-devtools-core/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -29498,9 +29566,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
-      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT",
       "optional": true
     },
@@ -29621,6 +29689,29 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.81.5.tgz",
+      "integrity": "sha512-UVXgV/db25OPIvwZySeToXD/9sKKhOdkcWmmf4Jh8iBZuyfML+/5CasaZ1E7Lqg6g3uqVQq75NqIwkYmORJMPw==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      },
+      "peerDependencies": {
+        "@types/react": "^19.1.0",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-native/node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -29657,18 +29748,18 @@
       }
     },
     "node_modules/react-native/node_modules/ws": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.4.tgz",
+      "integrity": "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==",
       "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"
       }
     },
     "node_modules/react-native/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -30926,9 +31017,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -31442,9 +31533,9 @@
       "optional": true
     },
     "node_modules/starknet": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/starknet/-/starknet-9.2.1.tgz",
-      "integrity": "sha512-bFJY2sMZ9tsLBhPCm719MWjoz+doabXIwPX/xtW56EHwAJMRAS6mICF6H2dCwOQHJmCMKpOSFBwW0SaiHzcioQ==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-10.5.0.tgz",
+      "integrity": "sha512-hHKW39sVFLCGPC8QKdQksbs8qo10Rjb6Zdpv3nKMYQUeXDtffvI1SOa62aX8+WcnpfG7Te4UBx5NTomz/X7ZpA==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.7.0",
@@ -31452,21 +31543,21 @@
         "@scure/base": "~1.2.1",
         "@scure/starknet": "1.1.0",
         "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
-        "@starknet-io/starknet-types-010": "npm:@starknet-io/types-js@0.10.0",
-        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.1",
+        "@starknet-io/get-starknet-wallet-standard-v6": "npm:@starknet-io/get-starknet-wallet-standard@6.0.2",
+        "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
+        "@starknet-io/starknet-types-0103": "npm:@starknet-io/types-js@0.10.3",
+        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.2",
         "abi-wan-kanabi": "2.2.4",
-        "lossless-json": "^4.2.0",
-        "pako": "^2.0.4",
-        "ts-mixer": "^6.0.3"
+        "lossless-json": "^4.2.0"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/starknet-devnet": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/starknet-devnet/-/starknet-devnet-0.7.2.tgz",
-      "integrity": "sha512-g4ayDPXZCe3dKNwIaaiiNkHmH1ZbqRnGbOLWYd2fGTodK1rR5+22Q27mHEbWrDkLdi4KMHBIxSBIaAFxvUMlNA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/starknet-devnet/-/starknet-devnet-0.8.2.tgz",
+      "integrity": "sha512-oDh0Yidm9xDmEgGeD0nvt7yRFQV2v9VW7HQOrPlpX63khgyfqo9TmoSfd3VRj2v7M0zVwMF55Rn8IfamGhn8OQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -32090,9 +32181,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -32436,6 +32527,7 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
       "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tsc-alias": {
@@ -36094,13 +36186,13 @@
       }
     },
     "packages/native/node_modules/@expo/metro-runtime": {
-      "version": "55.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-55.0.10.tgz",
-      "integrity": "sha512-7v+ldTvMWRa1ml83Jel9W2f8qT/NZZWrlHaEjf29nb72JTEO50+Xac9PWLo+X3LCDAAuyYuBGKYXOJwfqxV0fQ==",
+      "version": "55.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-55.0.11.tgz",
+      "integrity": "sha512-4KKi/jGrIEXi2YGu0hYTVr0CEeRJy5SXbCrz9+KDZkuD3ROwKNpM1DBawni5rhPVovFnR323HBck9GaxhnfrRw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@expo/log-box": "55.0.11",
+        "@expo/log-box": "55.0.12",
         "anser": "^1.4.9",
         "pretty-format": "^29.7.0",
         "stacktrace-parser": "^0.1.10",
@@ -36119,18 +36211,18 @@
       }
     },
     "packages/native/node_modules/@expo/metro-runtime/node_modules/@expo/log-box": {
-      "version": "55.0.11",
-      "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-55.0.11.tgz",
-      "integrity": "sha512-JQHFLWkskIbJi6cxYMjErx8lQqfFJilDQLKmdTO3m3YkdmN9GE/CrzjOfVlCG0DGEGZJ90br0pGKvGPdXNsHKw==",
+      "version": "55.0.12",
+      "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-55.0.12.tgz",
+      "integrity": "sha512-f9ARS8J60cq3LLNdIqmUjYwyerBzVS5Ecp7KjIf3GOIPjW0571rkcwLz4/U18l/1DeSkSzIkYsNl2TC9oTdWaQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@expo/dom-webview": "^55.0.5",
+        "@expo/dom-webview": "^55.0.6",
         "anser": "^1.4.9",
         "stacktrace-parser": "^0.1.10"
       },
       "peerDependencies": {
-        "@expo/dom-webview": "^55.0.5",
+        "@expo/dom-webview": "^55.0.6",
         "expo": "*",
         "react": "*",
         "react-native": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
       "devDependencies": {
         "@0no-co/graphql.web": "^1.2.0",
         "@avnu/avnu-sdk": "4.2.0-next.2",
-        "@cartridge/controller": "0.13.9",
+        "@cartridge/controller": "^0.13.13",
         "@eslint/js": "^9.39.2",
-        "@fatsolutions/tongo-sdk": "^1.3.2",
+        "@fatsolutions/tongo-sdk": "^1.5.0",
         "@hyperlane-xyz/registry": "^19.4.0",
         "@hyperlane-xyz/sdk": "^14.4.0",
         "@hyperlane-xyz/utils": "^14.4.0",
@@ -45,8 +45,8 @@
       },
       "peerDependencies": {
         "@avnu/avnu-sdk": "^4.2.0-next.2",
-        "@cartridge/controller": "^0.13.9",
-        "@fatsolutions/tongo-sdk": "^1.3.2",
+        "@cartridge/controller": "^0.13.13",
+        "@fatsolutions/tongo-sdk": "^1.5.0",
         "@hyperlane-xyz/registry": "^19.4.0",
         "@hyperlane-xyz/sdk": "^14.4.0",
         "@hyperlane-xyz/utils": "^14.4.0",
@@ -3200,17 +3200,17 @@
       }
     },
     "node_modules/@cartridge/controller": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/@cartridge/controller/-/controller-0.13.9.tgz",
-      "integrity": "sha512-LVjoBN8/Fa2Hv5bjOUBWcaJSxFthqr5JikUPZo3NERnLloUHOtGQs6HnIFOwP4N5i0A+GyTJVLa+fmk49ZJERg==",
+      "version": "0.13.13",
+      "resolved": "https://registry.npmjs.org/@cartridge/controller/-/controller-0.13.13.tgz",
+      "integrity": "sha512-/r8vgHzKPYkjb6Z4SAbTOM3S1MT/ZzflgZ/dfD2OqHBcQtqLz18YtMOoLcvhfljrxgr/MRkR8u3gRN4GKp72mg==",
       "dev": true,
       "dependencies": {
-        "@cartridge/controller-wasm": "0.9.4",
+        "@cartridge/controller-wasm": "0.10.1",
         "@cartridge/penpal": "^6.2.4",
-        "@starknet-io/get-starknet-wallet-standard": "5.0.0-beta.0",
+        "@starknet-io/get-starknet-core": "5.0.0",
         "@starknet-io/types-js": "0.9.1",
-        "@telegram-apps/sdk": "^2.4.0",
-        "@turnkey/sdk-browser": "^4.0.0",
+        "@turnkey/sdk-browser": "^5.15.2",
+        "@wallet-standard/wallet": "^1.1.0",
         "@walletconnect/ethereum-provider": "^2.20.0",
         "bs58": "^6.0.0",
         "cbor-x": "^1.5.0",
@@ -3219,12 +3219,24 @@
         "mipd": "^0.0.7",
         "open": "^10.1.0",
         "starknet": "^8.5.2"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@cartridge/controller-wasm": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@cartridge/controller-wasm/-/controller-wasm-0.9.4.tgz",
-      "integrity": "sha512-hkvXPhAnjY57MhdJfUWK5htCFeOv06ChwYtrsx3AKJRnNW9HU25dfWHqWPdy875/2KmqIBDVTdoxddhoHgmrBw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@cartridge/controller-wasm/-/controller-wasm-0.10.1.tgz",
+      "integrity": "sha512-NweHJ98lFrV103sT+ud0WOUT+j92bBdaTdT+cFRwPA+XmRB39UekMu35iWlFcBhlnxQF+GdX4G/IrQtfoXf9+A==",
       "dev": true
     },
     "node_modules/@cartridge/controller/node_modules/@noble/curves": {
@@ -3268,26 +3280,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/@cartridge/controller/node_modules/@starknet-io/get-starknet-wallet-standard": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0-beta.0.tgz",
-      "integrity": "sha512-1QBmWnd76KzKwnVlRXLh58wtd1e0P5fyOhs0bCCjivTpGJ2nUPRvTgmzVJStNBcuQ7617UfB5qIyBnkig31TmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@starknet-io/types-js": "^0.7.10",
-        "@wallet-standard/base": "^1.1.0",
-        "@wallet-standard/features": "^1.1.0",
-        "ox": "^0.4.4"
-      }
-    },
-    "node_modules/@cartridge/controller/node_modules/@starknet-io/get-starknet-wallet-standard/node_modules/@starknet-io/types-js": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
-      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@cartridge/controller/node_modules/starknet": {
       "version": "8.9.2",
@@ -7387,9 +7379,9 @@
       }
     },
     "node_modules/@fatsolutions/tongo-sdk": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@fatsolutions/tongo-sdk/-/tongo-sdk-1.3.2.tgz",
-      "integrity": "sha512-VW4SWJvNCLb+jyFj9ra0MmBomxfOs4I/ybVV/5Gjxt31Kbn6F4svBI9WPCkVE1SjhNcYSf4vfxdXZvZ6pJcg7w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@fatsolutions/tongo-sdk/-/tongo-sdk-1.5.0.tgz",
+      "integrity": "sha512-CCGU3XlgOVY7r2WI746dcA774YwNTEEJDw9qcZDE2xQBw4NZrqkOFlReFlyShQnb+iiZEMLzXthfsQgaDGbvmg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7398,12 +7390,7 @@
         "@noble/hashes": "1.8.0",
         "@scure/base": "1.2.5",
         "@scure/starknet": "1.1.0",
-        "commander": "^11.0.0",
-        "dotenv": "^16.3.1",
-        "starknet": "8.5.4"
-      },
-      "bin": {
-        "tongo": "dist/cli.js"
+        "starknet": "9.4.2"
       }
     },
     "node_modules/@fatsolutions/tongo-sdk/node_modules/@noble/curves": {
@@ -7445,33 +7432,10 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@fatsolutions/tongo-sdk/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@fatsolutions/tongo-sdk/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/@fatsolutions/tongo-sdk/node_modules/starknet": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/starknet/-/starknet-8.5.4.tgz",
-      "integrity": "sha512-nlD6C+98lxRdSPX9jT+Z+/Hw8o5IhBMCY2gauWjnvU/fd4Y9kWxfgIo2mRGCW1oq9aeQAJasoebbmXlKBhcOPA==",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-9.4.2.tgz",
+      "integrity": "sha512-NFtg077DjddHUSh8sLZ5uB149LEF4NR90FuJ0oF7+zhce7l0oG9Ubqr3H4+jHm/ghHtV+yjlv1UhEoo4SBfILA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7479,7 +7443,8 @@
         "@noble/hashes": "~1.6.0",
         "@scure/base": "~1.2.1",
         "@scure/starknet": "1.1.0",
-        "@starknet-io/starknet-types-08": "npm:@starknet-io/types-js@~0.8.4",
+        "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
+        "@starknet-io/starknet-types-010": "npm:@starknet-io/types-js@0.10.0",
         "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.1",
         "abi-wan-kanabi": "2.2.4",
         "lossless-json": "^4.2.0",
@@ -9515,6 +9480,43 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/@module-federation/error-codes": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.12.0.tgz",
+      "integrity": "sha512-DEXQjopcBuGzp/NA9OVtASO0uZ6grVK5TIe0PjrbDRyZDxVaYQXKrISxBLOE+3nSIELE98tYpfxptm8WC9A8zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/runtime": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.12.0.tgz",
+      "integrity": "sha512-Cz9/7+gSvrdencwA8LXUMKnZdu0/flyN+yk6t3pkxfhvPJi3W65ZcalAKyOgyk2x8rEYrRSyEXu+/2DIFgrzmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.12.0",
+        "@module-federation/runtime-core": "0.12.0",
+        "@module-federation/sdk": "0.12.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.12.0.tgz",
+      "integrity": "sha512-373zBM54196KHURs/O8lry9trCAM3PPidvsF4YdrtahNc8YaQynml0mE3zdZeBnqP6H0/4OpPqMMjACI80Ht8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.12.0",
+        "@module-federation/sdk": "0.12.0"
+      }
+    },
+    "node_modules/@module-federation/sdk": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.12.0.tgz",
+      "integrity": "sha512-vh3GcG90fxjbkMghK7iSWcMayi/y8U5DxI6mhEFuz11St3y1UgQO2TZYephL8nISFBld7DdiqAkimx+6Hb3hjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@msgpack/msgpack": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
@@ -10198,6 +10200,256 @@
       "integrity": "sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-rsa": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pfx": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/asn1-x509/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.12.3.tgz",
+      "integrity": "sha512-+Mzq+W7cNEKfkNZzyLl6A6ffqc3r21HGZUezgfKxpZrkORfOqgRXnS80Zu0IV6a9Ue9QBJeKD7kN0iWfc3bhRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.3.13",
+        "@peculiar/asn1-csr": "^2.3.13",
+        "@peculiar/asn1-ecc": "^2.3.14",
+        "@peculiar/asn1-pkcs9": "^2.3.13",
+        "@peculiar/asn1-rsa": "^2.3.13",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-x509": "^2.3.13",
+        "pvtsutils": "^1.3.5",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.7.0",
+        "tsyringe": "^4.8.0"
+      }
+    },
+    "node_modules/@peculiar/x509/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@phosphor-icons/webcomponents": {
       "version": "2.1.5",
@@ -15563,6 +15815,79 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@starknet-io/get-starknet-core": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-core/-/get-starknet-core-5.0.0.tgz",
+      "integrity": "sha512-FVKYeNGHWG978482ZdCf7VQMoMn0xxHS0mWYbNB6zwkpo2yForHJwN4/EIHQkd2xp2mfAD1VcIHSZ4SLWGV1zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@starknet-io/get-starknet-discovery": "^5.0.0",
+        "@starknet-io/get-starknet-virtual-wallet": "^5.0.0",
+        "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
+        "@starknet-io/get-starknet-wallets": "^5.0.0"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-discovery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-discovery/-/get-starknet-discovery-5.0.0.tgz",
+      "integrity": "sha512-b40ZfhbisiEonxWLe/naOraZvNc1hfhy4TEs0TP/cYppfECDhBKncvvFTGu++/rm+xV3SjmSzwNQGQmIn5DMLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@starknet-io/get-starknet-virtual-wallet": "^5.0.0",
+        "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
+        "@starknet-io/types-js": "^0.7.10",
+        "@wallet-standard/base": "^1.1.0"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-discovery/node_modules/@starknet-io/types-js": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
+      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/get-starknet-virtual-wallet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-virtual-wallet/-/get-starknet-virtual-wallet-5.0.0.tgz",
+      "integrity": "sha512-ne9Svr0tHj7a5OJOvC82ewth/GJTa78Gal/iiiRzQmvIDpZcu+nzrPAi350RKEtErxjG5rZSPv2DLz7VBClN0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "^0.12.0",
+        "@starknet-io/get-starknet-wallet-standard": "5.0.0",
+        "@starknet-io/types-js": "^0.7.10",
+        "@wallet-standard/base": "^1.1.0",
+        "@wallet-standard/features": "^1.1.0",
+        "async-mutex": "^0.5.0",
+        "viem": "^2.27.2"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-virtual-wallet/node_modules/@starknet-io/types-js": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
+      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/get-starknet-virtual-wallet/node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-virtual-wallet/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/@starknet-io/get-starknet-wallet-standard": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0.tgz",
@@ -15598,6 +15923,21 @@
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
       "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/get-starknet-wallets": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallets/-/get-starknet-wallets-5.0.0.tgz",
+      "integrity": "sha512-fuywFgoal4Al2KdFQCNTYgioK0ubu3cP+mM6OxE8ti78Nmd9ySlh78LwdKNXIp2Alq4kaQ5XMf6HMgkStCWhkw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/starknet-types-010": {
+      "name": "@starknet-io/types-js",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.0.tgz",
+      "integrity": "sha512-7ALSydz6pq3YIOpq5a7OkkxqwJciMc9Nlph0OGjhcC3xX0xH30XgizmziLyYVN10oO9+BJk8M9KbJjpzdbtRSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-0101": {
@@ -15674,84 +16014,16 @@
         "node": ">=14.16"
       }
     },
-    "node_modules/@telegram-apps/bridge": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/bridge/-/bridge-1.9.2.tgz",
-      "integrity": "sha512-SJLcNWLXhbbZr9MiqFH/g2ceuitSJKMxUIZysK4zUNyTUNuonrQG80Q/yrO+XiNbKUj8WdDNM86NBARhuyyinQ==",
-      "deprecated": "This package is not supported anymore. Use @tma.js/bridge instead",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@telegram-apps/signals": "^1.1.1",
-        "@telegram-apps/toolkit": "^1.1.1",
-        "@telegram-apps/transformers": "^1.2.2",
-        "@telegram-apps/types": "^1.2.1"
-      }
-    },
-    "node_modules/@telegram-apps/navigation": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/navigation/-/navigation-1.0.14.tgz",
-      "integrity": "sha512-bqNgF/J8Po7ZtsELm3E1a6aPr7awwxO3sIqD8J6u12urOlGoW5+1KxKKbkPa58mgXuQdsltd8apI+OVy0IYiUA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@telegram-apps/sdk": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/sdk/-/sdk-2.11.3.tgz",
-      "integrity": "sha512-KdULzgRe1gcR8B3Z/t3hQrEaDmLGrfsL2IePtPP6ehtMn5tT0uPfnjtDLjDNQMyI7D4Tv2ZOzvDx45wOhhreXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@telegram-apps/bridge": "^1.9.2",
-        "@telegram-apps/navigation": "^1.0.13",
-        "@telegram-apps/signals": "^1.1.1",
-        "@telegram-apps/toolkit": "^1.1.1",
-        "@telegram-apps/transformers": "^1.2.2"
-      }
-    },
-    "node_modules/@telegram-apps/signals": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/signals/-/signals-1.1.2.tgz",
-      "integrity": "sha512-1P1kdCLX7MfETGPxH7f3UZKIsdE7Tz5S7QmN4Km1sbYQMakD5Bi1NecSMR7/wnHp50gWMI1JzENcMtCEmouhSg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@telegram-apps/toolkit": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/toolkit/-/toolkit-1.1.1.tgz",
-      "integrity": "sha512-+vhKx6ngfvjyTE6Xagl3z1TPVbfx5s7xAkcYzCdHYUo6T60jLIqLgyZMcI1UPoIAMuMu1pHoO+p8QNCj/+tFmw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@telegram-apps/transformers": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/transformers/-/transformers-1.2.2.tgz",
-      "integrity": "sha512-vvMwXckd1D7Ozc0h66PSUwF5QLrRV9HlGJFFeBuUex8QEk5mSPtsJkLiqB8aBbwuFDa91+TUSM/CxqPZO/e9YQ==",
-      "deprecated": "This package is not supported anymore. Use @tma.js/transfomers instead",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@telegram-apps/toolkit": "^1.1.1",
-        "@telegram-apps/types": "^1.2.1"
-      }
-    },
-    "node_modules/@telegram-apps/types": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/types/-/types-1.2.1.tgz",
-      "integrity": "sha512-so4HLh7clur0YyMthi9KVIgWoGpZdXlFOuQjk3+Q5NAvJZ11nAheBSwPlGw/Ko92+zwvrSBE/lQyN2+p17RP+w==",
-      "deprecated": "This package is not supported anymore. Use @tma.js/types instead",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@turnkey/api-key-stamper": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@turnkey/api-key-stamper/-/api-key-stamper-0.4.5.tgz",
-      "integrity": "sha512-8UeYt/2WtMrK2uSFzjiRXdCVc9SmKlMVuA4f1Z+SlxcsW0wlEpNM/7bd8N4VVVAjoE8Yy50Vhk3ylfQFtlaKsQ==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@turnkey/api-key-stamper/-/api-key-stamper-0.6.5.tgz",
+      "integrity": "sha512-dSINHLIzYVw+ZNLwjM1wnEYFkYHPjQDSi43opCUhvow/ws6Fsn6gWkYpzbH+6Ej3rvSJTuaTwsld+dsTG/3HnA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.3.0",
-        "@turnkey/encoding": "0.4.0",
+        "@turnkey/crypto": "2.8.14",
+        "@turnkey/encoding": "0.6.0",
         "sha256-uint8array": "^0.10.7"
       },
       "engines": {
@@ -15759,153 +16031,154 @@
       }
     },
     "node_modules/@turnkey/crypto": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@turnkey/crypto/-/crypto-2.3.1.tgz",
-      "integrity": "sha512-fHKCw0inuThEKIpZnC8pvz16egZHf08wES0LdSkM9XrGDcI7p0eqF7nAHgfAMW/0qNVZD8AKW+g/5O97HBwZ4w==",
+      "version": "2.8.14",
+      "resolved": "https://registry.npmjs.org/@turnkey/crypto/-/crypto-2.8.14.tgz",
+      "integrity": "sha512-UZU+DEwhSUyyMHC9VZbp5av8NY/IJsfJ+g1E4dndQjMSAJd5NPKGS7sItlBy1ifN6wBb9JP5AcvmcfCdCfj9bw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/ciphers": "0.5.3",
-        "@noble/curves": "1.4.0",
-        "@noble/hashes": "1.4.0",
-        "@turnkey/encoding": "0.4.0",
-        "bs58": "^5.0.0",
-        "bs58check": "3.0.1"
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.0",
+        "@noble/hashes": "1.8.0",
+        "@peculiar/x509": "1.12.3",
+        "@turnkey/encoding": "0.6.0",
+        "@turnkey/sdk-types": "0.14.0",
+        "borsh": "2.0.0",
+        "cbor-js": "0.1.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@turnkey/crypto/node_modules/@noble/ciphers": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.5.3.tgz",
-      "integrity": "sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@turnkey/crypto/node_modules/@noble/curves": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.0.tgz",
+      "integrity": "sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.8.0"
       },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@turnkey/crypto/node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@turnkey/crypto/node_modules/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+    "node_modules/@turnkey/crypto/node_modules/borsh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-2.0.0.tgz",
+      "integrity": "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@turnkey/crypto/node_modules/bs58": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^4.0.0"
-      }
+      "license": "Apache-2.0"
     },
     "node_modules/@turnkey/encoding": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@turnkey/encoding/-/encoding-0.4.0.tgz",
-      "integrity": "sha512-ptLgcpWVt34KTPx0omF2QLJrosW6I//clCJ4G2+yngYFCzrdR0yBchV/BOcfME67mK1v3MmauyXl9AAnQTmB4Q==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@turnkey/encoding/-/encoding-0.6.0.tgz",
+      "integrity": "sha512-IC8qXvy36+iGAeiaVIuJvB35uU2Ld/RAWI/DRTKS+ttBej0GXhOn48Ouu5mlca4jt8ZEuwXmDVv74A8uBQclsA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "bs58": "6.0.0",
+        "bs58check": "4.0.0"
+      },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@turnkey/http": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@turnkey/http/-/http-3.3.0.tgz",
-      "integrity": "sha512-m1fP8aqQcI0U4j7Gw89UbavavWP7AWGmEwoJl5nBhQz88mtep6AaZTsUoDDU4HXg0ch+aQ2/lfl0KFPp8s2u5Q==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@turnkey/http/-/http-3.18.1.tgz",
+      "integrity": "sha512-KXhDAtohx3PPRigdU0qjdgSTuomD0xl3mONly5hn8/jgrp0Gs7BKXv0OGiw/3Sj02IPmlza3SRWBKGtWyGwNmg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@turnkey/api-key-stamper": "0.4.5",
-        "@turnkey/encoding": "0.4.0",
-        "@turnkey/webauthn-stamper": "0.5.0",
+        "@turnkey/api-key-stamper": "0.6.5",
+        "@turnkey/encoding": "0.6.0",
+        "@turnkey/webauthn-stamper": "0.6.0",
         "cross-fetch": "^3.1.5"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@turnkey/iframe-stamper": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@turnkey/iframe-stamper/-/iframe-stamper-2.5.0.tgz",
-      "integrity": "sha512-XjntbA5CNjxGRH+loceAlVLL9PG9Q4Y7p5zjBm4DeKclhD6lpUl9h8INArMEXIFbfLwLjjS6Q+SmQG4BHvNY6A==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@turnkey/iframe-stamper/-/iframe-stamper-2.11.0.tgz",
+      "integrity": "sha512-Iyf4W4S4Hx/RVsXl07PkRTh3g5Ca+vpN6SdUbRy8lt9IQZAJel/vxAk9XMyB7utX9TJx+icSjNYHvC0XGqJ47A==",
       "dev": true,
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@turnkey/indexed-db-stamper": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@turnkey/indexed-db-stamper/-/indexed-db-stamper-1.2.6.tgz",
+      "integrity": "sha512-RSlCpH96e46PYgc029/TK3nE/HOW4QgKo9bXIYjoUR8J7+xkq+0Z0wjHrp27Yn3PbW8743hEppqK9jxsYc8ptA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@turnkey/api-key-stamper": "0.6.5",
+        "@turnkey/encoding": "0.6.0"
+      },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@turnkey/sdk-browser": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@turnkey/sdk-browser/-/sdk-browser-4.3.0.tgz",
-      "integrity": "sha512-TBAWpA28PnqFOeD45Ljzq5RfAabj4Qlnvo1toekt+yf6Hk13Nsm6R5FEiivHUMSNcvKBAwf5uQg+MPbBndymlQ==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/@turnkey/sdk-browser/-/sdk-browser-5.16.1.tgz",
+      "integrity": "sha512-AXBUJVW83nZKnSVNUH235dbsu4S+a4F0Swo25Fm/gHWKPVh4nvpT/Pr2cr6PVh3UR15p787AVUkxO9ZgtNclPw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@turnkey/api-key-stamper": "0.4.5",
-        "@turnkey/crypto": "2.3.1",
-        "@turnkey/encoding": "0.4.0",
-        "@turnkey/http": "3.3.0",
-        "@turnkey/iframe-stamper": "2.5.0",
-        "@turnkey/wallet-stamper": "1.0.3",
-        "@turnkey/webauthn-stamper": "0.5.0",
-        "bs58check": "^3.0.1",
+        "@turnkey/api-key-stamper": "0.6.5",
+        "@turnkey/crypto": "2.8.14",
+        "@turnkey/encoding": "0.6.0",
+        "@turnkey/http": "3.18.1",
+        "@turnkey/iframe-stamper": "2.11.0",
+        "@turnkey/indexed-db-stamper": "1.2.6",
+        "@turnkey/sdk-types": "0.14.0",
+        "@turnkey/wallet-stamper": "1.1.16",
+        "@turnkey/webauthn-stamper": "0.6.0",
         "buffer": "^6.0.3",
         "cross-fetch": "^3.1.5",
-        "hpke-js": "^1.2.7"
+        "hpke-js": "^1.6.5"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@turnkey/sdk-types": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@turnkey/sdk-types/-/sdk-types-0.14.0.tgz",
+      "integrity": "sha512-FLN4p3Jc3rBMvM17tgFrO4VpqkQN0RgWtLknqcqpLuNgTJ7oqgvzm42YIrzvBlW6DPsnFjVZMzc4yCfaRN7Lmg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@turnkey/wallet-stamper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@turnkey/wallet-stamper/-/wallet-stamper-1.0.3.tgz",
-      "integrity": "sha512-8DMuVPo/u8oIzQ9Snsa24ZQO3nXVMfpd8VnlPLfZiW2jjZHPFyBGCJOYSArfp+W2xoudpYVu//JElBAVxk/u/g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@turnkey/wallet-stamper/-/wallet-stamper-1.1.16.tgz",
+      "integrity": "sha512-IdgoIRQr5RoiHAPnVag2QyaYg6cmmkZQs1rOig57/tQ/fXdPsC1+2660RisIAvv69ZFrArG8Z8wHaGSQMkStlw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@turnkey/crypto": "2.3.1",
-        "@turnkey/encoding": "0.4.0"
+        "@turnkey/crypto": "2.8.14",
+        "@turnkey/encoding": "0.6.0"
       },
       "optionalDependencies": {
         "viem": "^2.21.35"
       }
     },
     "node_modules/@turnkey/webauthn-stamper": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@turnkey/webauthn-stamper/-/webauthn-stamper-0.5.0.tgz",
-      "integrity": "sha512-iUbTUwD4f4ibdLy5PWWb7ITEz4S4VAP9/mNjFhoRY3cKVVTDfmykrVTKjPOIHWzDgAmLtgrLvySIIC9ZBVENBw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@turnkey/webauthn-stamper/-/webauthn-stamper-0.6.0.tgz",
+      "integrity": "sha512-jdN17QEnn7RBykEOhtKIialWmDjnDAH8DzbyITwn8jsKcwT1TBNYge89hTUTjbdsDLBAqQw8cHujPdy0RaAqvw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17722,6 +17995,28 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/asn1js/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -18642,31 +18937,14 @@
       }
     },
     "node_modules/bs58check": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
-      "integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
-        "bs58": "^5.0.0"
-      }
-    },
-    "node_modules/bs58check/node_modules/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/bs58check/node_modules/bs58": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^4.0.0"
+        "bs58": "^6.0.0"
       }
     },
     "node_modules/bser": {
@@ -19044,6 +19322,13 @@
         "@cbor-extract/cbor-extract-linux-x64": "2.2.0",
         "@cbor-extract/cbor-extract-win32-x64": "2.2.0"
       }
+    },
+    "node_modules/cbor-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cbor-js/-/cbor-js-0.1.0.tgz",
+      "integrity": "sha512-7sQ/TvDZPl7csT1Sif9G0+MA0I0JOVah8+wWlJVQdVEgIbCzlN/ab3x+uvMNsc34TUvO6osQTAmB2ls80JX6tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cbor-x": {
       "version": "1.6.0",
@@ -29077,6 +29362,33 @@
         "node": ">=6"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvtsutils/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/qrcode": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
@@ -29988,6 +30300,13 @@
       "dependencies": {
         "esprima": "~4.0.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -32630,6 +32949,19 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/tunnel-agent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
       },
       "devDependencies": {
         "@0no-co/graphql.web": "^1.2.0",
-        "@avnu/avnu-sdk": "^4.1.0-rc.0",
-        "@cartridge/controller": "^0.13.9",
+        "@avnu/avnu-sdk": "4.2.0-next.2",
+        "@cartridge/controller": "0.13.9",
         "@eslint/js": "^9.39.2",
         "@fatsolutions/tongo-sdk": "^1.3.2",
         "@hyperlane-xyz/registry": "^19.4.0",
@@ -44,7 +44,7 @@
         "vitest": "^4.0.17"
       },
       "peerDependencies": {
-        "@avnu/avnu-sdk": "^4.1.0-rc.0",
+        "@avnu/avnu-sdk": "^4.2.0-next.2",
         "@cartridge/controller": "^0.13.9",
         "@fatsolutions/tongo-sdk": "^1.3.2",
         "@hyperlane-xyz/registry": "^19.4.0",
@@ -332,23 +332,23 @@
       }
     },
     "node_modules/@avnu/avnu-sdk": {
-      "version": "4.1.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@avnu/avnu-sdk/-/avnu-sdk-4.1.0-rc.0.tgz",
-      "integrity": "sha512-f/y2898hzhjXpPk5e2mxcyHbbbBwqq9EdJLtjku04BlgkZwk9qfviMBgRPw2oKGTbGu9nd+WSKI+rNBfLUSVCg==",
+      "version": "4.2.0-next.2",
+      "resolved": "https://registry.npmjs.org/@avnu/avnu-sdk/-/avnu-sdk-4.2.0-next.2.tgz",
+      "integrity": "sha512-TBjJ1AL4PuYI/zf78I00eZkHZn2BBO+12VRvwzolmIZESFbVk2ijaJ5ZRncjLbQ55O/QyUEj9M7pkpaCgDRtrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "dayjs": "^1.11.19",
         "moment": "^2.30.1",
         "qs": "^6.14.1",
-        "zod": "^4.2.1"
+        "zod": "^4.3.6"
       },
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "ethers": "^6.15.0",
-        "starknet": "^8.9.1 || ^9.0.0"
+        "starknet": "^10.0.0"
       }
     },
     "node_modules/@avnu/avnu-sdk/node_modules/dayjs": {
@@ -3268,6 +3268,26 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@cartridge/controller/node_modules/@starknet-io/get-starknet-wallet-standard": {
+      "version": "5.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0-beta.0.tgz",
+      "integrity": "sha512-1QBmWnd76KzKwnVlRXLh58wtd1e0P5fyOhs0bCCjivTpGJ2nUPRvTgmzVJStNBcuQ7617UfB5qIyBnkig31TmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@starknet-io/types-js": "^0.7.10",
+        "@wallet-standard/base": "^1.1.0",
+        "@wallet-standard/features": "^1.1.0",
+        "ox": "^0.4.4"
+      }
+    },
+    "node_modules/@cartridge/controller/node_modules/@starknet-io/get-starknet-wallet-standard/node_modules/@starknet-io/types-js": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
+      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cartridge/controller/node_modules/starknet": {
       "version": "8.9.2",
@@ -7327,19 +7347,6 @@
         "@scure/starknet": "1.1.0"
       }
     },
-    "node_modules/@fatsolutions/she/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@fatsolutions/she/node_modules/@noble/curves": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
@@ -7397,19 +7404,6 @@
       },
       "bin": {
         "tongo": "dist/cli.js"
-      }
-    },
-    "node_modules/@fatsolutions/tongo-sdk/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@fatsolutions/tongo-sdk/node_modules/@noble/curves": {
@@ -7752,22 +7746,22 @@
       }
     },
     "node_modules/@hpke/chacha20poly1305": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@hpke/chacha20poly1305/-/chacha20poly1305-1.7.1.tgz",
-      "integrity": "sha512-Zp8IwRIkdCucu877wCNqDp3B8yOhAnAah/YDDkO94pPr/KKV7IGnBbpwIjDB3BsAySWBMrhhdE0JKYw3N4FCag==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@hpke/chacha20poly1305/-/chacha20poly1305-1.8.0.tgz",
+      "integrity": "sha512-FcBfAQ+Y99vMNJP2yrZ9wpL8V0GOwp1+zMyzvc6alasrBygfFjFm1yeUtyADJCu/27C3Lm5mJzx6u7pwg+cX5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hpke/common": "^1.8.1"
+        "@hpke/common": "^1.10.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@hpke/common": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@hpke/common/-/common-1.9.0.tgz",
-      "integrity": "sha512-Sdxj4KqtmBt8FiwRkNLxXF+peqLR3FwVxtnsemiiEzClgslckRpFv3yK8mchoCwvyRwLOMS3Y2Z9ND2bq3sRVg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@hpke/common/-/common-1.10.1.tgz",
+      "integrity": "sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7775,39 +7769,39 @@
       }
     },
     "node_modules/@hpke/core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@hpke/core/-/core-1.8.0.tgz",
-      "integrity": "sha512-yHuo+2q4HSPUFuxcg87Kiy7QZRk4IeR+cwBB0qW8fHnr71bnRCArM39Cq1bWHBt75gTyeERGD/v1H14yPB2wyw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@hpke/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-pFxWl1nNJeQCSUFs7+GAblHvXBCjn9EPN65vdKlYQil2aURaRxfGMO6vBKGqm1YHTKwiAxJQNEI70PbSowMP9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hpke/common": "^1.9.0"
+        "@hpke/common": "^1.10.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@hpke/dhkem-x25519": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@hpke/dhkem-x25519/-/dhkem-x25519-1.7.0.tgz",
-      "integrity": "sha512-mgqkCUj82jBoKSa55VG/QAih4d5npalRd3uu/U/t3PvvrSbrYjDnok6PDxFwRPh+9aUNRX0tBtxupqtAiT+P1A==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@hpke/dhkem-x25519/-/dhkem-x25519-1.8.0.tgz",
+      "integrity": "sha512-S1MWWkAfu+TFxySgv5+2P3O4Mx/jk7BsoplzQaA1s3sfUJVJ2UsZsSzSsMc+FXJumLXncoJFlO6mK6mDGspfmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hpke/common": "^1.9.0"
+        "@hpke/common": "^1.10.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@hpke/dhkem-x448": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@hpke/dhkem-x448/-/dhkem-x448-1.7.0.tgz",
-      "integrity": "sha512-12Qik0A5srTp5D2RbwYorF4OyJePN2Ccej8pM45VbZampZdM6qFmZ2I3vWjUaOcN4L+CgP8U2uzq1g1dpc5MBw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@hpke/dhkem-x448/-/dhkem-x448-1.8.0.tgz",
+      "integrity": "sha512-mFfnZfgp4OKkUIS/FKikfUgdnDKRy25ytCKBQiV+N+HbYy3I4v4ZCPBQ69QL+TYmKmCZJeUEnYeS5K+OBRP+Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hpke/common": "^1.9.0"
+        "@hpke/common": "^1.10.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -9532,11 +9526,14 @@
       }
     },
     "node_modules/@noble/ciphers": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.5.3.tgz",
-      "integrity": "sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -11444,19 +11441,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/core": {
       "version": "2.23.2",
       "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.2.tgz",
@@ -11755,19 +11739,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/@reown/appkit-utils/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@reown/appkit-utils/node_modules/@walletconnect/core": {
       "version": "2.23.2",
       "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.2.tgz",
@@ -12005,19 +11976,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@reown/appkit/node_modules/@walletconnect/core": {
@@ -15606,10 +15564,9 @@
       "license": "MIT"
     },
     "node_modules/@starknet-io/get-starknet-wallet-standard": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0-beta.0.tgz",
-      "integrity": "sha512-1QBmWnd76KzKwnVlRXLh58wtd1e0P5fyOhs0bCCjivTpGJ2nUPRvTgmzVJStNBcuQ7617UfB5qIyBnkig31TmQ==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0.tgz",
+      "integrity": "sha512-isDNGDlp16W24HE4IuweYXLDRZN0JbsDnazAieeKXE87Mn+jqhsjgTsMxcwWTjX7v906Bjz39FiDjGUddnr36g==",
       "license": "MIT",
       "dependencies": {
         "@starknet-io/types-js": "^0.7.10",
@@ -15641,7 +15598,6 @@
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
       "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-0101": {
@@ -15818,6 +15774,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@turnkey/crypto/node_modules/@noble/ciphers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.5.3.tgz",
+      "integrity": "sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@turnkey/crypto/node_modules/@noble/curves": {
@@ -17114,19 +17080,6 @@
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@walletconnect/utils/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
     },
     "node_modules/@walletconnect/utils/node_modules/abitype": {
       "version": "1.2.3",
@@ -24077,17 +24030,17 @@
       "license": "ISC"
     },
     "node_modules/hpke-js": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/hpke-js/-/hpke-js-1.7.0.tgz",
-      "integrity": "sha512-Ix6O3U7XmCs6Jc+8NkvyxTvk2DXliwYZ8+fDNjOtXC769ypslNIDwMHucaoCDALSyqqr3/pnpDwDx7Icac/iCg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/hpke-js/-/hpke-js-1.8.0.tgz",
+      "integrity": "sha512-N0PFQlUQsIPS9++nUNn2ZsxTPSv8pONyyrXIGZl0iiherRfS0XW1SvTd+RmepD0TN1S9zzTJkEutMIWWYt0/4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hpke/chacha20poly1305": "^1.7.0",
-        "@hpke/common": "^1.9.0",
-        "@hpke/core": "^1.8.0",
-        "@hpke/dhkem-x25519": "^1.7.0",
-        "@hpke/dhkem-x448": "^1.7.0"
+        "@hpke/chacha20poly1305": "^1.8.0",
+        "@hpke/common": "^1.10.0",
+        "@hpke/core": "^1.9.0",
+        "@hpke/dhkem-x25519": "^1.8.0",
+        "@hpke/dhkem-x448": "^1.8.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -31605,24 +31558,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/starknet/node_modules/@starknet-io/get-starknet-wallet-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0.tgz",
-      "integrity": "sha512-isDNGDlp16W24HE4IuweYXLDRZN0JbsDnazAieeKXE87Mn+jqhsjgTsMxcwWTjX7v906Bjz39FiDjGUddnr36g==",
-      "license": "MIT",
-      "dependencies": {
-        "@starknet-io/types-js": "^0.7.10",
-        "@wallet-standard/base": "^1.1.0",
-        "@wallet-standard/features": "^1.1.0",
-        "ox": "^0.4.4"
-      }
-    },
-    "node_modules/starknet/node_modules/@starknet-io/types-js": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
-      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
-      "license": "MIT"
-    },
     "node_modules/starkzap": {
       "resolved": "",
       "link": true
@@ -33525,19 +33460,6 @@
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/viem/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
     },
     "node_modules/viem/node_modules/@noble/curves": {
       "version": "1.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@starknet-io/starknet-types-0103": "npm:@starknet-io/types-js@0.10.3",
         "starknet": "^10.5.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "vitest": "^4.0.17"
   },
   "dependencies": {
+    "@starknet-io/starknet-types-0103": "npm:@starknet-io/types-js@0.10.3",
     "starknet": "^10.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     }
   },
   "peerDependencies": {
-    "@avnu/avnu-sdk": "^4.1.0-rc.0",
-    "@cartridge/controller": "^0.13.9",
+    "@avnu/avnu-sdk": "^4.2.0-next.2",
+    "@cartridge/controller": "^0.13.13",
     "@fatsolutions/tongo-sdk": "^1.3.2",
     "@hyperlane-xyz/registry": "^19.4.0",
     "@hyperlane-xyz/sdk": "^14.4.0",
@@ -107,8 +107,8 @@
   },
   "devDependencies": {
     "@0no-co/graphql.web": "^1.2.0",
-    "@avnu/avnu-sdk": "^4.1.0-rc.0",
-    "@cartridge/controller": "^0.13.9",
+    "@avnu/avnu-sdk": "4.2.0-next.2",
+    "@cartridge/controller": "^0.13.13",
     "@eslint/js": "^9.39.2",
     "@fatsolutions/tongo-sdk": "^1.3.2",
     "@hyperlane-xyz/registry": "^19.4.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "ethers": "^6.16.0",
     "husky": "^9.1.7",
     "prettier": "3.8.1",
-    "starknet-devnet": "^0.7.2",
+    "starknet-devnet": "^0.8.2",
     "tsc-alias": "^1.8.16",
     "tsx": "^4.21.0",
     "typedoc": "^0.28.16",
@@ -135,6 +135,6 @@
     "vitest": "^4.0.17"
   },
   "dependencies": {
-    "starknet": "^9.2.1"
+    "starknet": "^10.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@avnu/avnu-sdk": "^4.2.0-next.2",
     "@cartridge/controller": "^0.13.13",
-    "@fatsolutions/tongo-sdk": "^1.3.2",
+    "@fatsolutions/tongo-sdk": "^1.5.0",
     "@hyperlane-xyz/registry": "^19.4.0",
     "@hyperlane-xyz/sdk": "^14.4.0",
     "@hyperlane-xyz/utils": "^14.4.0",
@@ -110,7 +110,7 @@
     "@avnu/avnu-sdk": "4.2.0-next.2",
     "@cartridge/controller": "^0.13.13",
     "@eslint/js": "^9.39.2",
-    "@fatsolutions/tongo-sdk": "^1.3.2",
+    "@fatsolutions/tongo-sdk": "^1.5.0",
     "@hyperlane-xyz/registry": "^19.4.0",
     "@hyperlane-xyz/sdk": "^14.4.0",
     "@hyperlane-xyz/utils": "^14.4.0",

--- a/packages/native/metro.cjs
+++ b/packages/native/metro.cjs
@@ -21,6 +21,19 @@ const NEEDS_EXPORTS = (name) =>
 const DISABLE_EXPORTS = (name) =>
   name === "isows" || name.startsWith("zustand");
 
+// Browser-only packages that starkzap core reaches through a lazy `import()`.
+// The call never runs on React Native, but Metro still walks it into the graph,
+// so the package has to at least *bundle*. @cartridge/controller cannot: it
+// drives a browser keychain (iframe/popup) and its dist carries a
+// module-federation loader that calls `import(variable)`, which Metro rejects
+// outright ("Invalid call at line 4: import(t)"). Native apps use
+// `registerCartridgeTsAdapter` instead. Stubbing keeps the graph buildable, and
+// core's own module-shape check turns the empty module into its existing
+// "Cartridge integration requires '@cartridge/controller'" error if the web
+// flow is ever called from RN.
+const WEB_ONLY = (name) =>
+  name === "@cartridge/controller" || name.startsWith("@cartridge/controller/");
+
 // Polyfills hoisted to run before the app entry (when present in the graph).
 // REQUIRED: needed by every StarkZap flow — starknet hashes an entrypoint
 //   selector via TextEncoder on every contract read/write. Warned about when
@@ -166,6 +179,10 @@ function withStarkzap(config) {
       ? moduleName.slice(5)
       : moduleName;
     if (ALL_NODE_BUILTINS.has(bare) && !hasNpmPackage.has(bare)) {
+      return { type: "empty" };
+    }
+
+    if (WEB_ONLY(moduleName)) {
       return { type: "empty" };
     }
 

--- a/packages/native/src/cartridge/types.ts
+++ b/packages/native/src/cartridge/types.ts
@@ -3,6 +3,7 @@ import type {
   EstimateFeeResponseOverhead,
   PaymasterTimeBounds,
   Signature,
+  SimulateTransactionOverheadResponse,
   TypedData,
 } from "starknet";
 
@@ -115,9 +116,11 @@ export interface CartridgeNativeAccountLike {
     }
   ) => Promise<CartridgeExecutionResult>;
   signMessage?: (typedData: TypedData) => Promise<Signature>;
+  // starknet v10 returns `{ simulated_transactions }`
+  // If older starknet is resolved, accept a bare array.
   simulateTransaction?: (
     invocations: Array<{ type: "INVOKE"; payload: Call[] }>
-  ) => Promise<unknown[]>;
+  ) => Promise<SimulateTransactionOverheadResponse | unknown[]>;
   estimateInvokeFee?: (calls: Call[]) => Promise<EstimateFeeResponseOverhead>;
 }
 

--- a/packages/native/src/wallet/cartridge.ts
+++ b/packages/native/src/wallet/cartridge.ts
@@ -246,9 +246,11 @@ class NativeCartridgeAccount extends Account {
     if (!this.session.account.simulateTransaction) {
       throw unsupportedSessionFeature("simulateTransaction");
     }
-    return this.session.account.simulateTransaction(
-      invocations
-    ) as Promise<SimulateTransactionOverheadResponse>;
+    const res = await this.session.account.simulateTransaction(invocations);
+    // Normalize the legacy bare-array shape to v10's object shape.
+    return (
+      Array.isArray(res) ? { simulated_transactions: res } : res
+    ) as SimulateTransactionOverheadResponse;
   }
 
   override async signMessage(typedData: TypedData): Promise<Signature> {
@@ -420,7 +422,10 @@ export class NativeCartridgeWallet extends BaseWallet {
       const simulation = await simulate([
         { type: "INVOKE", payload: options.calls },
       ]);
-      const first = simulation[0] as
+      const results = Array.isArray(simulation)
+        ? simulation
+        : (simulation?.simulated_transactions ?? []);
+      const first = results[0] as
         | {
             transaction_trace?: {
               execute_invocation?: { revert_reason?: string };

--- a/packages/native/src/wallet/cartridge.ts
+++ b/packages/native/src/wallet/cartridge.ts
@@ -1,4 +1,4 @@
-import { BaseWallet, Tx, fromAddress } from "starkzap";
+import { BaseWallet, Tx, fromAddress, preflightFromSimulation } from "starkzap";
 import type {
   BridgingConfig,
   ChainId,
@@ -422,22 +422,7 @@ export class NativeCartridgeWallet extends BaseWallet {
       const simulation = await simulate([
         { type: "INVOKE", payload: options.calls },
       ]);
-      const results = Array.isArray(simulation)
-        ? simulation
-        : (simulation?.simulated_transactions ?? []);
-      const first = results[0] as
-        | {
-            transaction_trace?: {
-              execute_invocation?: { revert_reason?: string };
-            };
-          }
-        | undefined;
-      const reason =
-        first?.transaction_trace?.execute_invocation?.revert_reason;
-      if (reason) {
-        return { ok: false, reason };
-      }
-      return { ok: true };
+      return preflightFromSimulation(simulation);
     } catch (error) {
       return {
         ok: false,

--- a/src/bridge/ethereum/canonical/CanonicalEthereumBridge.ts
+++ b/src/bridge/ethereum/canonical/CanonicalEthereumBridge.ts
@@ -18,7 +18,8 @@ import {
 } from "@/types";
 import { ethereumAddress } from "@/bridge/ethereum/EtherToken";
 import { type ContractTransaction, type InterfaceAbi } from "ethers";
-import { type Call, CallData, RPC, uint256 } from "starknet";
+import { type Call, CallData, uint256 } from "starknet";
+import type { L1Message } from "@starknet-io/starknet-types-0103";
 import { FeeErrorCause } from "@/types/errors";
 import type { WalletInterface } from "@/wallet";
 import {
@@ -243,7 +244,7 @@ export class CanonicalEthereumBridge extends ContractRoutedEthereumBridge {
   ): Promise<{ fee: Amount; l2FeeError?: FeeErrorCause }> {
     try {
       const { low, high } = uint256.bnToUint256(amount.toBase());
-      const l1Message: RPC.RPCSPEC010.L1Message = {
+      const l1Message: L1Message = {
         from_address: await ethereumAddress(this.bridge),
         to_address: this.bridgeToken.starknetBridge.toString(),
         entry_point_selector: "handle_token_deposit",

--- a/src/bridge/ethereum/lords/LordsBridge.ts
+++ b/src/bridge/ethereum/lords/LordsBridge.ts
@@ -5,7 +5,8 @@ import type { Address, ExternalAddress } from "@/types";
 import { Amount, ContractRoutedEthereumBridgeToken } from "@/types";
 import type { EthereumWalletConfig } from "@/bridge/ethereum/types";
 import type { WalletInterface } from "@/wallet";
-import { type Call, CallData, RPC, uint256 } from "starknet";
+import { type Call, CallData, uint256 } from "starknet";
+import type { L1Message } from "@starknet-io/starknet-types-0103";
 import { FeeErrorCause } from "@/types/errors";
 import LORDS_BRIDGE_ABI from "@/abi/ethereum/lordsBridge.json";
 import { AutoWithdrawFeesHandler } from "@/bridge/utils/auto-withdraw-fees-handler";
@@ -68,7 +69,7 @@ export class LordsBridge extends CanonicalEthereumBridge {
   ): Promise<{ fee: Amount; l2FeeError?: FeeErrorCause }> {
     try {
       const { low, high } = uint256.bnToUint256(amount.toBase());
-      const l1Message: RPC.RPCSPEC010.L1Message = {
+      const l1Message: L1Message = {
         from_address: await ethereumAddress(this.bridge),
         to_address: this.bridgeToken.starknetBridge.toString(),
         entry_point_selector: "handle_deposit",

--- a/src/confidential/tongo.ts
+++ b/src/confidential/tongo.ts
@@ -54,7 +54,7 @@ export class TongoConfidential implements ConfidentialProvider {
   private readonly account: TongoAccount;
 
   constructor(config: ConfidentialConfig) {
-    // Cast needed: starkzap uses starknet v10 while tongo-sdk uses v8.
+    // Cast needed: starkzap uses starknet v10 while tongo-sdk (1.5.0) uses v9.
     // The Provider types are runtime-compatible but differ in private fields.
     this.account = new TongoAccount(
       config.privateKey,

--- a/src/confidential/tongo.ts
+++ b/src/confidential/tongo.ts
@@ -54,7 +54,7 @@ export class TongoConfidential implements ConfidentialProvider {
   private readonly account: TongoAccount;
 
   constructor(config: ConfidentialConfig) {
-    // Cast needed: starkzap uses starknet v9 while tongo-sdk uses v8.
+    // Cast needed: starkzap uses starknet v10 while tongo-sdk uses v8.
     // The Provider types are runtime-compatible but differ in private fields.
     this.account = new TongoAccount(
       config.privateKey,

--- a/src/dca/ekubo.ts
+++ b/src/dca/ekubo.ts
@@ -1,5 +1,6 @@
 import { CallData, cairo, type Call } from "starknet";
 import { fromAddress, type Address, type ChainId } from "@/types";
+import { resolveFetch } from "@/utils";
 import type {
   DcaCancelRequest,
   DcaCreateRequest,
@@ -115,7 +116,7 @@ export class EkuboDcaProvider implements DcaProvider {
   constructor(options: EkuboDcaProviderOptions = {}) {
     this.apiBase = options.apiBase ?? DEFAULT_EKUBO_DCA_API_BASE;
     this.quoteApiBase = options.quoteApiBase ?? DEFAULT_EKUBO_API_BASE;
-    this.fetcher = options.fetcher ?? fetch;
+    this.fetcher = resolveFetch(options.fetcher);
     this.minTvlUsd = options.minTvlUsd ?? 0;
     this.presets = {
       SN_MAIN: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ export type {
 // Wallet
 export { Wallet, AccountProvider, BaseWallet } from "@/wallet";
 export type { WalletInterface, WalletOptions } from "@/wallet";
+// Exported for wallet implementations outside this package (e.g. @starkzap/native).
+export { preflightFromSimulation } from "@/wallet/utils";
 
 // Transaction
 export { Tx, TxBuilder } from "@/tx";

--- a/src/swap/ekubo.ts
+++ b/src/swap/ekubo.ts
@@ -1,4 +1,5 @@
 import { fromAddress, type Address, type ChainId } from "@/types";
+import { resolveFetch } from "@/utils";
 import type {
   PreparedSwap,
   SwapProvider,
@@ -67,7 +68,7 @@ export class EkuboSwapProvider implements SwapProvider {
 
   constructor(options: EkuboSwapProviderOptions = {}) {
     this.apiBase = options.apiBase ?? DEFAULT_EKUBO_API_BASE;
-    this.fetcher = options.fetcher ?? fetch;
+    this.fetcher = resolveFetch(options.fetcher);
   }
 
   supportsChain(chainId: ChainId): boolean {

--- a/src/utils/avnu.ts
+++ b/src/utils/avnu.ts
@@ -60,7 +60,7 @@ export function resolveAvnuApiBases(
 ): AvnuApiBases {
   return {
     SN_MAIN: overrides?.SN_MAIN ?? [sdk.BASE_URL],
-    SN_SEPOLIA: overrides?.SN_SEPOLIA ?? [sdk.SEPOLIA_BASE_URL, sdk.BASE_URL],
+    SN_SEPOLIA: overrides?.SN_SEPOLIA ?? [sdk.SEPOLIA_BASE_URL],
   };
 }
 

--- a/src/wallet/accounts/provider.ts
+++ b/src/wallet/accounts/provider.ts
@@ -1,5 +1,5 @@
 import { hash, num, type Calldata } from "starknet";
-import type { PAYMASTER_API } from "@starknet-io/starknet-types-010";
+import type { PAYMASTER_API } from "@starknet-io/starknet-types-0103";
 import { OpenZeppelinPreset } from "@/account";
 import type { SignerInterface } from "@/signer";
 import { type Address, fromAddress } from "@/types";

--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -162,17 +162,7 @@ export async function preflightTransaction(
       { type: "INVOKE", payload: calls },
     ]);
 
-    // Response shape depends on the resolved starknet version: v10 returns
-    // `{ simulated_transactions }`, while v8/v9 returns a bare array.
-    const results = Array.isArray(simulation)
-      ? simulation
-      : (simulation?.simulated_transactions ?? []);
-    const revertReason = extractRevertReason(results[0]);
-    if (revertReason !== null) {
-      return { ok: false, reason: revertReason };
-    }
-
-    return { ok: true };
+    return preflightFromSimulation(simulation);
   } catch (error) {
     return {
       ok: false,
@@ -196,6 +186,29 @@ export function paymasterDetails(options: {
     ...(options.timeBounds && { timeBounds: options.timeBounds }),
     ...(options.deploymentData && { deploymentData: options.deploymentData }),
   };
+}
+
+/**
+ * Derive a preflight verdict from a raw `simulateTransaction` response.
+ *
+ * Response shape depends on the resolved starknet version: v10 returns
+ * `{ simulated_transactions }`, while v8/v9 returns a bare array. An
+ * unrecognized or empty response is treated as a pass — preflight is a
+ * best-effort revert check, so an unreadable simulation must not block a
+ * transaction that would otherwise succeed.
+ */
+export function preflightFromSimulation(simulation: unknown): PreflightResult {
+  const results = Array.isArray(simulation)
+    ? simulation
+    : isRecord(simulation)
+      ? simulation.simulated_transactions
+      : undefined;
+  const revertReason = extractRevertReason(
+    Array.isArray(results) ? results[0] : undefined
+  );
+  return revertReason !== null
+    ? { ok: false, reason: revertReason }
+    : { ok: true };
 }
 
 /**

--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -5,7 +5,7 @@ import {
   type Call,
   type PaymasterTimeBounds,
 } from "starknet";
-import type { PAYMASTER_API } from "@starknet-io/starknet-types-010";
+import type { PAYMASTER_API } from "@starknet-io/starknet-types-0103";
 import { Tx } from "@/tx";
 import { isRecord } from "@/utils/ekubo";
 import type { Address } from "@/types";
@@ -143,7 +143,7 @@ export async function preflightTransaction(
   account: {
     simulateTransaction: (
       invocations: Array<{ type: "INVOKE"; payload: Call[] }>
-    ) => Promise<unknown[]>;
+    ) => Promise<{ simulated_transactions: unknown[] } | unknown[]>;
   },
   options: PreflightOptions
 ): Promise<PreflightResult> {
@@ -162,7 +162,12 @@ export async function preflightTransaction(
       { type: "INVOKE", payload: calls },
     ]);
 
-    const revertReason = extractRevertReason(simulation[0]);
+    // Response shape depends on the resolved starknet version: v10 returns
+    // `{ simulated_transactions }`, while v8/v9 returns a bare array.
+    const results = Array.isArray(simulation)
+      ? simulation
+      : (simulation?.simulated_transactions ?? []);
+    const revertReason = extractRevertReason(results[0]);
     if (revertReason !== null) {
       return { ok: false, reason: revertReason };
     }

--- a/tests/cartridge.test.ts
+++ b/tests/cartridge.test.ts
@@ -350,6 +350,36 @@ describe("CartridgeWallet", () => {
 
       expect(result.ok).toBe(true);
     });
+
+    it("returns the same verdict whichever response shape simulation uses", async () => {
+      const calls = [
+        { contractAddress: "0x123", entrypoint: "transfer", calldata: [] },
+      ];
+      const reverted = [
+        {
+          transaction_trace: {
+            execute_invocation: { revert_reason: "insufficient balance" },
+          },
+        },
+      ];
+
+      // The mock above returns v10's `{ simulated_transactions }`; a session
+      // account resolved against starknet v8/v9 hands back a bare array.
+      for (const simulation of [
+        { simulated_transactions: reverted },
+        reverted,
+      ]) {
+        const wallet = await CartridgeWallet.create();
+        vi.spyOn(wallet.getAccount(), "simulateTransaction").mockResolvedValue(
+          simulation as never
+        );
+
+        await expect(wallet.preflight({ calls })).resolves.toEqual({
+          ok: false,
+          reason: "insufficient balance",
+        });
+      }
+    });
   });
 
   describe("getAccount", () => {

--- a/tests/cartridge.test.ts
+++ b/tests/cartridge.test.ts
@@ -56,13 +56,15 @@ vi.mock("@cartridge/controller", () => {
       type: "invoke",
       invoke: { signature: ["0xsig"] },
     }),
-    simulateTransaction: vi.fn().mockResolvedValue([
-      {
-        transaction_trace: {
-          execute_invocation: {},
+    simulateTransaction: vi.fn().mockResolvedValue({
+      simulated_transactions: [
+        {
+          transaction_trace: {
+            execute_invocation: {},
+          },
         },
-      },
-    ]),
+      ],
+    }),
     estimateInvokeFee: vi.fn().mockResolvedValue({}),
   };
   MockController.prototype.connect = vi

--- a/tests/dca-avnu-provider.test.ts
+++ b/tests/dca-avnu-provider.test.ts
@@ -264,37 +264,30 @@ describe("AvnuDcaProvider", () => {
     expect(request?.frequency.toISOString()).toBe("PT1H");
   });
 
-  it("falls back to the second sepolia endpoint when the first create attempt fails", async () => {
-    avnuMocks.createDcaToCalls
-      .mockRejectedValueOnce(new Error("temporary failure"))
-      .mockResolvedValueOnce({
-        chainId: "SN_SEPOLIA",
-        calls: [
-          {
-            contractAddress: "0x777",
-            entrypoint: "open_dca",
-            calldata: [],
-          },
-        ],
-      });
+  it("does not fall back to the mainnet API for Sepolia when the create attempt fails", async () => {
+    // A mainnet fallback would build DCA calls against mainnet-only contracts
+    // that are not deployed on Sepolia. The Sepolia failure must propagate
+    // without ever reaching the mainnet base.
+    avnuMocks.createDcaToCalls.mockRejectedValue(
+      new Error("temporary failure")
+    );
 
     const provider = new AvnuDcaProvider();
 
-    await provider.prepareCreate(context, {
-      sellToken,
-      buyToken,
-      sellAmount: Amount.parse("2", sellToken),
-      sellAmountPerCycle: Amount.parse("1", sellToken),
-      frequency: "P1D",
-      traderAddress,
-    });
+    await expect(
+      provider.prepareCreate(context, {
+        sellToken,
+        buyToken,
+        sellAmount: Amount.parse("2", sellToken),
+        sellAmountPerCycle: Amount.parse("1", sellToken),
+        frequency: "P1D",
+        traderAddress,
+      })
+    ).rejects.toThrow();
 
-    expect(avnuMocks.createDcaToCalls).toHaveBeenCalledTimes(2);
+    expect(avnuMocks.createDcaToCalls).toHaveBeenCalledTimes(1);
     expect(avnuMocks.createDcaToCalls.mock.calls[0]![1]).toEqual({
       baseUrl: "https://sepolia.api.avnu.fi",
-    });
-    expect(avnuMocks.createDcaToCalls.mock.calls[1]![1]).toEqual({
-      baseUrl: "https://starknet.api.avnu.fi",
     });
   });
 

--- a/tests/integration/globalSetup.ts
+++ b/tests/integration/globalSetup.ts
@@ -2,14 +2,13 @@ import type { TestProject } from "vitest/node";
 import { Devnet } from "starknet-devnet";
 import "dotenv/config";
 import { getChainId } from "../../src/types/config.js";
-import { forkRPC, type TestConfig } from "./shared";
+import { type TestConfig } from "./shared";
 import { RpcProvider } from "starknet";
 
 let devnet: Devnet | null = null;
 
 // Compatibility constants
-const DEVNET_VERSION = "v0.7.2";
-const RPC_VERSION = "v0_10";
+const DEVNET_VERSION = "v0.9.1";
 
 /**
  * Global setup for integration tests.
@@ -24,8 +23,7 @@ const RPC_VERSION = "v0_10";
  * @see https://0xspaceshard.github.io/starknet-devnet/docs/forking
  */
 export default async function setup(project: TestProject) {
-  const forkNetwork = forkRPC(RPC_VERSION);
-
+  const forkNetwork = process.env.FORK_NETWORK;
   const args = ["--seed", "0"];
   if (forkNetwork) {
     args.push("--fork-network", forkNetwork);
@@ -36,8 +34,8 @@ export default async function setup(project: TestProject) {
 
   devnet = await Devnet.spawnVersion(DEVNET_VERSION, {
     args,
-    stdout: "ignore",
-    stderr: "ignore",
+    stdout: "inherit",
+    stderr: "inherit",
     maxStartupMillis: 15000,
   });
 

--- a/tests/integration/shared.ts
+++ b/tests/integration/shared.ts
@@ -39,27 +39,6 @@ export async function fund(
   return result;
 }
 
-export function forkRPC(version: string): string | null {
-  const env = process.env.FORK_NETWORK;
-  if (!env) {
-    return null;
-  }
-  const url = new URL(env);
-
-  // Pattern to match /rpc/v{major}_{minor} at the end of pathname
-  const rpcVersionPattern = /\/rpc\/v\d+_\d+$/;
-
-  if (rpcVersionPattern.test(url.pathname)) {
-    // Replace existing version
-    url.pathname = url.pathname.replace(rpcVersionPattern, `/rpc/${version}`);
-  } else {
-    // Append version (remove trailing slash if present)
-    url.pathname = url.pathname.replace(/\/$/, "") + `/rpc/${version}`;
-  }
-
-  return url.toString();
-}
-
 export type TestConfig = {
   rpcUrl: string;
   chainId: ChainIdLiteral;

--- a/tests/swap-avnu.test.ts
+++ b/tests/swap-avnu.test.ts
@@ -195,14 +195,41 @@ describe("AvnuSwapProvider", () => {
     );
   });
 
-  it("falls back to second Sepolia endpoint when first has no routes", async () => {
+  it("does not fall back to the mainnet API for Sepolia (no cross-network calls)", async () => {
+    // Sepolia has no route; a mainnet fallback would build calls against the
+    // mainnet router, which is not deployed on Sepolia. Must fail on Sepolia
+    // only, never reaching the mainnet base.
+    avnuMocks.getQuotes.mockResolvedValue([]);
+
+    const provider = new AvnuSwapProvider();
+
+    await expect(
+      provider.getQuote({
+        chainId: ChainId.SEPOLIA,
+        tokenIn,
+        tokenOut,
+        amountIn: Amount.parse("1", tokenIn),
+      })
+    ).rejects.toThrow();
+
+    expect(avnuMocks.getQuotes).toHaveBeenCalledTimes(1);
+    expect(avnuMocks.getQuotes.mock.calls[0]![1]).toEqual({
+      baseUrl: "https://sepolia.api.avnu.fi",
+    });
+  });
+
+  it("still honors multiple explicit Sepolia endpoints via override", async () => {
     avnuMocks.getQuotes
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         makeQuote({ quoteId: "q-2", buyAmount: 1900000n }),
       ]);
 
-    const provider = new AvnuSwapProvider();
+    const provider = new AvnuSwapProvider({
+      apiBases: {
+        SN_SEPOLIA: ["https://sepolia-a.avnu.fi", "https://sepolia-b.avnu.fi"],
+      },
+    });
 
     const quote = await provider.getQuote({
       chainId: ChainId.SEPOLIA,
@@ -214,10 +241,10 @@ describe("AvnuSwapProvider", () => {
     expect(quote.amountOutBase).toBe(1900000n);
     expect(avnuMocks.getQuotes).toHaveBeenCalledTimes(2);
     expect(avnuMocks.getQuotes.mock.calls[0]![1]).toEqual({
-      baseUrl: "https://sepolia.api.avnu.fi",
+      baseUrl: "https://sepolia-a.avnu.fi",
     });
     expect(avnuMocks.getQuotes.mock.calls[1]![1]).toEqual({
-      baseUrl: "https://starknet.api.avnu.fi",
+      baseUrl: "https://sepolia-b.avnu.fi",
     });
   });
 

--- a/tests/wallet-utils.test.ts
+++ b/tests/wallet-utils.test.ts
@@ -6,6 +6,7 @@ import {
   isPaymasterMode,
   normalizeFeeMode,
   paymasterDetails,
+  preflightFromSimulation,
 } from "@/wallet/utils";
 import { fromAddress } from "@/types";
 
@@ -237,6 +238,58 @@ describe("wallet utils", () => {
           feeMode: "sponsored",
         })
       );
+    });
+  });
+
+  describe("preflightFromSimulation", () => {
+    const reverted = (reason: unknown) => [
+      { transaction_trace: { execute_invocation: { revert_reason: reason } } },
+    ];
+    const succeeded = [{ transaction_trace: { execute_invocation: {} } }];
+
+    it("reads a revert reason from both response shapes identically", () => {
+      // v10 returns `{ simulated_transactions }`, v8/v9 a bare array.
+      expect(
+        preflightFromSimulation({ simulated_transactions: reverted("boom") })
+      ).toEqual({ ok: false, reason: "boom" });
+      expect(preflightFromSimulation(reverted("boom"))).toEqual({
+        ok: false,
+        reason: "boom",
+      });
+    });
+
+    it("passes a successful simulation in both response shapes", () => {
+      expect(
+        preflightFromSimulation({ simulated_transactions: succeeded })
+      ).toEqual({ ok: true });
+      expect(preflightFromSimulation(succeeded)).toEqual({ ok: true });
+    });
+
+    it("reports a failure when revert_reason is present but not a string", () => {
+      // An empty string is still a revert; only absence means success.
+      expect(preflightFromSimulation(reverted(""))).toEqual({
+        ok: false,
+        reason: "",
+      });
+      expect(preflightFromSimulation(reverted({ nested: true }))).toEqual({
+        ok: false,
+        reason: "Simulation failed",
+      });
+    });
+
+    it("passes unreadable responses rather than blocking the transaction", () => {
+      for (const simulation of [
+        undefined,
+        null,
+        {},
+        [],
+        { simulated_transactions: [] },
+        { simulated_transactions: "not-an-array" },
+        [{ no_trace: true }],
+        [{ transaction_trace: { execute_invocation: "nope" } }],
+      ]) {
+        expect(preflightFromSimulation(simulation)).toEqual({ ok: true });
+      }
     });
   });
 });


### PR DESCRIPTION
The main goal is to lay the foundation needed for private tx support (Separate PR)

* Update `starknet.js` to `10.5.0` 
    * Updates related to `simulateTransaction` new schema. Keeps compatibility with the old schema when cartridge wallet is used (v8)
    * Updates to `@starknet-io/starknet-types-0103`
* Update `avnu-sdk` to `4.2.0-next.2` (support `starknet.js` v10)
* Update `tongo` to `1.5.0`
* Fix fork tests
* Fix avnu base url on sepolia that falls back to mainnet