### PR TITLE
fix: Make optional peer deps truly optional (supersedes #136)

### DIFF
--- a/src/bridge/ethereum/ContractRoutedEthereumBridge.ts
+++ b/src/bridge/ethereum/ContractRoutedEthereumBridge.ts
@@ -14,7 +14,8 @@ import type {
   EthereumTransactionDetails,
   EthereumWalletConfig,
 } from "@/bridge/ethereum/types";
-import { Contract, type ContractTransaction, type InterfaceAbi } from "ethers";
+import type { Contract, ContractTransaction, InterfaceAbi } from "ethers";
+import { requireEthers } from "@/connect/ethersRuntime";
 import { FeeErrorCause } from "@/types/errors";
 import type { WalletInterface } from "@/wallet";
 import CANONICAL_BRIDGE_ABI from "@/abi/ethereum/canonicalBridge.json";
@@ -45,6 +46,10 @@ export abstract class ContractRoutedEthereumBridge extends EthereumBridge {
     bridgeAbi: InterfaceAbi = CANONICAL_BRIDGE_ABI
   ) {
     super(bridgeToken, config, starknetWallet, logger);
+    // Sync accessor is safe: bridges are only constructed after
+    // `BridgeOperator.createEthereumBridge` has awaited `loadEthers`, and the
+    // `config.signer` passed in is itself an ethers object.
+    const { Contract } = requireEthers("Ethereum bridge construction");
     this.bridge = new Contract(
       bridgeToken.bridgeAddress,
       bridgeAbi,

--- a/src/bridge/ethereum/EtherToken.ts
+++ b/src/bridge/ethereum/EtherToken.ts
@@ -3,20 +3,19 @@ import {
   ExternalChain,
   NATIVE_TOKEN_ADDRESS,
 } from "@/types/bridge/external-chain";
-import {
-  Contract,
-  type ContractTransaction,
-  getAddress,
-  type Provider,
-  type Signer,
-} from "ethers";
+import type { Contract, ContractTransaction, Provider, Signer } from "ethers";
 import ERC20_ABI from "@/abi/ethereum/erc20.json";
 import { type EthereumWalletConfig } from "@/bridge/ethereum/types";
-import { fromEthereumAddress } from "@/connect/ethersRuntime";
+import {
+  fromEthereumAddress,
+  loadEthers,
+  requireEthers,
+} from "@/connect/ethersRuntime";
 
 export async function ethereumAddress(
   contract: Contract
 ): Promise<EthereumAddress> {
+  const { getAddress } = await loadEthers("Ethereum token address");
   const target = contract.target;
   const address =
     typeof target === "string" ? target : await target.getAddress();
@@ -65,6 +64,9 @@ export class ERC20EthereumToken implements EthereumTokenInterface {
   }>;
 
   public static create(address: EthereumAddress, provider: Provider) {
+    // Sync accessor is safe: the caller holds an ethers `Provider`, which
+    // cannot exist unless ethers has already been loaded.
+    const { Contract } = requireEthers("Ethereum ERC20 token");
     const contract = new Contract(address, ERC20_ABI, provider);
     return new ERC20EthereumToken(contract);
   }

--- a/src/bridge/ethereum/EthereumBridge.ts
+++ b/src/bridge/ethereum/EthereumBridge.ts
@@ -18,18 +18,15 @@ import {
   type ApprovalFeeEstimation,
   type EthereumWalletConfig,
 } from "@/bridge/ethereum/types";
-import {
-  type ContractTransaction,
-  type ContractTransactionReceipt,
-  type ContractTransactionResponse,
-  getAddress,
-  isError,
-  toBigInt,
-  type TransactionRequest,
+import type {
+  ContractTransaction,
+  ContractTransactionReceipt,
+  ContractTransactionResponse,
+  TransactionRequest,
 } from "ethers";
 import { FeeErrorCause, TransactionErrorCause } from "@/types/errors";
 import type { WalletInterface } from "@/wallet";
-import { fromEthereumAddress } from "@/connect/ethersRuntime";
+import { fromEthereumAddress, loadEthers } from "@/connect/ethersRuntime";
 import { Erc20 } from "@/erc20";
 import { type StarkZapLogger } from "@/logger";
 
@@ -85,6 +82,7 @@ export abstract class EthereumBridge implements BridgeInterface<EthereumAddress>
       Date.now() - this.allowanceCache.timestamp >
       EthereumBridge.ALLOWANCE_CACHE_TTL
     ) {
+      const { getAddress } = await loadEthers("Ethereum bridge operations");
       const signerAddress = await this.config.signer.getAddress();
       const allowance = await this.token.allowance(
         fromEthereumAddress(signerAddress, { getAddress }),
@@ -147,6 +145,7 @@ export abstract class EthereumBridge implements BridgeInterface<EthereumAddress>
         tx
       )) as ContractTransactionResponse;
     } catch (e) {
+      const { isError } = await loadEthers("Ethereum bridge operations");
       if (isError(e, "ACTION_REJECTED")) {
         throw new Error(TransactionErrorCause.USER_REJECTED);
       }
@@ -214,6 +213,7 @@ export abstract class EthereumBridge implements BridgeInterface<EthereumAddress>
   protected async estimateEthereumSafeGasLimitForTx(
     tx: ContractTransaction
   ): Promise<bigint> {
+    const { toBigInt } = await loadEthers("Ethereum bridge operations");
     const estimated = await this.config.provider.estimateGas(tx);
     return (
       (estimated *

--- a/src/bridge/ethereum/canonical/CanonicalEthereumBridge.ts
+++ b/src/bridge/ethereum/canonical/CanonicalEthereumBridge.ts
@@ -17,7 +17,7 @@ import {
   type ExternalTransactionResponse,
 } from "@/types";
 import { ethereumAddress } from "@/bridge/ethereum/EtherToken";
-import { type ContractTransaction, type InterfaceAbi } from "ethers";
+import type { ContractTransaction, InterfaceAbi } from "ethers";
 import { type Call, CallData, uint256 } from "starknet";
 import type { L1Message } from "@starknet-io/starknet-types-0103";
 import { FeeErrorCause } from "@/types/errors";

--- a/src/bridge/ethereum/cctp/CCTPBridge.ts
+++ b/src/bridge/ethereum/cctp/CCTPBridge.ts
@@ -20,7 +20,7 @@ import type {
   EthereumWalletConfig,
 } from "@/bridge";
 import { ERC20EthereumToken } from "@/bridge/ethereum/EtherToken";
-import { getAddress, Interface, type TransactionRequest } from "ethers";
+import type { Interface, TransactionRequest } from "ethers";
 import { FeeErrorCause } from "@/types/errors";
 import { BridgeDirection, CCTPFees } from "@/bridge/ethereum/cctp/CCTPFees";
 import {
@@ -38,31 +38,55 @@ import {
   STARKNET_DOMAIN_ID,
 } from "@/bridge/ethereum/cctp/constants";
 import { EthereumBridge } from "@/bridge/ethereum/EthereumBridge";
-import { fromEthereumAddress } from "@/connect/ethersRuntime";
+import {
+  fromEthereumAddress,
+  loadEthers,
+  requireEthers,
+} from "@/connect/ethersRuntime";
 import type { Tx } from "@/tx";
 import { cairo, type Call, CallData, uint256 } from "starknet";
 import type { WalletInterface } from "@/wallet";
 import { type StarkZapLogger } from "@/logger";
 
 export class CCTPBridge extends EthereumBridge {
-  private static readonly MAINNET_TOKEN_MESSENGER = fromEthereumAddress(
-    "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
-    { getAddress }
-  );
-  private static readonly SEPOLIA_TOKEN_MESSENGER = fromEthereumAddress(
-    "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
-    { getAddress }
-  );
+  // The ethers-derived statics below are lazy so that this module never
+  // references the optional "ethers" peer at module-evaluation time. The
+  // sync `requireEthers` accessor is safe here: these getters are only
+  // reached from instances, which are constructed after `BridgeOperator`
+  // has awaited `loadEthers`.
+  private static _mainnetTokenMessenger?: EthereumAddress;
+  private static get MAINNET_TOKEN_MESSENGER(): EthereumAddress {
+    return (CCTPBridge._mainnetTokenMessenger ??= fromEthereumAddress(
+      "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+      { getAddress: requireEthers("CCTP bridge operations").getAddress }
+    ));
+  }
+
+  private static _sepoliaTokenMessenger?: EthereumAddress;
+  private static get SEPOLIA_TOKEN_MESSENGER(): EthereumAddress {
+    return (CCTPBridge._sepoliaTokenMessenger ??= fromEthereumAddress(
+      "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
+      { getAddress: requireEthers("CCTP bridge operations").getAddress }
+    ));
+  }
 
   private static DEFAULT_CCTP_DEPOSIT_GAS = 104_581n;
 
-  private static TOKEN_MESSENGER_INTERFACE = new Interface([
-    "function depositForBurn(uint256 amount, uint32 destinationDomain, bytes32 mintRecipient, address burnToken, bytes32 destinationCaller, uint256 maxFee, uint32 minFinalityThreshold)",
-  ]);
+  private static _tokenMessengerInterface?: Interface;
+  private static get TOKEN_MESSENGER_INTERFACE(): Interface {
+    const { Interface } = requireEthers("CCTP bridge operations");
+    return (CCTPBridge._tokenMessengerInterface ??= new Interface([
+      "function depositForBurn(uint256 amount, uint32 destinationDomain, bytes32 mintRecipient, address burnToken, bytes32 destinationCaller, uint256 maxFee, uint32 minFinalityThreshold)",
+    ]));
+  }
 
-  private static MESSAGE_TRANSMITTER_INTERFACE = new Interface([
-    "function receiveMessage(bytes message, bytes attestation)",
-  ]);
+  private static _messageTransmitterInterface?: Interface;
+  private static get MESSAGE_TRANSMITTER_INTERFACE(): Interface {
+    const { Interface } = requireEthers("CCTP bridge operations");
+    return (CCTPBridge._messageTransmitterInterface ??= new Interface([
+      "function receiveMessage(bytes message, bytes attestation)",
+    ]));
+  }
 
   private static readonly DUMMY_SN_ADDRESS = fromAddress(
     "0x0000000000000000000000000000000000000000000000000000000000000001"
@@ -185,7 +209,7 @@ export class CCTPBridge extends EthereumBridge {
     const [calls, fastTransferBpFee] = await Promise.all([
       this.buildInitiateWithdrawCalls(
         fromEthereumAddress("0x0000000000000000000000000000000000000001", {
-          getAddress,
+          getAddress: (await loadEthers("CCTP bridge operations")).getAddress,
         }),
         await this.token.amount(1n),
         fastTransfer

--- a/src/bridge/ethereum/oft/LayerZeroApi.ts
+++ b/src/bridge/ethereum/oft/LayerZeroApi.ts
@@ -1,8 +1,7 @@
 import type { ContractTransaction } from "ethers";
-import { getAddress, Interface } from "ethers";
 import { type EthereumAddress, ExternalChain } from "@/types";
 import type { Address, Amount } from "@/types";
-import { fromEthereumAddress } from "@/connect/ethersRuntime";
+import { fromEthereumAddress, requireEthers } from "@/connect/ethersRuntime";
 import type { Call } from "starknet";
 
 const LAYERZERO_API_BASE = "https://transfer.layerzero-api.com/v1";
@@ -153,6 +152,12 @@ export class LayerZeroApi {
     approvalTx: ContractTransaction | null
   ): EthereumAddress | null {
     if (!approvalTx?.data) return null;
+    // Sync accessor is safe: the caller holds an ethers `ContractTransaction`,
+    // which cannot exist unless ethers has already been loaded. Resolved
+    // outside the try block so a missing module is not swallowed as `null`.
+    const { getAddress, Interface } = requireEthers(
+      "LayerZero approval parsing"
+    );
     try {
       const approveInterface = new Interface([
         "function approve(address spender, uint256 value)",

--- a/src/bridge/monitor/canonical/utils.ts
+++ b/src/bridge/monitor/canonical/utils.ts
@@ -1,4 +1,5 @@
-import { AbiCoder, dataSlice, type TransactionReceipt } from "ethers";
+import type { TransactionReceipt } from "ethers";
+import { requireEthers } from "@/connect/ethersRuntime";
 import { constants, hash } from "starknet";
 
 const ZERO = "0x0";
@@ -33,6 +34,9 @@ export function deriveStarknetDepositTxHash(
     return null;
   }
 
+  // Sync accessor is safe: the caller holds an ethers `TransactionReceipt`,
+  // which cannot exist unless ethers has already been loaded.
+  const { AbiCoder, dataSlice } = requireEthers("Canonical deposit monitoring");
   const decoded = AbiCoder.defaultAbiCoder().decode(
     ["uint256[]", "uint256", "uint256"],
     dataSlice(log.data)

--- a/src/bridge/solana/hyperlaneRuntime.ts
+++ b/src/bridge/solana/hyperlaneRuntime.ts
@@ -21,23 +21,31 @@ export async function loadHyperlane(
     return cachedHyperlane;
   }
 
-  loadingHyperlane ??= Promise.all([
-    import("@hyperlane-xyz/sdk"),
-    import("@hyperlane-xyz/registry"),
-    import("@hyperlane-xyz/utils"),
-  ])
-    .then(([sdk, registry, utils]) => {
+  // NOTE: the import() must be wrapped in try/catch (not a .catch() chain):
+  // webpack only downgrades an unresolvable dynamic import to a build warning
+  // (with a runtime error) when the import() sits inside a try block — the
+  // same pattern the Cartridge loader in src/wallet/cartridge.ts relies on.
+  // With a .then()/.catch() chain instead, consumers without the optional
+  // peer installed get a hard "Module not found" build error.
+  loadingHyperlane ??= (async () => {
+    try {
+      // Awaited sequentially (not Promise.all) so each import() is directly
+      // awaited inside the try block — the shape esbuild also recognizes as
+      // handled, deferring a missing module to run-time instead of failing
+      // the consumer's bundle at build-time.
+      const sdk = await import("@hyperlane-xyz/sdk");
+      const registry = await import("@hyperlane-xyz/registry");
+      const utils = await import("@hyperlane-xyz/utils");
       cachedHyperlane = { sdk, registry, utils };
       return cachedHyperlane;
-    })
-    .catch(() => {
+    } catch {
       throw new Error(
         `[starkzap] ${feature} requires optional peer dependencies "@hyperlane-xyz/sdk", "@hyperlane-xyz/registry", and "@hyperlane-xyz/utils". Install them with: npm i @hyperlane-xyz/sdk @hyperlane-xyz/registry @hyperlane-xyz/utils`
       );
-    })
-    .finally(() => {
+    } finally {
       loadingHyperlane = undefined;
-    });
+    }
+  })();
 
   return await loadingHyperlane;
 }

--- a/src/confidential/tongo.ts
+++ b/src/confidential/tongo.ts
@@ -33,12 +33,17 @@ export async function loadTongoSdk(
     return cachedTongoSdk;
   }
 
-  loadingTongoSdk ??= import("@fatsolutions/tongo-sdk")
-    .then((module) => {
+  // NOTE: the import() must be wrapped in try/catch (not a .catch() chain):
+  // webpack only downgrades an unresolvable dynamic import to a build warning
+  // (with a runtime error) when the import() sits inside a try block. With a
+  // .then()/.catch() chain instead, consumers without the optional peer
+  // installed get a hard "Module not found" build error.
+  loadingTongoSdk ??= (async () => {
+    try {
+      const module = await import("@fatsolutions/tongo-sdk");
       cachedTongoSdk = module as unknown as TongoSdkModule;
       return cachedTongoSdk;
-    })
-    .catch((error) => {
+    } catch (error) {
       const detail =
         error instanceof Error && error.message
           ? ` Original error: ${error.message}`
@@ -46,10 +51,10 @@ export async function loadTongoSdk(
       throw new Error(
         `[starkzap] ${feature} requires optional peer dependency "@fatsolutions/tongo-sdk". Install it with: npm i @fatsolutions/tongo-sdk.${detail}`
       );
-    })
-    .finally(() => {
+    } finally {
       loadingTongoSdk = undefined;
-    });
+    }
+  })();
 
   return await loadingTongoSdk;
 }

--- a/src/connect/ethersRuntime.ts
+++ b/src/connect/ethersRuntime.ts
@@ -11,21 +11,46 @@ export async function loadEthers(feature: string): Promise<EthersModule> {
     return cachedEthers;
   }
 
-  loadingEthers ??= import("ethers")
-    .then((ethersModule) => {
+  // NOTE: the import() must be wrapped in try/catch (not a .catch() chain):
+  // webpack only downgrades an unresolvable dynamic import to a build warning
+  // (with a runtime error) when the import() sits inside a try block — the
+  // same pattern the Cartridge loader in src/wallet/cartridge.ts relies on.
+  // With a .then()/.catch() chain instead, consumers without the optional
+  // peer installed get a hard "Module not found" build error.
+  loadingEthers ??= (async () => {
+    try {
+      const ethersModule = await import("ethers");
       cachedEthers = ethersModule as unknown as EthersModule;
       return cachedEthers;
-    })
-    .catch(() => {
+    } catch {
       throw new Error(
         `[starkzap] ${feature} requires optional peer dependency "ethers". Install it with: npm i ethers`
       );
-    })
-    .finally(() => {
+    } finally {
       loadingEthers = undefined;
-    });
+    }
+  })();
 
   return await loadingEthers;
+}
+
+/**
+ * Returns the already-loaded ethers module synchronously.
+ *
+ * For sync code paths (constructors, static helpers) that cannot await
+ * {@link loadEthers}. Safe wherever the caller already holds an ethers
+ * object (a `Provider`, `Signer`, `Contract` or receipt) — such an object
+ * cannot exist unless ethers was loaded — and in bridge classes, which are
+ * only constructed after `BridgeOperator` has awaited `loadEthers`.
+ */
+export function requireEthers(feature: string): EthersModule {
+  if (!cachedEthers) {
+    throw new Error(
+      `[starkzap] ${feature} requires optional peer dependency "ethers" to be loaded first. ` +
+        `Install it with: npm i ethers`
+    );
+  }
+  return cachedEthers;
 }
 
 import type { EthereumAddress } from "@/types/address";

--- a/src/connect/solanaWeb3Runtime.ts
+++ b/src/connect/solanaWeb3Runtime.ts
@@ -13,19 +13,25 @@ export async function loadSolanaWeb3(
     return cachedSolanaWeb3;
   }
 
-  loadingSolanaWeb3 ??= import("@solana/web3.js")
-    .then((module) => {
+  // NOTE: the import() must be wrapped in try/catch (not a .catch() chain):
+  // webpack only downgrades an unresolvable dynamic import to a build warning
+  // (with a runtime error) when the import() sits inside a try block — the
+  // same pattern the Cartridge loader in src/wallet/cartridge.ts relies on.
+  // With a .then()/.catch() chain instead, consumers without the optional
+  // peer installed get a hard "Module not found" build error.
+  loadingSolanaWeb3 ??= (async () => {
+    try {
+      const module = await import("@solana/web3.js");
       cachedSolanaWeb3 = module as unknown as SolanaWeb3Module;
       return cachedSolanaWeb3;
-    })
-    .catch(() => {
+    } catch {
       throw new Error(
         `[starkzap] ${feature} requires optional peer dependency "@solana/web3.js". Install it with: npm i @solana/web3.js`
       );
-    })
-    .finally(() => {
+    } finally {
       loadingSolanaWeb3 = undefined;
-    });
+    }
+  })();
 
   return await loadingSolanaWeb3;
 }

--- a/src/utils/avnu.ts
+++ b/src/utils/avnu.ts
@@ -18,12 +18,18 @@ export async function loadAvnuSdk(feature: string): Promise<AvnuSdkModule> {
     return cachedAvnuSdk;
   }
 
-  loadingAvnuSdk ??= import("@avnu/avnu-sdk")
-    .then((module) => {
+  // NOTE: the import() must be wrapped in try/catch (not a .catch() chain):
+  // webpack only downgrades an unresolvable dynamic import to a build warning
+  // (with a runtime error) when the import() sits inside a try block — the
+  // same pattern the Cartridge loader in src/wallet/cartridge.ts relies on.
+  // With a .then()/.catch() chain instead, consumers without the optional
+  // peer installed get a hard "Module not found" build error.
+  loadingAvnuSdk ??= (async () => {
+    try {
+      const module = await import("@avnu/avnu-sdk");
       cachedAvnuSdk = module as unknown as AvnuSdkModule;
       return cachedAvnuSdk;
-    })
-    .catch((error) => {
+    } catch (error) {
       const detail =
         error instanceof Error && error.message
           ? ` Original error: ${error.message}`
@@ -31,10 +37,10 @@ export async function loadAvnuSdk(feature: string): Promise<AvnuSdkModule> {
       throw new Error(
         `[starkzap] ${feature} requires optional peer dependency "@avnu/avnu-sdk". Install it with: npm i @avnu/avnu-sdk.${detail}`
       );
-    })
-    .finally(() => {
+    } finally {
       loadingAvnuSdk = undefined;
-    });
+    }
+  })();
 
   return await loadingAvnuSdk;
 }

--- a/tests/bridge/monitor/canonical-utils.test.ts
+++ b/tests/bridge/monitor/canonical-utils.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { AbiCoder, type TransactionReceipt } from "ethers";
 import { constants, hash } from "starknet";
 import { deriveStarknetDepositTxHash } from "@/bridge/monitor/canonical/utils";
+import { loadEthers } from "@/connect/ethersRuntime";
+
+// `deriveStarknetDepositTxHash` reads ethers from the lazy runtime cache
+// (ethers is an optional peer dependency); populate it as production does.
+beforeAll(async () => {
+  await loadEthers("canonical-utils tests");
+});
 
 /** Event topic0: `LogMessageToL2` (Starknet Core Contract). Must match `canonical/utils.ts`. */
 const L2_MSG_TOPIC =

--- a/tests/optional-peer-imports.test.ts
+++ b/tests/optional-peer-imports.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import ts from "typescript";
+
+/**
+ * Regression guard: optional peer dependencies must never be imported
+ * statically from any module reachable from the package entry points.
+ *
+ * Consumers that don't use bridging/confidential/Solana features must be able
+ * to bundle and `import("starkzap")` without installing the optional peers.
+ * Bundlers (webpack, esbuild) resolve every static `import`/`export ... from`
+ * at build time — including inside modules that are only reached through a
+ * dynamic `import()` — so a single static peer import produces hard
+ * "Module not found" build failures downstream.
+ *
+ * Allowed pattern: dynamic `import("<peer>")` behind a lazy runtime loader
+ * (`loadEthers`, `loadSolanaWeb3`, `loadHyperlane`, `loadTongo`, ...).
+ *
+ * Note on `verbatimModuleSyntax` (enabled in tsconfig): only statements
+ * written as `import type { ... }` / `export type { ... }` are elided from the
+ * emitted JS. Inline forms like `import { type Foo } from "ethers"` still emit
+ * `import {} from "ethers"` and are therefore violations too.
+ */
+
+const ROOT = resolve(__dirname, "..");
+const SRC = join(ROOT, "src");
+
+const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")) as {
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+};
+const optionalPeers = Object.entries(pkg.peerDependenciesMeta ?? {})
+  .filter(([, meta]) => meta.optional)
+  .map(([name]) => name);
+
+function isOptionalPeer(specifier: string): string | undefined {
+  return optionalPeers.find(
+    (peer) => specifier === peer || specifier.startsWith(`${peer}/`)
+  );
+}
+
+/** Resolve a relative or `@/` alias specifier to a source file path. */
+function resolveInternal(from: string, specifier: string): string | undefined {
+  let base: string;
+  if (specifier.startsWith("@/")) {
+    base = join(SRC, specifier.slice(2));
+  } else if (specifier.startsWith(".")) {
+    base = resolve(dirname(from), specifier);
+  } else {
+    return undefined; // bare specifier (dependency)
+  }
+  for (const candidate of [base, `${base}.ts`, join(base, "index.ts")]) {
+    if (candidate.endsWith(".json")) return undefined;
+    if (candidate.endsWith(".ts") && existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+type Violation = { file: string; specifier: string };
+
+/**
+ * Walks the emitted-JS module graph from the given entry points, following
+ * both static imports/re-exports and internal dynamic `import()` calls, and
+ * collects every statically emitted reference to an optional peer.
+ */
+function findStaticPeerImports(entries: string[]): Violation[] {
+  const queue = [...entries];
+  const seen = new Set<string>();
+  const violations: Violation[] = [];
+
+  while (queue.length > 0) {
+    const file = queue.pop()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+
+    const source = ts.createSourceFile(
+      file,
+      readFileSync(file, "utf8"),
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const record = (specifier: string, elided: boolean, dynamic: boolean) => {
+      const peer = isOptionalPeer(specifier);
+      if (peer) {
+        // Dynamic import() of a peer is the sanctioned lazy-loading pattern;
+        // fully type-only statements are erased at compile time.
+        if (!dynamic && !elided) {
+          violations.push({ file: file.slice(ROOT.length + 1), specifier });
+        }
+        return;
+      }
+      if (elided) return;
+      const target = resolveInternal(file, specifier);
+      if (target) queue.push(target);
+    };
+
+    const visit = (node: ts.Node) => {
+      if (ts.isImportDeclaration(node)) {
+        const specifier = (node.moduleSpecifier as ts.StringLiteral).text;
+        // Only `import type { ... }` is fully elided under
+        // verbatimModuleSyntax; inline `{ type X }` still emits the import.
+        record(specifier, node.importClause?.isTypeOnly === true, false);
+      } else if (ts.isExportDeclaration(node) && node.moduleSpecifier) {
+        const specifier = (node.moduleSpecifier as ts.StringLiteral).text;
+        record(specifier, node.isTypeOnly, false);
+      } else if (
+        ts.isCallExpression(node) &&
+        node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+        node.arguments.length === 1 &&
+        ts.isStringLiteralLike(node.arguments[0]!)
+      ) {
+        record((node.arguments[0] as ts.StringLiteral).text, false, true);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  }
+
+  return violations;
+}
+
+describe("optional peer dependencies", () => {
+  it("declares optional peers in package.json", () => {
+    expect(optionalPeers.length).toBeGreaterThan(0);
+  });
+
+  it("are never statically imported from modules reachable from the package entry points", () => {
+    const entries = [join(SRC, "index.ts"), join(SRC, "cartridge.ts")].filter(
+      (entry) => existsSync(entry)
+    );
+    expect(entries.length).toBeGreaterThan(0);
+
+    const violations = findStaticPeerImports(entries);
+
+    expect(
+      violations,
+      violations
+        .map(
+          (v) =>
+            `${v.file} statically imports optional peer "${v.specifier}" — ` +
+            `route it through a lazy runtime loader (see src/connect/ethersRuntime.ts) ` +
+            `or make the import "import type".`
+        )
+        .join("\n")
+    ).toEqual([]);
+  });
+
+  // Sanity check: the walker actually parses imports (guards against the
+  // guard silently walking nothing).
+  it("walks a non-trivial portion of the source tree", () => {
+    const allSrcFiles: string[] = [];
+    const collect = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) collect(full);
+        else if (entry.name.endsWith(".ts")) allSrcFiles.push(full);
+      }
+    };
+    collect(SRC);
+
+    const seen = new Set<string>();
+    const queue = [join(SRC, "index.ts")];
+    while (queue.length > 0) {
+      const file = queue.pop()!;
+      if (seen.has(file)) continue;
+      seen.add(file);
+      const source = ts.createSourceFile(
+        file,
+        readFileSync(file, "utf8"),
+        ts.ScriptTarget.Latest,
+        true
+      );
+      const visit = (node: ts.Node) => {
+        let specifier: string | undefined;
+        if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+          specifier =
+            node.moduleSpecifier && ts.isStringLiteralLike(node.moduleSpecifier)
+              ? node.moduleSpecifier.text
+              : undefined;
+        } else if (
+          ts.isCallExpression(node) &&
+          node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+          node.arguments.length === 1 &&
+          ts.isStringLiteralLike(node.arguments[0]!)
+        ) {
+          specifier = (node.arguments[0] as ts.StringLiteral).text;
+        }
+        if (specifier) {
+          const target = resolveInternal(file, specifier);
+          if (target) queue.push(target);
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(source);
+    }
+
+    // The root entry re-exports every subsystem; the reachable graph should
+    // cover the majority of src/.
+    expect(seen.size).toBeGreaterThan(allSrcFiles.length / 2);
+  });
+});


### PR DESCRIPTION
Supersedes #136 by @l-henri, whose commit is carried here unchanged (authorship preserved). Moved into a branch on this repo because a fork PR cannot get green CI here: its workflow run sat at `action_required` and never produced a single check, and CI installs the privacy SDK from GitHub Packages with `secrets.GITHUB_TOKEN`, which a fork's read-only token cannot resolve against this org.

## Problem

starkzap declares its heavy dependencies as optional peers, but a consumer using none of those features still could not build. Two causes: peers imported statically in root-reachable modules, and lazy loaders written as `.then()/.catch()` chains, which webpack treats as a hard resolution failure rather than an optional import.

## Change

From #136, unchanged:

- **`ethers` out of the root graph.** Seven bridge modules move to `import type` and reach values through `await loadEthers(...)`, or a new synchronous `requireEthers(feature)` where the caller cannot await. `CCTPBridge`'s module-eval statics (`new Interface(...)`, checksummed addresses) become lazily cached getters.
- **All loaders restructured** to `try { await import(...) } catch` — avnu, ethers, `@solana/web3.js`, hyperlane. Error messages unchanged.
- **`tests/optional-peer-imports.test.ts`** walks the emitted module graph from `src/index.ts` and `src/cartridge.ts`, following static imports, re-exports and internal dynamic `import()`s, and asserts no optional peer is reachable statically.

Added here:

- **The tongo loader gets the same `try/catch` treatment.** #140 made it dynamic but left a `.then()/.catch()` chain.

## Dropped from #136, with reasons

#136's tongo work is superseded by #140, which landed after it was opened:

- **`src/confidential/tongoRuntime.ts` and `TongoConfidential.ready()`** — #140 removed the static tongo import by making `TongoConfidential.create(...)` an async factory. The module is loaded before an instance exists, so nothing needs a separate `ready()` step and the synchronous accessors never observe a half-built object. #136's approach reached the same goal but required `await ready()` before `address`, `recipientId`, `recipientFromAddress` and `getTongoAccount` would work.
- **`tests/tongo-optional-dep.test.ts`** — both PRs added a file with this name; #140's version is kept.

These were the only cherry-pick conflicts, and both were in tongo tests.

## Verified

Webpack 5 production build of an app importing `StarkZap` + `PrivySigner`, from a packed install into a project with **no** optional peers:

| tongo loader form | Result |
| --- | --- |
| `.then()/.catch()` (before) | **1 error**, 7 warnings — `ERROR in .../confidential/tongo.js` |
| `try { await import() } catch` (this branch) | **0 errors**, 8 warnings |

All eight warnings are on lazy loaders, which is the intended outcome: a missing peer becomes a runtime error only if the feature is used. The emitted bundle then runs and both exports are usable.

Also: typecheck, lint and prettier clean; 761 unit tests pass, 12 skipped; `optional-peer-imports.test.ts` passes with both halves of the fix present. Integration tests not run (they need a devnet).

Closes #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
