### PR TITLE
fix: fail builds on TypeScript errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc; tsc-alias",
+    "build": "tsc && tsc-alias",
     "build:all": "npm run build --workspace starkzap-native",
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "check:declarations": "node scripts/check-declaration-leaks.mjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
+    "noEmitOnError": true,
     // Strict Typechecking
     "strict": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
## Summary

Fix the root build pipeline so TypeScript failures cannot be masked by a successful `tsc-alias` run.

- run `tsc-alias` only after `tsc` succeeds
- enable `noEmitOnError` so failed compilations do not leave partial artifacts in `dist`

Closes #137.

## Testing

- confirmed `npm run build` exits non-zero when the compiler command fails and does not invoke `tsc-alias`
- verified the effective TypeScript config enables `noEmitOnError`
- `git diff --check`

A clean dependency install is currently blocked on `main` because `package-lock.json` is missing `@solana/kit@5.5.1` and `@types/react@19.2.18`; no dependency or lockfile changes are included here.
