### PR TITLE
fix: make optional peer deps truly optional (lazy-import tongo-sdk/ethers in root-reachable modules)

### DIFF
--- a/src/bridge/ethereum/ContractRoutedEthereumBridge.ts
+++ b/src/bridge/ethereum/ContractRoutedEthereumBridge.ts
@@ -14,7 +14,8 @@ import type {
   EthereumTransactionDetails,
   EthereumWalletConfig,
 } from "@/bridge/ethereum/types";
-import { Contract, type ContractTransaction, type InterfaceAbi } from "ethers";
+import type { Contract, ContractTransaction, InterfaceAbi } from "ethers";
+import { requireEthers } from "@/connect/ethersRuntime";
 import { FeeErrorCause } from "@/types/errors";
 import type { WalletInterface } from "@/wallet";
 import CANONICAL_BRIDGE_ABI from "@/abi/ethereum/canonicalBridge.json";
@@ -45,6 +46,10 @@ export abstract class ContractRoutedEthereumBridge extends EthereumBridge {
     bridgeAbi: InterfaceAbi = CANONICAL_BRIDGE_ABI
   ) {
     super(bridgeToken, config, starknetWallet, logger);
+    // Sync accessor is safe: bridges are only constructed after
+    // `BridgeOperator.createEthereumBridge` has awaited `loadEthers`, and the
+    // `config.signer` passed in is itself an ethers object.
+    const { Contract } = requireEthers("Ethereum bridge construction");
     this.bridge = new Contract(
       bridgeToken.bridgeAddress,
       bridgeAbi,

--- a/src/bridge/ethereum/EtherToken.ts
+++ b/src/bridge/ethereum/EtherToken.ts
@@ -3,20 +3,19 @@ import {
   ExternalChain,
   NATIVE_TOKEN_ADDRESS,
 } from "@/types/bridge/external-chain";
-import {
-  Contract,
-  type ContractTransaction,
-  getAddress,
-  type Provider,
-  type Signer,
-} from "ethers";
+import type { Contract, ContractTransaction, Provider, Signer } from "ethers";
 import ERC20_ABI from "@/abi/ethereum/erc20.json";
 import { type EthereumWalletConfig } from "@/bridge/ethereum/types";
-import { fromEthereumAddress } from "@/connect/ethersRuntime";
+import {
+  fromEthereumAddress,
+  loadEthers,
+  requireEthers,
+} from "@/connect/ethersRuntime";
 
 export async function ethereumAddress(
   contract: Contract
 ): Promise<EthereumAddress> {
+  const { getAddress } = await loadEthers("Ethereum token address");
   const target = contract.target;
   const address =
     typeof target === "string" ? target : await target.getAddress();
@@ -65,6 +64,9 @@ export class ERC20EthereumToken implements EthereumTokenInterface {
   }>;
 
   public static create(address: EthereumAddress, provider: Provider) {
+    // Sync accessor is safe: the caller holds an ethers `Provider`, which
+    // cannot exist unless ethers has already been loaded.
+    const { Contract } = requireEthers("Ethereum ERC20 token");
     const contract = new Contract(address, ERC20_ABI, provider);
     return new ERC20EthereumToken(contract);
   }

--- a/src/bridge/ethereum/EthereumBridge.ts
+++ b/src/bridge/ethereum/EthereumBridge.ts
@@ -18,18 +18,15 @@ import {
   type ApprovalFeeEstimation,
   type EthereumWalletConfig,
 } from "@/bridge/ethereum/types";
-import {
-  type ContractTransaction,
-  type ContractTransactionReceipt,
-  type ContractTransactionResponse,
-  getAddress,
-  isError,
-  toBigInt,
-  type TransactionRequest,
+import type {
+  ContractTransaction,
+  ContractTransactionReceipt,
+  ContractTransactionResponse,
+  TransactionRequest,
 } from "ethers";
 import { FeeErrorCause, TransactionErrorCause } from "@/types/errors";
 import type { WalletInterface } from "@/wallet";
-import { fromEthereumAddress } from "@/connect/ethersRuntime";
+import { fromEthereumAddress, loadEthers } from "@/connect/ethersRuntime";
 import { Erc20 } from "@/erc20";
 import { type StarkZapLogger } from "@/logger";
 
@@ -85,6 +82,7 @@ export abstract class EthereumBridge implements BridgeInterface<EthereumAddress>
       Date.now() - this.allowanceCache.timestamp >
       EthereumBridge.ALLOWANCE_CACHE_TTL
     ) {
+      const { getAddress } = await loadEthers("Ethereum bridge operations");
       const signerAddress = await this.config.signer.getAddress();
       const allowance = await this.token.allowance(
         fromEthereumAddress(signerAddress, { getAddress }),
@@ -147,6 +145,7 @@ export abstract class EthereumBridge implements BridgeInterface<EthereumAddress>
         tx
       )) as ContractTransactionResponse;
     } catch (e) {
+      const { isError } = await loadEthers("Ethereum bridge operations");
       if (isError(e, "ACTION_REJECTED")) {
         throw new Error(TransactionErrorCause.USER_REJECTED);
       }
@@ -214,6 +213,7 @@ export abstract class EthereumBridge implements BridgeInterface<EthereumAddress>
   protected async estimateEthereumSafeGasLimitForTx(
     tx: ContractTransaction
   ): Promise<bigint> {
+    const { toBigInt } = await loadEthers("Ethereum bridge operations");
     const estimated = await this.config.provider.estimateGas(tx);
     return (
       (estimated *

--- a/src/bridge/ethereum/canonical/CanonicalEthereumBridge.ts
+++ b/src/bridge/ethereum/canonical/CanonicalEthereumBridge.ts
@@ -17,7 +17,7 @@ import {
   type ExternalTransactionResponse,
 } from "@/types";
 import { ethereumAddress } from "@/bridge/ethereum/EtherToken";
-import { type ContractTransaction, type InterfaceAbi } from "ethers";
+import type { ContractTransaction, InterfaceAbi } from "ethers";
 import { type Call, CallData, uint256 } from "starknet";
 import type { L1Message } from "@starknet-io/starknet-types-0103";
 import { FeeErrorCause } from "@/types/errors";

--- a/src/bridge/ethereum/cctp/CCTPBridge.ts
+++ b/src/bridge/ethereum/cctp/CCTPBridge.ts
@@ -20,7 +20,7 @@ import type {
   EthereumWalletConfig,
 } from "@/bridge";
 import { ERC20EthereumToken } from "@/bridge/ethereum/EtherToken";
-import { getAddress, Interface, type TransactionRequest } from "ethers";
+import type { Interface, TransactionRequest } from "ethers";
 import { FeeErrorCause } from "@/types/errors";
 import { BridgeDirection, CCTPFees } from "@/bridge/ethereum/cctp/CCTPFees";
 import {
@@ -38,31 +38,55 @@ import {
   STARKNET_DOMAIN_ID,
 } from "@/bridge/ethereum/cctp/constants";
 import { EthereumBridge } from "@/bridge/ethereum/EthereumBridge";
-import { fromEthereumAddress } from "@/connect/ethersRuntime";
+import {
+  fromEthereumAddress,
+  loadEthers,
+  requireEthers,
+} from "@/connect/ethersRuntime";
 import type { Tx } from "@/tx";
 import { cairo, type Call, CallData, uint256 } from "starknet";
 import type { WalletInterface } from "@/wallet";
 import { type StarkZapLogger } from "@/logger";
 
 export class CCTPBridge extends EthereumBridge {
-  private static readonly MAINNET_TOKEN_MESSENGER = fromEthereumAddress(
-    "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
-    { getAddress }
-  );
-  private static readonly SEPOLIA_TOKEN_MESSENGER = fromEthereumAddress(
-    "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
-    { getAddress }
-  );
+  // The ethers-derived statics below are lazy so that this module never
+  // references the optional "ethers" peer at module-evaluation time. The
+  // sync `requireEthers` accessor is safe here: these getters are only
+  // reached from instances, which are constructed after `BridgeOperator`
+  // has awaited `loadEthers`.
+  private static _mainnetTokenMessenger?: EthereumAddress;
+  private static get MAINNET_TOKEN_MESSENGER(): EthereumAddress {
+    return (CCTPBridge._mainnetTokenMessenger ??= fromEthereumAddress(
+      "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+      { getAddress: requireEthers("CCTP bridge operations").getAddress }
+    ));
+  }
+
+  private static _sepoliaTokenMessenger?: EthereumAddress;
+  private static get SEPOLIA_TOKEN_MESSENGER(): EthereumAddress {
+    return (CCTPBridge._sepoliaTokenMessenger ??= fromEthereumAddress(
+      "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
+      { getAddress: requireEthers("CCTP bridge operations").getAddress }
+    ));
+  }
 
   private static DEFAULT_CCTP_DEPOSIT_GAS = 104_581n;
 
-  private static TOKEN_MESSENGER_INTERFACE = new Interface([
-    "function depositForBurn(uint256 amount, uint32 destinationDomain, bytes32 mintRecipient, address burnToken, bytes32 destinationCaller, uint256 maxFee, uint32 minFinalityThreshold)",
-  ]);
+  private static _tokenMessengerInterface?: Interface;
+  private static get TOKEN_MESSENGER_INTERFACE(): Interface {
+    const { Interface } = requireEthers("CCTP bridge operations");
+    return (CCTPBridge._tokenMessengerInterface ??= new Interface([
+      "function depositForBurn(uint256 amount, uint32 destinationDomain, bytes32 mintRecipient, address burnToken, bytes32 destinationCaller, uint256 maxFee, uint32 minFinalityThreshold)",
+    ]));
+  }
 
-  private static MESSAGE_TRANSMITTER_INTERFACE = new Interface([
-    "function receiveMessage(bytes message, bytes attestation)",
-  ]);
+  private static _messageTransmitterInterface?: Interface;
+  private static get MESSAGE_TRANSMITTER_INTERFACE(): Interface {
+    const { Interface } = requireEthers("CCTP bridge operations");
+    return (CCTPBridge._messageTransmitterInterface ??= new Interface([
+      "function receiveMessage(bytes message, bytes attestation)",
+    ]));
+  }
 
   private static readonly DUMMY_SN_ADDRESS = fromAddress(
     "0x0000000000000000000000000000000000000000000000000000000000000001"
@@ -185,7 +209,7 @@ export class CCTPBridge extends EthereumBridge {
     const [calls, fastTransferBpFee] = await Promise.all([
       this.buildInitiateWithdrawCalls(
         fromEthereumAddress("0x0000000000000000000000000000000000000001", {
-          getAddress,
+          getAddress: (await loadEthers("CCTP bridge operations")).getAddress,
         }),
         await this.token.amount(1n),
         fastTransfer

--- a/src/bridge/ethereum/oft/LayerZeroApi.ts
+++ b/src/bridge/ethereum/oft/LayerZeroApi.ts
@@ -1,8 +1,7 @@
 import type { ContractTransaction } from "ethers";
-import { getAddress, Interface } from "ethers";
 import { type EthereumAddress, ExternalChain } from "@/types";
 import type { Address, Amount } from "@/types";
-import { fromEthereumAddress } from "@/connect/ethersRuntime";
+import { fromEthereumAddress, requireEthers } from "@/connect/ethersRuntime";
 import type { Call } from "starknet";
 
 const LAYERZERO_API_BASE = "https://transfer.layerzero-api.com/v1";
@@ -153,6 +152,12 @@ export class LayerZeroApi {
     approvalTx: ContractTransaction | null
   ): EthereumAddress | null {
     if (!approvalTx?.data) return null;
+    // Sync accessor is safe: the caller holds an ethers `ContractTransaction`,
+    // which cannot exist unless ethers has already been loaded. Resolved
+    // outside the try block so a missing module is not swallowed as `null`.
+    const { getAddress, Interface } = requireEthers(
+      "LayerZero approval parsing"
+    );
     try {
       const approveInterface = new Interface([
         "function approve(address spender, uint256 value)",

--- a/src/bridge/monitor/canonical/utils.ts
+++ b/src/bridge/monitor/canonical/utils.ts
@@ -1,4 +1,5 @@
-import { AbiCoder, dataSlice, type TransactionReceipt } from "ethers";
+import type { TransactionReceipt } from "ethers";
+import { requireEthers } from "@/connect/ethersRuntime";
 import { constants, hash } from "starknet";
 
 const ZERO = "0x0";
@@ -33,6 +34,9 @@ export function deriveStarknetDepositTxHash(
     return null;
   }
 
+  // Sync accessor is safe: the caller holds an ethers `TransactionReceipt`,
+  // which cannot exist unless ethers has already been loaded.
+  const { AbiCoder, dataSlice } = requireEthers("Canonical deposit monitoring");
   const decoded = AbiCoder.defaultAbiCoder().decode(
     ["uint256[]", "uint256", "uint256"],
     dataSlice(log.data)

--- a/src/bridge/solana/hyperlaneRuntime.ts
+++ b/src/bridge/solana/hyperlaneRuntime.ts
@@ -21,23 +21,31 @@ export async function loadHyperlane(
     return cachedHyperlane;
   }
 
-  loadingHyperlane ??= Promise.all([
-    import("@hyperlane-xyz/sdk"),
-    import("@hyperlane-xyz/registry"),
-    import("@hyperlane-xyz/utils"),
-  ])
-    .then(([sdk, registry, utils]) => {
+  // NOTE: the import() must be wrapped in try/catch (not a .catch() chain):
+  // webpack only downgrades an unresolvable dynamic import to a build warning
+  // (with a runtime error) when the import() sits inside a try block — the
+  // same pattern the Cartridge loader in src/wallet/cartridge.ts relies on.
+  // With a .then()/.catch() chain instead, consumers without the optional
+  // peer installed get a hard "Module not found" build error.
+  loadingHyperlane ??= (async () => {
+    try {
+      // Awaited sequentially (not Promise.all) so each import() is directly
+      // awaited inside the try block — the shape esbuild also recognizes as
+      // handled, deferring a missing module to run-time instead of failing
+      // the consumer's bundle at build-time.
+      const sdk = await import("@hyperlane-xyz/sdk");
+      const registry = await import("@hyperlane-xyz/registry");
+      const utils = await import("@hyperlane-xyz/utils");
       cachedHyperlane = { sdk, registry, utils };
       return cachedHyperlane;
-    })
-    .catch(() => {
+    } catch {
       throw new Error(
         `[starkzap] ${feature} requires optional peer dependencies "@hyperlane-xyz/sdk", "@hyperlane-xyz/registry", and "@hyperlane-xyz/utils". Install them with: npm i @hyperlane-xyz/sdk @hyperlane-xyz/registry @hyperlane-xyz/utils`
       );
-    })
-    .finally(() => {
+    } finally {
       loadingHyperlane = undefined;
-    });
+    }
+  })();
 
   return await loadingHyperlane;
 }

--- a/src/confidential/tongo.ts
+++ b/src/confidential/tongo.ts
@@ -33,12 +33,17 @@ export async function loadTongoSdk(
     return cachedTongoSdk;
   }
 
-  loadingTongoSdk ??= import("@fatsolutions/tongo-sdk")
-    .then((module) => {
+  // NOTE: the import() must be wrapped in try/catch (not a .catch() chain):
+  // webpack only downgrades an unresolvable dynamic import to a build warning
+  // (with a runtime error) when the import() sits inside a try block. With a
+  // .then()/.catch() chain instead, consumers without the optional peer
+  // installed get a hard "Module not found" build error.
+  loadingTongoSdk ??= (async () => {
+    try {
+      const module = await import("@fatsolutions/tongo-sdk");
       cachedTongoSdk = module as unknown as TongoSdkModule;
       return cachedTongoSdk;
-    })
-    .catch((error) => {
+    } catch (error) {
       const detail =
         error instanceof Error && error.message
           ? ` Original error: ${error.message}`
@@ -46,10 +51,10 @@ export async function loadTongoSdk(
       throw new Error(
         `[starkzap] ${feature} requires optional peer dependency "@fatsolutions/tongo-sdk". Install it with: npm i @fatsolutions/tongo-sdk.${detail}`
       );
-    })
-    .finally(() => {
+    } finally {
       loadingTongoSdk = undefined;
-    });
+    }
+  })();
 
   return await loadingTongoSdk;
 }

--- a/src/connect/ethersRuntime.ts
+++ b/src/connect/ethersRuntime.ts
@@ -11,21 +11,46 @@ export async function loadEthers(feature: string): Promise<EthersModule> {
     return cachedEthers;
   }
 
-  loadingEthers ??= import("ethers")
-    .then((ethersModule) => {
+  // NOTE: the import() must be wrapped in try/catch (not a .catch() chain):
+  // webpack only downgrades an unresolvable dynamic import to a build warning
+  // (with a runtime error) when the import() sits inside a try block — the
+  // same pattern the Cartridge loader in src/wallet/cartridge.ts relies on.
+  // With a .then()/.catch() chain instead, consumers without the optional
+  // peer installed get a hard "Module not found" build error.
+  loadingEthers ??= (async () => {
+    try {
+      const ethersModule = await import("ethers");
       cachedEthers = ethersModule as unknown as EthersModule;
       return cachedEthers;
-    })
-    .catch(() => {
+    } catch {
       throw new Error(
         `[starkzap] ${feature} requires optional peer dependency "ethers". Install it with: npm i ethers`
       );
-    })
-    .finally(() => {
+    } finally {
       loadingEthers = undefined;
-    });
+    }
+  })();
 
   return await loadingEthers;
+}
+
+/**
+ * Returns the already-loaded ethers module synchronously.
+ *
+ * For sync code paths (constructors, static helpers) that cannot await
+ * {@link loadEthers}. Safe wherever the caller already holds an ethers
+ * object (a `Provider`, `Signer`, `Contract` or receipt) — such an object
+ * cannot exist unless ethers was loaded — and in bridge classes, which are
+ * only constructed after `BridgeOperator` has awaited `loadEthers`.
+ */
+export function requireEthers(feature: string): EthersModule {
+  if (!cachedEthers) {
+    throw new Error(
+      `[starkzap] ${feature} requires optional peer dependency "ethers" to be loaded first. ` +
+        `Install it with: npm i ethers`
+    );
+  }
+  return cachedEthers;
 }
 
 import type { EthereumAddress } from "@/types/address";

--- a/src/connect/solanaWeb3Runtime.ts
+++ b/src/connect/solanaWeb3Runtime.ts
@@ -13,19 +13,25 @@ export async function loadSolanaWeb3(
     return cachedSolanaWeb3;
   }
 
-  loadingSolanaWeb3 ??= import("@solana/web3.js")
-    .then((module) => {
+  // NOTE: the import() must be wrapped in try/catch (not a .catch() chain):
+  // webpack only downgrades an unresolvable dynamic import to a build warning
+  // (with a runtime error) when the import() sits inside a try block — the
+  // same pattern the Cartridge loader in src/wallet/cartridge.ts relies on.
+  // With a .then()/.catch() chain instead, consumers without the optional
+  // peer installed get a hard "Module not found" build error.
+  loadingSolanaWeb3 ??= (async () => {
+    try {
+      const module = await import("@solana/web3.js");
       cachedSolanaWeb3 = module as unknown as SolanaWeb3Module;
       return cachedSolanaWeb3;
-    })
-    .catch(() => {
+    } catch {
       throw new Error(
         `[starkzap] ${feature} requires optional peer dependency "@solana/web3.js". Install it with: npm i @solana/web3.js`
       );
-    })
-    .finally(() => {
+    } finally {
       loadingSolanaWeb3 = undefined;
-    });
+    }
+  })();
 
   return await loadingSolanaWeb3;
 }

--- a/src/utils/avnu.ts
+++ b/src/utils/avnu.ts
@@ -18,12 +18,18 @@ export async function loadAvnuSdk(feature: string): Promise<AvnuSdkModule> {
     return cachedAvnuSdk;
   }
 
-  loadingAvnuSdk ??= import("@avnu/avnu-sdk")
-    .then((module) => {
+  // NOTE: the import() must be wrapped in try/catch (not a .catch() chain):
+  // webpack only downgrades an unresolvable dynamic import to a build warning
+  // (with a runtime error) when the import() sits inside a try block — the
+  // same pattern the Cartridge loader in src/wallet/cartridge.ts relies on.
+  // With a .then()/.catch() chain instead, consumers without the optional
+  // peer installed get a hard "Module not found" build error.
+  loadingAvnuSdk ??= (async () => {
+    try {
+      const module = await import("@avnu/avnu-sdk");
       cachedAvnuSdk = module as unknown as AvnuSdkModule;
       return cachedAvnuSdk;
-    })
-    .catch((error) => {
+    } catch (error) {
       const detail =
         error instanceof Error && error.message
           ? ` Original error: ${error.message}`
@@ -31,10 +37,10 @@ export async function loadAvnuSdk(feature: string): Promise<AvnuSdkModule> {
       throw new Error(
         `[starkzap] ${feature} requires optional peer dependency "@avnu/avnu-sdk". Install it with: npm i @avnu/avnu-sdk.${detail}`
       );
-    })
-    .finally(() => {
+    } finally {
       loadingAvnuSdk = undefined;
-    });
+    }
+  })();
 
   return await loadingAvnuSdk;
 }

--- a/tests/bridge/monitor/canonical-utils.test.ts
+++ b/tests/bridge/monitor/canonical-utils.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { AbiCoder, type TransactionReceipt } from "ethers";
 import { constants, hash } from "starknet";
 import { deriveStarknetDepositTxHash } from "@/bridge/monitor/canonical/utils";
+import { loadEthers } from "@/connect/ethersRuntime";
+
+// `deriveStarknetDepositTxHash` reads ethers from the lazy runtime cache
+// (ethers is an optional peer dependency); populate it as production does.
+beforeAll(async () => {
+  await loadEthers("canonical-utils tests");
+});
 
 /** Event topic0: `LogMessageToL2` (Starknet Core Contract). Must match `canonical/utils.ts`. */
 const L2_MSG_TOPIC =

--- a/tests/optional-peer-imports.test.ts
+++ b/tests/optional-peer-imports.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import ts from "typescript";
+
+/**
+ * Regression guard: optional peer dependencies must never be imported
+ * statically from any module reachable from the package entry points.
+ *
+ * Consumers that don't use bridging/confidential/Solana features must be able
+ * to bundle and `import("starkzap")` without installing the optional peers.
+ * Bundlers (webpack, esbuild) resolve every static `import`/`export ... from`
+ * at build time — including inside modules that are only reached through a
+ * dynamic `import()` — so a single static peer import produces hard
+ * "Module not found" build failures downstream.
+ *
+ * Allowed pattern: dynamic `import("<peer>")` behind a lazy runtime loader
+ * (`loadEthers`, `loadSolanaWeb3`, `loadHyperlane`, `loadTongo`, ...).
+ *
+ * Note on `verbatimModuleSyntax` (enabled in tsconfig): only statements
+ * written as `import type { ... }` / `export type { ... }` are elided from the
+ * emitted JS. Inline forms like `import { type Foo } from "ethers"` still emit
+ * `import {} from "ethers"` and are therefore violations too.
+ */
+
+const ROOT = resolve(__dirname, "..");
+const SRC = join(ROOT, "src");
+
+const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")) as {
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+};
+const optionalPeers = Object.entries(pkg.peerDependenciesMeta ?? {})
+  .filter(([, meta]) => meta.optional)
+  .map(([name]) => name);
+
+function isOptionalPeer(specifier: string): string | undefined {
+  return optionalPeers.find(
+    (peer) => specifier === peer || specifier.startsWith(`${peer}/`)
+  );
+}
+
+/** Resolve a relative or `@/` alias specifier to a source file path. */
+function resolveInternal(from: string, specifier: string): string | undefined {
+  let base: string;
+  if (specifier.startsWith("@/")) {
+    base = join(SRC, specifier.slice(2));
+  } else if (specifier.startsWith(".")) {
+    base = resolve(dirname(from), specifier);
+  } else {
+    return undefined; // bare specifier (dependency)
+  }
+  for (const candidate of [base, `${base}.ts`, join(base, "index.ts")]) {
+    if (candidate.endsWith(".json")) return undefined;
+    if (candidate.endsWith(".ts") && existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+type Violation = { file: string; specifier: string };
+
+/**
+ * Walks the emitted-JS module graph from the given entry points, following
+ * both static imports/re-exports and internal dynamic `import()` calls, and
+ * collects every statically emitted reference to an optional peer.
+ */
+function findStaticPeerImports(entries: string[]): Violation[] {
+  const queue = [...entries];
+  const seen = new Set<string>();
+  const violations: Violation[] = [];
+
+  while (queue.length > 0) {
+    const file = queue.pop()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+
+    const source = ts.createSourceFile(
+      file,
+      readFileSync(file, "utf8"),
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const record = (specifier: string, elided: boolean, dynamic: boolean) => {
+      const peer = isOptionalPeer(specifier);
+      if (peer) {
+        // Dynamic import() of a peer is the sanctioned lazy-loading pattern;
+        // fully type-only statements are erased at compile time.
+        if (!dynamic && !elided) {
+          violations.push({ file: file.slice(ROOT.length + 1), specifier });
+        }
+        return;
+      }
+      if (elided) return;
+      const target = resolveInternal(file, specifier);
+      if (target) queue.push(target);
+    };
+
+    const visit = (node: ts.Node) => {
+      if (ts.isImportDeclaration(node)) {
+        const specifier = (node.moduleSpecifier as ts.StringLiteral).text;
+        // Only `import type { ... }` is fully elided under
+        // verbatimModuleSyntax; inline `{ type X }` still emits the import.
+        record(specifier, node.importClause?.isTypeOnly === true, false);
+      } else if (ts.isExportDeclaration(node) && node.moduleSpecifier) {
+        const specifier = (node.moduleSpecifier as ts.StringLiteral).text;
+        record(specifier, node.isTypeOnly, false);
+      } else if (
+        ts.isCallExpression(node) &&
+        node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+        node.arguments.length === 1 &&
+        ts.isStringLiteralLike(node.arguments[0]!)
+      ) {
+        record((node.arguments[0] as ts.StringLiteral).text, false, true);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  }
+
+  return violations;
+}
+
+describe("optional peer dependencies", () => {
+  it("declares optional peers in package.json", () => {
+    expect(optionalPeers.length).toBeGreaterThan(0);
+  });
+
+  it("are never statically imported from modules reachable from the package entry points", () => {
+    const entries = [join(SRC, "index.ts"), join(SRC, "cartridge.ts")].filter(
+      (entry) => existsSync(entry)
+    );
+    expect(entries.length).toBeGreaterThan(0);
+
+    const violations = findStaticPeerImports(entries);
+
+    expect(
+      violations,
+      violations
+        .map(
+          (v) =>
+            `${v.file} statically imports optional peer "${v.specifier}" — ` +
+            `route it through a lazy runtime loader (see src/connect/ethersRuntime.ts) ` +
+            `or make the import "import type".`
+        )
+        .join("\n")
+    ).toEqual([]);
+  });
+
+  // Sanity check: the walker actually parses imports (guards against the
+  // guard silently walking nothing).
+  it("walks a non-trivial portion of the source tree", () => {
+    const allSrcFiles: string[] = [];
+    const collect = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) collect(full);
+        else if (entry.name.endsWith(".ts")) allSrcFiles.push(full);
+      }
+    };
+    collect(SRC);
+
+    const seen = new Set<string>();
+    const queue = [join(SRC, "index.ts")];
+    while (queue.length > 0) {
+      const file = queue.pop()!;
+      if (seen.has(file)) continue;
+      seen.add(file);
+      const source = ts.createSourceFile(
+        file,
+        readFileSync(file, "utf8"),
+        ts.ScriptTarget.Latest,
+        true
+      );
+      const visit = (node: ts.Node) => {
+        let specifier: string | undefined;
+        if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+          specifier =
+            node.moduleSpecifier && ts.isStringLiteralLike(node.moduleSpecifier)
+              ? node.moduleSpecifier.text
+              : undefined;
+        } else if (
+          ts.isCallExpression(node) &&
+          node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+          node.arguments.length === 1 &&
+          ts.isStringLiteralLike(node.arguments[0]!)
+        ) {
+          specifier = (node.arguments[0] as ts.StringLiteral).text;
+        }
+        if (specifier) {
+          const target = resolveInternal(file, specifier);
+          if (target) queue.push(target);
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(source);
+    }
+
+    // The root entry re-exports every subsystem; the reachable graph should
+    // cover the majority of src/.
+    expect(seen.size).toBeGreaterThan(allSrcFiles.length / 2);
+  });
+});


### PR DESCRIPTION
## Problem

starkzap declares its heavy deps as **optional** peerDependencies (`@fatsolutions/tongo-sdk`, `ethers`, `@solana/web3.js`, `@hyperlane-xyz/*`, `@avnu/avnu-sdk`, `@cartridge/controller`) and already has lazy runtime loaders for most of them (`loadEthers`, `loadSolanaWeb3`, `loadHyperlane`, `loadAvnuSdk`) — clearly the intended design. But in practice a consumer that uses none of those features still **cannot build** without installing the peers, for two reasons:

**1. Static peer imports survive in the emitted JS.** In the current `main` build:

- `dist/src/confidential/tongo.js` → `import { Account as TongoAccount, pubKeyBase58ToAffine } from "@fatsolutions/tongo-sdk"`, statically reachable from the root: `index.js → confidential/index.js → confidential/tongo.js`. Every bundler must resolve tongo-sdk just to import `StarkZap`.
- Six bridge modules import `ethers` values at module scope: `bridge/ethereum/{EthereumBridge,EtherToken,ContractRoutedEthereumBridge}.js`, `bridge/ethereum/cctp/CCTPBridge.js`, `bridge/ethereum/oft/LayerZeroApi.js`, `bridge/monitor/canonical/utils.js` — plus `bridge/ethereum/canonical/CanonicalEthereumBridge.js`, where the inline-type form `import { type X } from "ethers"` still emits `import {} from "ethers"` under `verbatimModuleSyntax`. These are reached through `BridgeOperator`'s dynamic `import()`s — which bundlers **also resolve at build time** — so they fail consumer builds even though they're off the static root graph.

**2. The lazy loaders themselves hard-fail bundlers.** The `.then()/.catch()` chain shape (`import("ethers").then(...).catch(...)`) is treated by webpack as an unresolvable request → **build ERROR**. Only a `try { await import("x") } catch` shape (the one `src/wallet/cartridge.ts` already uses) is downgraded to a build warning + run-time error. esbuild behaves the same, and additionally needs each `import()` to be directly awaited in the `try` (the `Promise.all([import(...), ...])` shape in `hyperlaneRuntime` still hard-fails).

### Real-world impact

A Next.js 15 app importing only `StarkZap` + `PrivySigner` fails to build with 5 "Module not found" errors. `webpack.IgnorePlugin` is **not** a workaround: ignored modules throw at load time, which kills `import("starkzap")` at runtime — consumers are forced to alias each peer to a hand-written Proxy stub. Reproduced here with vanilla webpack 5 against the packed 3.0.0-main tarball in a project with no optional peers installed: **7 build errors** (3× hyperlane, tongo-sdk, ethers, @solana/web3.js, @avnu/avnu-sdk).

## Approach

Follow the codebase's own lazy-runtime pattern everywhere; no subsystem was moved to a subpath export.

- **`src/confidential/tongo.ts`** — new `src/confidential/tongoRuntime.ts` (`loadTongo`/`requireTongo`, mirroring `ethersRuntime`). `TongoConfidential`'s constructor now kicks off the lazy load and builds the underlying `Account` when it resolves; all async methods await it. New public `ready(): Promise<void>`.
- **`src/connect/ethersRuntime.ts`** — added a sync `requireEthers(feature)` accessor for code paths that can't await (constructors, static helpers). It's safe wherever the caller already holds an ethers object (`Provider`, `Signer`, receipt — which can't exist unless ethers loaded) and in bridge classes, which are only constructed after `BridgeOperator` awaits `loadEthers`.
- **Bridge modules** — all `ethers` imports are now `import type`; value uses go through `await loadEthers(...)` in async methods, `requireEthers(...)` in sync ones (each site has a comment justifying why sync access is safe there). `CCTPBridge`'s module-eval statics (`new Interface(...)`, checksummed messenger addresses) became lazy cached static getters.
- **All five runtime loaders** (`ethers`, `@solana/web3.js`, hyperlane, avnu, tongo) — restructured from `.then()/.catch()` chains to `try { await import(...) } catch`, with hyperlane's three imports awaited sequentially, so webpack/esbuild downgrade a missing peer to the intended run-time install-hint error instead of a build failure. Error messages are unchanged.

### Regression guards (new tests)

- `tests/optional-peer-imports.test.ts` — walks the emitted-JS module graph from `src/index.ts`/`src/cartridge.ts` (static imports/re-exports **and** internal dynamic `import()`s, modeling `verbatimModuleSyntax` elision rules) and asserts no optional peer is imported statically. It fails on current `main` with exactly the 8 offending files.
- `tests/tongo-optional-dep.test.ts` — mirrors the existing `avnu-optional-dep.test.ts`: with tongo-sdk missing, construction doesn't throw and `ready()`/async methods reject with the install hint.

## API-visible consequences

- `TongoConfidential` gains `ready(): Promise<void>`.
- `TongoConfidential`'s **sync** accessors (`address`, `recipientId`, `recipientFromAddress`, `getTongoAccount`) now require the lazy module load to have settled — i.e. `await ready()` (or any async method) first — and otherwise throw an actionable error. This is the one behavior change: previously `new TongoConfidential(...).address` worked synchronously. It could not be preserved without a static import (top-level await was rejected for bundler-compat reasons). All async methods behave exactly as before.
- Everything else is internal; no exports were added/removed from `src/index.ts`.

## Verified

- `npm run typecheck`, `npm run typecheck:all`, `npm run lint`, `npm run prettier:check`, `npm run build`, `npm run build:all`: pass.
- `npm test`: 762 passed / 12 skipped; the only 2 failures (`tests/amount.test.ts` thousand-separator cases) also fail on a clean `main` checkout in this environment (locale/ICU-dependent), unrelated to this change.
- Integration tests were **not** run (they need a local devnet/fork setup).
- **End-to-end no-peers repro**: `npm pack` the built package → install the tarball into a fresh project with no optional peers →
  - `node --input-type=module -e "await import('starkzap')"` evaluates; `new TongoConfidential(...)` then `await ready()` rejects with the `npm i @fatsolutions/tongo-sdk` hint;
  - **webpack 5** production build of an app importing `StarkZap` + `PrivySigner`: **0 errors** (down from 7), only the expected "Module not found" *warnings* on the lazy loaders; the emitted bundle evaluates and both exports are usable;
  - **esbuild** `--bundle` of the same app: exits 0; the bundle runs.
  - Before the loader restructuring, the same repro produced 7 webpack ERRORs, confirming both halves of the fix are needed.

## Notes for reviewers

- The `requireEthers` sync-accessor sites are the part worth scrutinizing: they assume ethers is already cached when reached (arguments given in each site's comment). If you'd rather pay the churn, any of them can be converted to async + `await loadEthers`.
- The sequential (vs `Promise.all`) hyperlane imports trade a little first-load parallelism for esbuild compatibility.
- Docs under `docs/api/**` are generated and not tracked in git, so they were not regenerated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
